### PR TITLE
Support for rate limiter and brute force protection

### DIFF
--- a/UI/src/app/_components/login/login.component.html
+++ b/UI/src/app/_components/login/login.component.html
@@ -1,7 +1,7 @@
 <div class="container text-center d-flex justify-content-center mt-5 pt-5">
     <main class="form-signin">
         <h1 class="h3 mb-3 fw-normal">Please sign in</h1>
-        <div class="my-2 text-danger" *ngIf="loginFailed">{{ errorMessage }}</div>
+        <div class="my-2 text-danger" *ngIf="!loginResponse.loginOk">{{ loginResponse.message }}</div>
         <div class="form-floating">
             <input type="text" class="form-control" (keydown.enter)="inputPassword.focus()" [(ngModel)]="username" id="username" placeholder="Username">
             <label for="username">Username</label>

--- a/UI/src/app/_components/login/login.component.html
+++ b/UI/src/app/_components/login/login.component.html
@@ -1,7 +1,7 @@
 <div class="container text-center d-flex justify-content-center mt-5 pt-5">
     <main class="form-signin">
         <h1 class="h3 mb-3 fw-normal">Please sign in</h1>
-        <div class="my-2 text-danger" *ngIf="wrongUsernameOrPassword">Wrong username or password!</div>
+        <div class="my-2 text-danger" *ngIf="loginFailed">{{ errorMessage }}</div>
         <div class="form-floating">
             <input type="text" class="form-control" (keydown.enter)="inputPassword.focus()" [(ngModel)]="username" id="username" placeholder="Username">
             <label for="username">Username</label>

--- a/UI/src/app/_components/login/login.component.ts
+++ b/UI/src/app/_components/login/login.component.ts
@@ -9,7 +9,8 @@ import { AuthService } from 'src/app/_services/auth.service';
 })
 export class LoginComponent {
   public loading = false;
-  public wrongUsernameOrPassword = false;
+  public loginFailed = false;
+  public errorMessage = '';
   public username = "";
   public password = "";
   private type!: "producer" | "settings";
@@ -25,8 +26,12 @@ export class LoginComponent {
       this.loading = false;
       if (result === true) {
         this.router.navigate([this.type]);
+      } else if (result === -1) {
+        this.loginFailed = true;
+        this.errorMessage = "Too many attemps! Please retry later.";
       } else {
-        this.wrongUsernameOrPassword = true;
+        this.loginFailed = true;
+        this.errorMessage = "Wrong username or password!";
       }
     });
   }

