### PR TITLE
Allow HTTPS JSON Requests for Outgoing Webhooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,10 +233,12 @@ var output_types_datafields = [ //data fields for the outgoing actions
 		]
 	},
 	{ outputTypeId: 'ffe2b0b6', fields: [ //Outgoing Webhook
-			{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+			{ fieldName: 'protocol', fieldLabel: 'Protocol', fieldType: 'dropdown', options: [ { id: 'http://', label: 'HTTP' }, { id: 'https://', label: 'HTTPS'} ] },
+			{ fieldName: 'ip', fieldLabel: 'Ip/URL', fieldType: 'text' },
 			{ fieldName: 'port', fieldLabel: 'Port', fieldType: 'port' },
 			{ fieldName: 'path', fieldLabel: 'Path', fieldType: 'text' },
 			{ fieldName: 'method', fieldLabel: 'Method', fieldType: 'dropdown', options: [ { id: 'GET', label: 'GET' }, { id: 'POST', label: 'POST'} ] },
+			{ fieldName: 'content', fieldLabel: 'Content', fieldType: 'dropdown', options: [ { id: 'JSON', label: 'JSON' }, { id: 'RAW', label: 'RAW'} ] },
 			{ fieldName: 'postdata', fieldLabel: 'POST Data', fieldType: 'text' }
 		]
 	},
@@ -3817,21 +3819,29 @@ function RunAction_TSL_31_TCP(data) {
 
 function RunAction_Webhook(data) {
 	try {
-		let path = (data.path.startsWith('/') ? data.path : '/' + data.path);
+		let path = data.path ? (data.path.startsWith('/') ? data.path : '/' + data.path) : '';
+		data.protocol = data.protocol || 'http://';
 		let options = {
 			method: data.method,
-			url: 'http://' + data.ip + ':' + data.port + path
+			url: data.protocol + data.ip + (data.port ? ':' + data.port : '') + path
 		};
 
+		if(data.content == 'JSON'){
+			options.headers = options.headers || {};
+			options.headers['Content-Type']= 'application/json';
+
+		}
 		if (data.method === 'POST') {
 			if (data.postdata !== '') {
 				options.data = data.postdata;
 			}
 		}
-
+		logger(JSON.stringify(options), 'quiet')
 		axios(options)
 		.then(function (response) {
 			logger(`Outgoing Webhook triggered.`, 'info');
+			logger('response:','info');
+			logger(JSON.stringify(response.data),'info');
 		})
 		.catch(function (error) {
 			logger(`An error occured triggering the Outgoing Webhook: ${error}`, 'error');

--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ var output_types_datafields = [ //data fields for the outgoing actions
 			{ fieldName: 'port', fieldLabel: 'Port', fieldType: 'port' },
 			{ fieldName: 'path', fieldLabel: 'Path', fieldType: 'text' },
 			{ fieldName: 'method', fieldLabel: 'Method', fieldType: 'dropdown', options: [ { id: 'GET', label: 'GET' }, { id: 'POST', label: 'POST'} ] },
-			{ fieldName: 'content', fieldLabel: 'Content', fieldType: 'dropdown', options: [ { id: 'JSON', label: 'JSON' }, { id: 'RAW', label: 'RAW'} ] },
+			{ fieldName: 'content', fieldLabel: 'Content-Type', fieldType: 'dropdown', options: [ { id: 'application/json', label: 'JSON' }, { id: 'application/xml', label: 'XML'}, { id: 'application/x-www-form-urlencoded', label: 'FORM-URLENCODED'}, { id: 'text/plain', label: 'TEXT'}, { id: '', label: 'DEFAULT'}  ] },
 			{ fieldName: 'postdata', fieldLabel: 'POST Data', fieldType: 'text' }
 		]
 	},
@@ -4186,10 +4186,10 @@ function RunAction_Webhook(data) {
 			method: data.method,
 			url: data.protocol + data.ip + (data.port ? ':' + data.port : '') + path
 		};
-
-		if(data.content == 'JSON'){
-			options.headers = options.headers || {};
-			options.headers['Content-Type']= 'application/json';
+		options.headers = options.headers || {};
+		if(data.content != ''){
+			
+			options.headers['Content-Type']= data.content;
 
 		}
 		if (data.method === 'POST') {

--- a/index.js
+++ b/index.js
@@ -4197,7 +4197,7 @@ function RunAction_Webhook(data) {
 				options.data = data.postdata;
 			}
 		}
-		logger(JSON.stringify(options), 'quiet')
+		logger(JSON.stringify(options), 'info-quiet')
 		axios(options)
 		.then(function (response) {
 			logger(`Outgoing Webhook triggered.`, 'info');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "TallyArbiter",
-    "version": "1.5.1",
+    "version": "1.5.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -553,27 +553,22 @@
             "integrity": "sha512-IU+77+jJ7lpw2qZ3NUuqBZFy3GuioNgXUdsL1L9tooDNTaw0TgOnwNuc+8Ns+haDaTifK97QLzmOANJtI/rGvw=="
         },
         "engine.io": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.5.0.tgz",
-            "integrity": "sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
+            "integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
             "requires": {
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
-                "cookie": "~0.4.1",
+                "cookie": "0.3.1",
                 "debug": "~4.1.0",
                 "engine.io-parser": "~2.2.0",
-                "ws": "~7.4.2"
+                "ws": "^7.1.2"
             },
             "dependencies": {
                 "cookie": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-                    "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-                },
-                "ws": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-                    "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                    "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
                 }
             }
         },
@@ -1479,109 +1474,16 @@
             "integrity": "sha1-ukWpIwNNbPQbGieuvnEoKCyNVR8="
         },
         "socket.io": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.0.tgz",
-            "integrity": "sha512-9UPJ1UTvKayuQfVv2IQ3k7tCQC/fboDyIK62i99dAQIyHKaBsNdTpwHLgKJ6guRWxRtC9H+138UwpaGuQO9uWQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
+            "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
             "requires": {
                 "debug": "~4.1.0",
-                "engine.io": "~3.5.0",
+                "engine.io": "~3.4.0",
                 "has-binary2": "~1.0.2",
                 "socket.io-adapter": "~1.1.0",
-                "socket.io-client": "2.4.0",
+                "socket.io-client": "2.3.0",
                 "socket.io-parser": "~3.4.0"
-            },
-            "dependencies": {
-                "component-emitter": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-                    "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-                },
-                "engine.io-client": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
-                    "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
-                    "requires": {
-                        "component-emitter": "~1.3.0",
-                        "component-inherit": "0.0.3",
-                        "debug": "~3.1.0",
-                        "engine.io-parser": "~2.2.0",
-                        "has-cors": "1.1.0",
-                        "indexof": "0.0.1",
-                        "parseqs": "0.0.6",
-                        "parseuri": "0.0.6",
-                        "ws": "~7.4.2",
-                        "xmlhttprequest-ssl": "~1.5.4",
-                        "yeast": "0.1.2"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        }
-                    }
-                },
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-                },
-                "parseqs": {
-                    "version": "0.0.6",
-                    "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-                    "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
-                },
-                "parseuri": {
-                    "version": "0.0.6",
-                    "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-                    "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
-                },
-                "socket.io-client": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-                    "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
-                    "requires": {
-                        "backo2": "1.0.2",
-                        "component-bind": "1.0.0",
-                        "component-emitter": "~1.3.0",
-                        "debug": "~3.1.0",
-                        "engine.io-client": "~3.5.0",
-                        "has-binary2": "~1.0.2",
-                        "indexof": "0.0.1",
-                        "parseqs": "0.0.6",
-                        "parseuri": "0.0.6",
-                        "socket.io-parser": "~3.3.0",
-                        "to-array": "0.1.4"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        },
-                        "socket.io-parser": {
-                            "version": "3.3.2",
-                            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-                            "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
-                            "requires": {
-                                "component-emitter": "~1.3.0",
-                                "debug": "~3.1.0",
-                                "isarray": "2.0.1"
-                            }
-                        }
-                    }
-                },
-                "ws": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-                    "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
-                }
             }
         },
         "socket.io-adapter": {


### PR DESCRIPTION
I modified the outgoing web hook mechanism to extend it so that it can be used for sending json requests.

I personally use this to setup actions to control tp-link smart plugs through the outgoing web hook actions.

I added the protocol because the service communicates over https.

I also added content to set the content type of the request. JSON Will set the content-type to JSON. RAW will not set the content-type.

![image](https://user-images.githubusercontent.com/1423119/109374954-0b463280-7887-11eb-88de-d0d2ae0d7b3d.png)
