### PR TITLE
Always send devices list when a M5Stick registers as a listener.

### DIFF
--- a/index.js
+++ b/index.js
@@ -673,19 +673,25 @@ function initialSetup() {
 			let deviceId = obj.deviceId;
 			let device = GetDeviceByDeviceId(deviceId);
 			let listenerType = 'm5';
+			
+			if (devices.length > 0) {
+				socket.emit('devices', devices);
+			}
 
 			if ((deviceId === 'null') || (device.id === 'unassigned')) {
 				if (devices.length > 0) {
 					deviceId = devices[0].id;
 					socket.emit('deviceId', deviceId);
-					socket.emit('devices', devices);
-					socket.emit('device_states', GetDeviceStatesByDeviceId(deviceId));
 				}
 				else {
 					deviceId = 'unassigned';
 				}
 			}
-
+			
+			if (devices.length > 0) {
+				socket.emit('device_states', GetDeviceStatesByDeviceId(deviceId));
+			}
+			
 			if (obj.listenerType) {
 				listenerType = obj.listenerType;
 			}
@@ -695,7 +701,7 @@ function initialSetup() {
 				socket.join('messaging');
 			}
 			let deviceName = GetDeviceByDeviceId(deviceId).name;
-			logger(`Listener Client Connected. Type: ${listenerType} Device: ${deviceName}`, 'info');
+			logger(`Listener Client Connected. Type: ${listenerType} Device: ${deviceName} DeviceID: ${deviceId}`, 'info');
 
 			let ipAddress = socket.request.connection.remoteAddress;
 			let datetimeConnected = new Date().getTime();


### PR DESCRIPTION
If the M5Stick was once connected to the server and one would change the name of a device, it does not get updated on the M5Stick because the deviceID is still valid.

Secondly, if there is a valid device ID the device_states are not getting send during connection and only on the next switch.

Both issues where fixed by moving the sending the information outside of the if statement.

Note: The devices message must be send before changing the deviceId to set the correct DeviceName that gets displayed on the M5Stick.