### PR TITLE
Call NoSleep from within a user input event handler

### DIFF
--- a/views/tally.html
+++ b/views/tally.html
@@ -178,8 +178,6 @@
 			selectedDeviceId = deviceId;
 			updateTallyInfo();
 		});
-
-		KeepScreenAwake(true); //keeps the phone from falling asleep
 	}
 
 	function updateDeviceList() {
@@ -216,6 +214,7 @@
 		if (id !== '0') {
 			selectDevice(id);
 		}
+		KeepScreenAwake(true); //keeps the phone from falling asleep
 	}
 
 	function selectDevice(deviceId) {


### PR DESCRIPTION
noSleep.enable() "must be wrapped in a user input event handler e.g. a mouse or touch handler" in order to work.
It was not working properly on some older Android 4.1 devices because it was called inside on onLoad().
This will fix it