--- a/UI/src/app/_components/login/login.component.ts
+++ b/UI/src/app/_components/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { AuthService } from 'src/app/_services/auth.service';
+import { AuthService, LoginResponse } from 'src/app/_services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -9,8 +9,7 @@ import { AuthService } from 'src/app/_services/auth.service';
 })
 export class LoginComponent {
   public loading = false;
-  public loginFailed = false;
-  public errorMessage = '';
+  public loginResponse: LoginResponse = {loginOk: false, message: ''};
   public username = "";
   public password = "";
   private type!: "producer" | "settings";
@@ -22,16 +21,11 @@ export class LoginComponent {
   login(): void {
     this.loading = true;
     this.type = this.router.url.endsWith("producer") ? "producer" : "settings";
-    this.authService.login(this.type, this.username, this.password).then((result) => {
+    this.authService.login(this.type, this.username, this.password).then((response: LoginResponse) => {
+      this.loginResponse = response;
       this.loading = false;
-      if (result === true) {
+      if (response.loginOk === true) {
         this.router.navigate([this.type]);
-      } else if (result === -1) {
-        this.loginFailed = true;
-        this.errorMessage = "Too many attemps! Please retry later.";
-      } else {
-        this.loginFailed = true;
-        this.errorMessage = "Wrong username or password!";
       }
     });
   }

--- a/UI/src/app/_services/auth.service.ts
+++ b/UI/src/app/_services/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
   public login(type: "producer" | "settings", username: string, password: string) {
     return new Promise((resolve) => {
       this.socketService.socket.emit("login", type, username, password);
-      this.socketService.socket.once("login_result", (result: boolean) => {
+      this.socketService.socket.once("login_result", (result: boolean|number) => {
         if (result === true) {
           if (type == "producer") {
             this._isProducer = true;
@@ -28,6 +28,8 @@ export class AuthService {
             this._isAdmin = true;
           }
           resolve(true);
+        } else if(result === -1) {
+          resolve(-1);
         } else {
           resolve(false);
         }

--- a/UI/src/app/_services/auth.service.ts
+++ b/UI/src/app/_services/auth.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@angular/core';
 import { SocketService } from './socket.service';
 
+export interface LoginResponse {
+  loginOk: boolean;
+  message: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -18,21 +23,17 @@ export class AuthService {
   }
 
   public login(type: "producer" | "settings", username: string, password: string) {
-    return new Promise((resolve) => {
+    return new Promise<LoginResponse>((resolve) => {
       this.socketService.socket.emit("login", type, username, password);
-      this.socketService.socket.once("login_result", (result: boolean|number) => {
-        if (result === true) {
+      this.socketService.socket.once("login_response", (response: LoginResponse) => {
+        if (response.loginOk === true) {
           if (type == "producer") {
             this._isProducer = true;
           } else {
             this._isAdmin = true;
           }
-          resolve(true);
-        } else if(result === -1) {
-          resolve(-1);
-        } else {
-          resolve(false);
         }
+        resolve(response);
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -29,18 +29,18 @@ const findRemoveSync            = require('find-remove');
 
 //Rate limiter configurations
 const maxWrongAttemptsByIPperDay = 100;
-const maxConsecutiveFailsByUsernameAndIP = 2;
+const maxConsecutiveFailsByUsernameAndIP = 10;
 const limiterSlowBruteByIP = new RateLimiterMemory({
   keyPrefix: 'login_fail_ip_per_day',
   points: maxWrongAttemptsByIPperDay,
-  duration: 60 * 60 * 24,
-  blockDuration: 60 * 60 * 24, // Block for 4 hours
+  duration: 60 * 60 * 24, // Store number for 1 day since first fail
+  blockDuration: 60 * 60 * 24, // Block for 1 day
 });
 const limiterConsecutiveFailsByUsernameAndIP = new RateLimiterMemory({
   keyPrefix: 'login_fail_consecutive_username_and_ip',
   points: maxConsecutiveFailsByUsernameAndIP,
-  duration: 60 * 60 * 24, // Store number for 90 days since first fail
-  blockDuration: 60 * 60, // Block for 1 hour
+  duration: 60 * 60 * 24, // Store number for 1 day since first fail
+  blockDuration: 60 * 60 * 2, // Block for 2 hours
 });
 
 //Tally Arbiter variables

--- a/index.js
+++ b/index.js
@@ -948,7 +948,8 @@ function initialSetup() {
 			if((type === "producer" && username == username_producer && password == password_producer)
 			|| (type === "settings" && username == username_settings && password == password_settings)) {
 				//login successfull
-				socket.emit('login_result', true);
+				socket.emit('login_result', true); //old response, for compatibility with old UI clients
+				socket.emit('login_response', { loginOk: true, message: "" });
 			} else {
 				//wrong credentials
 				Promise.all([
@@ -956,10 +957,12 @@ function initialSetup() {
 					limiterSlowBruteByIP.consume(`${username}_${ipAddr}`)
 				]).then((values) => {
 					//rate limits not exceeded
-					socket.emit('login_result', false);
+					socket.emit('login_result', false); //old response, for compatibility with old UI clients
+					socket.emit('login_response', { loginOk: false, message: "Wrong username or password!" });
 				}).catch((error) => {
 					//rate limits exceeded
-					socket.emit('login_result', -1);
+					socket.emit('login_result', false); //old response, for compatibility with old UI clients
+					socket.emit('login_response', { loginOk: false, message: "Too many attemps! Please retry later." });
 				});
 			}
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3271,6 +3271,11 @@
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
+		"rate-limiter-flexible": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.2.4.tgz",
+			"integrity": "sha512-8u4k5b1afuBcfydX0L0l3J2PNjgcuo3zua8plhvIisyDqOBldrCwfSFut/Fj00LAB1nxJYVM9jeszr2rZyDhQw=="
+		},
 		"raw-body": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"obs-websocket-js": "^4.0.2",
 		"osc": "^2.4.1",
 		"packet": "0.0.7",
+		"rate-limiter-flexible": "^2.2.4",
 		"socket.io": "4.1.2",
 		"socket.io-client": "4.1.2",
 		"tsl-umd": "^1.1.2",


### PR DESCRIPTION
Currently, logins are vulnerable to brute force, since there are no rate limits to the login event in websocket.
I tried implementing rate limits using an advaced library, [rate-limiter-flexible](https://github.com/animir/node-rate-limiter-flexible), so, in the future, we can implement rate limits to the entire application using a custom Express middleware (for example [https://github.com/animir/node-rate-limiter-flexible/wiki/Express-Middleware](https://github.com/animir/node-rate-limiter-flexible/wiki/Express-Middleware)) and/or Websocket connections (https://github.com/animir/node-rate-limiter-flexible/wiki/Overall-example#websocket-single-connection-prevent-flooding).
P.S: I added "-1" in `login_response` to maintain compatibility with "old `login_response` versions"