### PR TITLE
device renaming

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -493,7 +493,8 @@
           <tr>
             <th>Source</th>
             <th>Address</th>
-            <th>(Bus)</th>
+			<th>(Bus)</th>
+			<th>Allow Renaming</th>
             <th></th>
           </tr>
         </thead>
@@ -503,7 +504,8 @@
               {{socketService.getSourceById(deviceSource.sourceId)?.name}}
             </td>
             <td>{{deviceSource.address}}</td>
-            <td>{{deviceSource.bus}}</td>
+			<td>{{deviceSource.bus}}</td>
+			<td>{{deviceSource.rename}}</td>
             <td>
               <button class="btn btn-outline-dark me-1" (click)="editDeviceSource(deviceSource)"><i class="fas fa-pen"></i> Edit</button>
               <button class="btn btn-outline-danger" (click)="deleteDeviceSource(deviceSource)"><i class="fas fa-trash"></i> Delete</button>
@@ -547,6 +549,10 @@
             *ngFor="let bus of getSourceBusOptionsBySourceTypeId(socketService.sources[currentDeviceSource.sourceIdx!].sourceTypeId)[0].busses"
             [value]="bus.bus">{{bus.name}}</option>
         </select>
+	  </div>
+      <div class="mb-3" *ngIf="socketService.sources[currentDeviceSource.sourceIdx!]">
+        <label for="deviceSourceRename" class="form-label">Allow Device Renaming</label>
+		<input type="checkbox" placholder="Rename" [(ngModel)]="currentDeviceSource.rename">
       </div>
       <div class="d-flex justify-content-end">
         <button class="btn btn-outline-dark" (click)="saveDeviceSource()"><i class="fas fa-save"></i> {{currentDeviceSource.id !== undefined ? 'Save Changes' : 'Add Device Source'}}</button>

--- a/UI/src/app/_models/DeviceSource.ts
+++ b/UI/src/app/_models/DeviceSource.ts
@@ -3,7 +3,8 @@ export interface DeviceSource {
     deviceId: string;
     id: string;
     sourceId: string;
-    bus: string;
+	bus: string;
+	rename: boolean;
     
     // Volatile
     sourceIdx?: number;

--- a/index.js
+++ b/index.js
@@ -4976,9 +4976,29 @@ function processTSLTally(sourceId, tallyObj) // Processes the TSL Data
 	for (let i = 0; i < device_sources.length; i++) {
 		if ((device_sources[i].sourceId === sourceId) && (device_sources[i].address === tallyObj.address.toString())) {
 			deviceId = device_sources[i].deviceId;
+			if (device_sources[i].rename === true) {
+				RenameDevice(deviceId, tallyObj.label);
+			}
 			CheckDeviceState(deviceId, sourceId, tallyObj);
 		}
 	}
+}
+
+function RenameDevice(deviceId, name) {
+	//renames the Device with the new name that originated in the source type
+
+	for (let i = 0; i < devices.length; i++) {
+		if (devices[i].id === deviceId) {
+			if (label) {
+				devices[i].name = name;
+			}
+			break;
+		}
+	}
+
+	UpdateSockets('devices');
+	SendTSLClientData(deviceId);
+	SendCloudData(sourceId, tallyObj);
 }
 
 function CheckDeviceState(deviceId, sourceId, tallyObj) {
@@ -6502,6 +6522,7 @@ function TallyArbiter_Edit_Device_Source(obj) {
 		if (device_sources[i].bus) {
 			device_sources[i].bus = deviceSourceObj.bus;
 		}
+		device_sources[i].rename = deviceSourceObj.rename;
 	}
 
 	//also remove this device source address from device_states where device = this device, source = this source, address = this old address

--- a/index.js
+++ b/index.js
@@ -3386,7 +3386,7 @@ function renameOBSSource(sourceId, oldname, newname) {
     if(deviceSourceIndex > -1){
         device_sources[deviceSourceIndex].address = newname;
         UpdateCloud('device_sources');
-        logger(`Device Source Edited: ${deviceName} - ${sourceName}`, 'info');
+        logger(`Device Source Edited: ${sourceId} - ${oldname} to ${newname}`, 'info');
     }    
 }
 
@@ -4989,7 +4989,7 @@ function RenameDevice(deviceId, name) {
 
 	for (let i = 0; i < devices.length; i++) {
 		if (devices[i].id === deviceId) {
-			if (label) {
+			if (name) {
 				devices[i].name = name;
 			}
 			break;
@@ -4998,7 +4998,6 @@ function RenameDevice(deviceId, name) {
 
 	UpdateSockets('devices');
 	SendTSLClientData(deviceId);
-	SendCloudData(sourceId, tallyObj);
 }
 
 function CheckDeviceState(deviceId, sourceId, tallyObj) {


### PR DESCRIPTION
This will allow the user to rename their TA Devices based on the incoming mnemonic/label of the source's tally data (for tsl, obs, et al). The user can select per device-source mapping if they want it to rename their Device or not.