### PR TITLE
Writes logs and tally data to their own file and deletes any log or tally data file older than 1 week

### DIFF
--- a/index.js
+++ b/index.js
@@ -1914,7 +1914,7 @@ function logger(log, type) { //logs the item to the console, to the log array, a
 	logObj.type = type;
 	Logs.push(logObj);
 
-	writeLogFile(dtNow, log);
+	writeLogFile(log);
 
 	io.to('settings').emit('log_item', logObj);
 }
@@ -1924,7 +1924,8 @@ function writeLogFile(log) {
 		var humanFriendlyDtNow = new Date().toLocaleString();
 
 		var logString = '[' + humanFriendlyDtNow + '] ' + log;
-		fs.writeSync(logFile, logString + '\n');
+
+		fs.appendFileSync(logFile, logString + '\n');
 	}
 	catch (error) {
 		logger(`Error saving logs to file: ${error}`, 'error');
@@ -1936,7 +1937,7 @@ function writeTallyDataFile(log) {
 
 		logLine = JSON.stringify(log) + ','
 
-		fs.writeSync(tallyDataFile, logLine + '\n');
+		fs.appendFileSync(tallyDataFile, logLine + '\n');
 	}
 	catch (error) {
 		logger(`Error saving logs to file: ${error}`, 'error');

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const osc 						= require('osc');
 const xml2js					= require('xml2js');
 const jspack 					= require('jspack').jspack;
 const os 						= require('os') // For getting available Network interfaces on host device
+const findRemoveSync            = require('find-remove');
 
 
 //Tally Arbiter variables
@@ -43,6 +44,8 @@ const socketupdates_Companion = ['sources', 'devices', 'device_sources', 'device
 const oscPort 		= 5958;
 const vmixEmulatorPort = '8099'; // Default 8099 
 var oscUDP			= null;
+var logFile = fs.openSync(getLogFilePath(), 'w'); // Setup Log file
+var tallyDataFile = fs.openSync(getTallyDataPath(), 'w'); // Setup TallyData File
 var vmix_emulator	= null; //TCP server for VMix Emulator
 var vmix_clients 	= []; //Clients currently connected to the VMix Emulator
 const config_file 	= getConfigFilePath(); //local storage JSON file
@@ -936,6 +939,11 @@ function initialSetup() {
 		});
 
 		socket.on('source_tallydata', function(sourceId) { //gets all Source Tally Data
+
+			let tally_data = data;
+
+			
+
 			let source = GetSourceBySourceId(sourceId);
 			let sourceType = GetSourceTypeBySourceTypeId(source.sourceTypeId);
 			let result = false;
@@ -1906,7 +1914,33 @@ function logger(log, type) { //logs the item to the console, to the log array, a
 	logObj.type = type;
 	Logs.push(logObj);
 
+	writeLogFile(dtNow, log);
+
 	io.to('settings').emit('log_item', logObj);
+}
+
+function writeLogFile(log) {
+	try {
+		var humanFriendlyDtNow = new Date().toLocaleString();
+
+		var logString = '[' + humanFriendlyDtNow + '] ' + log;
+		fs.writeSync(logFile, logString + '\n');
+	}
+	catch (error) {
+		logger(`Error saving logs to file: ${error}`, 'error');
+	}
+}
+
+function writeTallyDataFile(log) {
+	try {
+
+		logLine = JSON.stringify(log) + ','
+
+		fs.writeSync(tallyDataFile, logLine + '\n');
+	}
+	catch (error) {
+		logger(`Error saving logs to file: ${error}`, 'error');
+	}
 }
 
 function loadConfig() { // loads the JSON data from the config file to memory
@@ -4766,6 +4800,8 @@ function processTSLTally(sourceId, tallyObj) // Processes the TSL Data
 {
 	//logger(`Processing new tally object.`, 'info-quiet');
 
+	writeTallyDataFile(tallyObj);
+
 	io.to('settings').emit('tally_data', sourceId, tallyObj);
 
 	let deviceId = null;
@@ -6926,6 +6962,36 @@ function getConfigFilePath() {
 	}
 	const configName = "config.json";
 	return path.join(configFolder, configName);
+}
+
+function getLogFilePath() {
+
+	var today = new Date();
+
+	const logFolder = path.join(process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + "/.local/share/"), "TallyArbiter/logs");
+
+	findRemoveSync(logFolder, {age: {seconds: 604800}, extensions: '.talog', limit: 100});
+
+	if (!fs.existsSync(logFolder)) {
+		fs.mkdirSync(logFolder, { recursive: true });
+	}
+	var logName = today + ".talog"
+	return path.join(logFolder, logName);
+}
+
+function getTallyDataPath() {
+
+	var today = new Date();
+
+	const TallyDataFolder = path.join(process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + "/.local/share/"), "TallyArbiter/TallyData");
+
+	findRemoveSync(TallyDataFolder, {age: {seconds: 604800}, extensions: '.tadata', limit: 100});
+
+	if (!fs.existsSync(TallyDataFolder)) {
+		fs.mkdirSync(TallyDataFolder, { recursive: true });
+	}
+	var logName = today + ".tadata"
+	return path.join(TallyDataFolder, logName);
 }
 
 function getNetworkInterfaces() { // Get all network interfaces on host device

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "tallyarbiter",
-	"version": "2.0.0",
+	"version": "2.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -655,8 +655,7 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"base64-arraybuffer": {
 			"version": "0.1.4",
@@ -834,7 +833,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1226,8 +1224,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -2116,6 +2113,20 @@
 				"unpipe": "~1.0.0"
 			}
 		},
+		"find-remove": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/find-remove/-/find-remove-3.1.0.tgz",
+			"integrity": "sha512-F4DAR/JnsadDA9KZRWLZXNZjaQ9X6KJ1OcHFz1cXq4OCm1v2hxu7+hbgxIaqUzU3dzYNP5npJ/dQzaR6pEf3EQ==",
+			"requires": {
+				"fmerge": "1.2.0",
+				"rimraf": "3.0.2"
+			}
+		},
+		"fmerge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fmerge/-/fmerge-1.2.0.tgz",
+			"integrity": "sha1-NumdKuJV4+4a9ma033gFU2cc9pI="
+		},
 		"follow-redirects": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
@@ -2151,8 +2162,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -2201,7 +2211,6 @@
 			"version": "7.1.7",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
 			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2392,7 +2401,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"cli-truncate": "^1.1.0"
+				"cli-truncate": "^1.1.0",
+				"node-addon-api": "^1.6.3"
 			}
 		},
 		"iconv-lite": {
@@ -2435,7 +2445,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -2844,7 +2853,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -2909,6 +2917,13 @@
 			"requires": {
 				"semver": "^5.4.1"
 			}
+		},
+		"node-addon-api": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+			"dev": true,
+			"optional": true
 		},
 		"noop-logger": {
 			"version": "0.1.1",
@@ -3108,8 +3123,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -3374,6 +3388,14 @@
 			"dev": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
+			}
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"requires": {
+				"glob": "^7.1.3"
 			}
 		},
 		"roarr": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"electron-updater": "^4.3.9",
 		"esm": "^3.2.25",
 		"express": "^4.17.1",
+		"find-remove": "^3.1.0",
 		"jquery": "^3.6.0",
 		"jspack": "^0.0.4",
 		"obs-websocket-js": "^4.0.2",


### PR DESCRIPTION
The logs are written to a logs folder under the TallyArbiter folder and the tally_data is written to a TallyData folder in the same place 

The logs use the .talog extension and tally data uses the .tadata extension. 

I am using the find-remove package to find and remove log and tally data files older than 1 week.