### PR TITLE
Fix autoupdate on MacOS

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -30,7 +30,8 @@
     },
     "mac": {
         "target": [
-            "dmg"
+            "dmg",
+            "zip"
         ],
         "category": "public.app-category.video"
     },


### PR DESCRIPTION
I noticed in another one of my Electron apps that the autoupdate on MacOS was not working. So I checked TallyArbiter and we have the same problem here. Apparently the updater needs the application in a `.zip` file.