### PR TITLE
Migrate logging and tally data to Winston

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,24 +67,24 @@ var Logs = []; //Used for loading logs in settings page
 var tallyDataFilePath = getTallyDataPath();
 
 const serverLoggerLevels = {
-  levels: {
-    critical: 0,
-    error: 2,
-    warning: 3,
-    console_action: 4,
-    info: 5,
-    'info-quiet': 6,
-    debug: 7
-  },
-  colors: {
-    critical: 'red',
-    error: 'red',
-    warning: 'yellow',
-    console_action: 'green',
-    info: 'white',
-    'info-quiet': 'white',
-    debug: 'blue'
-  }
+	levels: {
+	    critical: 0,
+	    error: 2,
+	    warning: 3,
+		console_action: 4,
+		info: 5,
+	    'info-quiet': 6,
+	    debug: 7
+	},
+	colors: {
+		critical: 'red',
+	    error: 'red',
+	    warning: 'yellow',
+		console_action: 'green',
+		info: 'white',
+	    'info-quiet': 'white',
+	    debug: 'blue'
+	}
 };
 winston.addColors(serverLoggerLevels.colors);
 let serverLoggerFormat = printf(({ timestamp, level, message }) => {
@@ -119,7 +119,7 @@ winston.loggers.add('server', {
 });
 
 let tallyLoggerFormat = printf((info) => {
-    return `${info.message}`;
+    return JSON.stringify({timestamp: Date.now(), tally: JSON.parse(info.message)});
 });
 winston.loggers.add('tally', {
 	format: tallyLoggerFormat,
@@ -2102,7 +2102,7 @@ function logger(log, type = "info-quiet") { //logs the item to the console, to t
 }
 
 function writeTallyDataFile(log) {
-	tallyLogger.info(JSON.stringify(log) + ',');
+	tallyLogger.info(JSON.stringify(log));
 }
 
 function loadConfig() { // loads the JSON data from the config file to memory

--- a/index.js
+++ b/index.js
@@ -67,24 +67,24 @@ var Logs = []; //Used for loading logs in settings page
 var tallyDataFilePath = getTallyDataPath();
 
 const serverLoggerLevels = {
-	levels: {
-	    critical: 0,
-	    error: 2,
-	    warning: 3,
-		console_action: 4,
-		info: 5,
-	    'info-quiet': 6,
-	    debug: 7
-	},
-	colors: {
-		critical: 'red',
-	    error: 'red',
-	    warning: 'yellow',
-		console_action: 'green',
-		info: 'white',
-	    'info-quiet': 'white',
-	    debug: 'blue'
-	}
+  levels: {
+    critical: 0,
+    error: 2,
+    warning: 3,
+    console_action: 4,
+    info: 5,
+    'info-quiet': 6,
+    debug: 7
+  },
+  colors: {
+    critical: 'red',
+    error: 'red',
+    warning: 'yellow',
+    console_action: 'green',
+    info: 'white',
+    'info-quiet': 'white',
+    debug: 'blue'
+  }
 };
 winston.addColors(serverLoggerLevels.colors);
 let serverLoggerFormat = printf(({ timestamp, level, message }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,16 @@
 			"integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
 			"dev": true
 		},
+		"@dabh/diagnostics": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+			"integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+			"requires": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
 		"@develar/schema-utils": {
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
@@ -1189,6 +1199,30 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"optional": true
 		},
+		"color": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+			"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+			"requires": {
+				"color-convert": "^1.9.1",
+				"color-string": "^1.5.2"
+			},
+			"dependencies": {
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				}
+			}
+		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1201,14 +1235,31 @@
 		"color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"color-string": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+			"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+			"requires": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
 		},
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
 			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
 			"dev": true
+		},
+		"colorspace": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+			"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+			"requires": {
+				"color": "3.0.x",
+				"text-hex": "1.0.x"
+			}
 		},
 		"commander": {
 			"version": "5.1.0",
@@ -1767,6 +1818,11 @@
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
 		},
+		"enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -2070,6 +2126,11 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
+		"fast-safe-stringify": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+			"integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+		},
 		"fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2078,6 +2139,11 @@
 			"requires": {
 				"pend": "~1.2.0"
 			}
+		},
+		"fecha": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
 		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
@@ -2121,6 +2187,11 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fmerge/-/fmerge-1.2.0.tgz",
 			"integrity": "sha1-NumdKuJV4+4a9ma033gFU2cc9pI="
+		},
+		"fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
 		"follow-redirects": {
 			"version": "1.14.1",
@@ -2460,6 +2531,11 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 		},
+		"is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+		},
 		"is-ci": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -2524,6 +2600,11 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
 			"integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA="
+		},
+		"is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -2698,6 +2779,11 @@
 				"json-buffer": "3.0.0"
 			}
 		},
+		"kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+		},
 		"latest-version": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -2728,6 +2814,30 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"logform": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+			"integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+			"requires": {
+				"colors": "^1.2.1",
+				"fast-safe-stringify": "^2.0.4",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"triple-beam": "^1.3.0"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+					"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				}
+			}
 		},
 		"long": {
 			"version": "4.0.0",
@@ -3050,6 +3160,14 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"requires": {
+				"fn.name": "1.x.x"
 			}
 		},
 		"osc": {
@@ -3604,6 +3722,14 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
@@ -3780,6 +3906,11 @@
 			"dev": true,
 			"optional": true
 		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
 		"stat-mode": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -3936,6 +4067,11 @@
 				}
 			}
 		},
+		"text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+		},
 		"textextensions": {
 			"version": "5.12.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.12.0.tgz",
@@ -3979,6 +4115,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+		},
+		"triple-beam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
 		"truncate-utf8-bytes": {
 			"version": "1.0.2",
@@ -4341,6 +4482,48 @@
 						"ansi-regex": "^5.0.0"
 					}
 				}
+			}
+		},
+		"winston": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+			"integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+			"requires": {
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.1.0",
+				"is-stream": "^2.0.0",
+				"logform": "^2.2.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+					"integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"winston-transport": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+			"integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+			"requires": {
+				"readable-stream": "^2.3.7",
+				"triple-beam": "^1.2.0"
 			}
 		},
 		"wolfy87-eventemitter": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"socket.io-client": "4.1.2",
 		"tsl-umd": "^1.1.2",
 		"tsl-umd-v5": "^1.0.3",
+		"winston": "^3.3.3",
 		"xml2js": "^0.4.23"
 	},
 	"main": "main.js",


### PR DESCRIPTION
As described in #195 
Everything is compatible with the old version of the logger, except that now every line of server logs is similar to
```[2021-08-31 21:53:19] info: Starting HTTP Server.``` or ```[2021-08-31 21:53:40] error: An error occurred etc```


-------------

_Winston options for file output:_
![chrome_BNcSWGT34T](https://user-images.githubusercontent.com/27729549/131572091-de814a4a-4705-493c-b6bc-abdbfaaefa12.png)


Current options used in server loggin and in Tally data:
```javascript
{
  filename: filepath,
  maxsize: 3e+7
  maxFiles: 3,
  ...
}
```

-------------

@JTF4 can you explain to me what is Tally data logging and why its format is
`{TallyObj},  {TallyObj}, {TallyObj},`?