### PR TITLE
initial i18n support

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -19,6 +19,8 @@
         "@angular/service-worker": "~12.1.3",
         "@fortawesome/fontawesome-free": "^5.15.3",
         "@ng-bootstrap/ng-bootstrap": "^9.1.1",
+        "@ngx-translate/core": "^13.0.0",
+        "@ngx-translate/http-loader": "^6.0.0",
         "@types/socket.io-client": "^3.0.0",
         "bootstrap": "^5.0.1",
         "ng-qrcode": "^4.2.0",
@@ -4693,6 +4695,31 @@
         "@angular/compiler-cli": "^12.0.0 || ^12.1.0-next",
         "typescript": "~4.2.3 || ~4.3.2",
         "webpack": "^5.30.0"
+      }
+    },
+    "node_modules/@ngx-translate/core": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-13.0.0.tgz",
+      "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=10.0.0",
+        "rxjs": ">=6.5.3"
+      }
+    },
+    "node_modules/@ngx-translate/http-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
+      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=10.0.0",
+        "@ngx-translate/core": ">=13.0.0",
+        "rxjs": ">=6.5.3"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -21965,6 +21992,22 @@
       "dev": true,
       "requires": {
         "enhanced-resolve": "5.8.2"
+      }
+    },
+    "@ngx-translate/core": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-13.0.0.tgz",
+      "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@ngx-translate/http-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz",
+      "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "@nodelib/fs.scandir": {

--- a/UI/package.json
+++ b/UI/package.json
@@ -23,6 +23,8 @@
     "@angular/service-worker": "~12.1.3",
     "@fortawesome/fontawesome-free": "^5.15.3",
     "@ng-bootstrap/ng-bootstrap": "^9.1.1",
+    "@ngx-translate/core": "^13.0.0",
+    "@ngx-translate/http-loader": "^6.0.0",
     "@types/socket.io-client": "^3.0.0",
     "bootstrap": "^5.0.1",
     "ng-qrcode": "^4.2.0",

--- a/UI/src/app/_components/about/about.component.html
+++ b/UI/src/app/_components/about/about.component.html
@@ -1,5 +1,5 @@
 <div class="container pt-3">
-    <h1>About</h1>
+    <h1>{{"GENERAL.ABOUT" | translate}}</h1>
   <div class="row mt-3">
     <div class="col">
         <div class="card p-3">
@@ -15,7 +15,7 @@
     </div>
     <div class="col">
         <div class="card p-3">
-            <h4>Version</h4>
+            <h4>{{"GENERAL.VERSION" | translate}}</h4>
             <b>{{socketService.version}}</b>
         </div>
     </div>

--- a/UI/src/app/_components/chat/chat.component.html
+++ b/UI/src/app/_components/chat/chat.component.html
@@ -11,7 +11,7 @@
         </div>
     </div>
     <div class="input-group">
-        <input type="text" class="form-control" placeholder="Type a message" (keydown.enter)="sendMessage()" [(ngModel)]="message">
+        <input type="text" class="form-control" [placeholder]="'CHAT.TYPE_MESSAGE' | translate" (keydown.enter)="sendMessage()" [(ngModel)]="message">
         <button class="btn btn-outline-dark" (click)="sendMessage()"><i class="fas fa-paper-plane"></i></button>
     </div>
 </div>

--- a/UI/src/app/_components/error-report/error-report.component.html
+++ b/UI/src/app/_components/error-report/error-report.component.html
@@ -1,31 +1,30 @@
 <div class="d-flex justify-content-center mt-5 pt-5" *ngIf="loading">
     <div class="spinner spinner-border"></div>
 </div>
-<button (click)="locationBackService.goBack()" id="backBtn" title="Go back"><i class="fas fa-arrow-left"></i> Back</button>
+<button (click)="locationBackService.goBack()" id="backBtn" title="Go back"><i class="fas fa-arrow-left"></i> {{"GENERAL.BACK" | translate}}</button>
 <div id="page" *ngIf="validReport">
     <div id="text">
         <h1>:(</h1>
-        <h2>There was an unexpected error. Please open a bug report on the project's Github page or contact one of
-            the developers.</h2>
+        <h2>{{"ERRORS.UNEXPECTED_ERROR" | translate}}</h2>
     </div>
     <div style="text-align: center">
-        <button id="bugReportButton" class="btn btn-lg btn-custom" [disabled]="!bugReportUrlLoaded" (click)="bugReportButtonClick()" role="button">Open a bug report on Github</button>
+        <button id="bugReportButton" class="btn btn-lg btn-custom" [disabled]="!bugReportUrlLoaded" (click)="bugReportButtonClick()" role="button">{{"ERRORS.OPEN_BUG_REPORT" | translate}}</button>
     </div>
     <div class="col">
-        <h3>Stacktrace:</h3>
+        <h3>{{"ERRORS.STACKTRACE" | translate}}:</h3>
         <pre id="stacktrace">{{ currentReport.stacktrace }}</pre>
     </div>
     <div class="col">
-        <h3>Error datetime</h3>
+        <h3>{{"ERRORS.DATE" | translate}}</h3>
         <h4>{{ currentReport.datetime | date:'YYYY-MM-dd HH:mm:ss' }}</h4>
     </div>
     <div id="row">
         <div class="col">
-            <h3>Logs:</h3>
+            <h3>{{"GENERAL.LOGS" | translate}}:</h3>
             <pre class="limit" id="logs">{{ currentReport.logs }}</pre>
         </div>
         <div class="col">
-            <h3>Config file:</h3>
+            <h3>{{"ERRORS.CONFIG_FILE" | translate}}:</h3>
             <pre class="limit" id="config">{{ currentReport.config | json }}</pre>
         </div>
     </div>
@@ -33,6 +32,6 @@
 <div id="page" *ngIf="!validReport && !loading">
     <div id="text">
         <h1>:(</h1>
-        <h2>Error report not found.</h2>
+        <h2>{{"ERRORS.ERROR_REPORT_NOT_FOUND" | translate}}</h2>
     </div>
 </div>

--- a/UI/src/app/_components/error-reports-list/error-reports-list.component.html
+++ b/UI/src/app/_components/error-reports-list/error-reports-list.component.html
@@ -1,19 +1,19 @@
 <div class="d-flex justify-content-center mt-5 pt-5" *ngIf="!errorReportsLoaded">
     <div class="spinner spinner-border"></div>
 </div>
-<button (click)="locationBackService.goBack()" class="btn btn-outline-primary" style="margin: 10px" title="Go back"><i class="fas fa-arrow-left"></i> Back</button>
+<button (click)="locationBackService.goBack()" class="btn btn-outline-primary" style="margin: 10px" title="Go back"><i class="fas fa-arrow-left"></i> {{"GENERAL.BACK" | translate}}</button>
 <div *ngIf="errorReportsLoaded">
     <div class="container mt-5">
         <div class="form-group" *ngIf="socketService.errorReports.length > 0">
             <select class='form-control col-xs-6 col-md-3' (change)="selectErrorReport($event)">
-                <option disabled selected>-- Select an error report --</option>
+                <option disabled selected>-- {{"ERRORS.SELECT_ERROR_REPORT" | translate}} --</option>
                 <option [value]="errorReport.id" *ngFor="let errorReport of socketService.errorReports">{{ errorReport.datetime }} {{ unread_error_reports.includes(errorReport.id) ? "(unread)" : "" }}</option>
             </select>
             <div class="text-center" id="buttons_div">
-                <button class="btn btn-outline-success" (click)="markErrorReportsAsRead()">Mark all as read</button>
-                <button class="btn btn-outline-danger" (click)="deleteEveryErrorReport()" style="margin-left: 10px">Permanently delete every bug report from disk</button>
+                <button class="btn btn-outline-success" (click)="markErrorReportsAsRead()">{{"ERRORS.MARK_ALL_AS_READ" | translate}}</button>
+                <button class="btn btn-outline-danger" (click)="deleteEveryErrorReport()" style="margin-left: 10px">{{"ERRORS.DELETE_ALL_ERROR_REPORTS" | translate}}</button>
             </div>
         </div>
     </div>
-    <h2 class="lead mt-5 text-center" *ngIf="socketService.errorReports.length == 0">Hurray! No error report detected.</h2>
+    <h2 class="lead mt-5 text-center" *ngIf="socketService.errorReports.length == 0">{{"ERRORS.NO_ERROR_REPORTS_FOUND" | translate}}</h2>
 </div>

--- a/UI/src/app/_components/home/home.component.html
+++ b/UI/src/app/_components/home/home.component.html
@@ -1,45 +1,45 @@
 <div class="container pt-5">
     <div class="row text-center">
-        <h1 class="display-4">Welcome to Tally Arbiter</h1>
+        <h1 class="display-4">{{"HOME.HOME" | translate}}</h1>
     </div>
     <div class="row mt-5 row-cols-1 row-cols-md-2 g-5 text-center">
         <div class="col">
             <div class="rounded bg-light p-3">
-                <h3><i class="fas fa-mobile-alt"></i> Tally Web Clients</h3>
+                <h3><i class="fas fa-mobile-alt"></i> {{"HOME.TALLY_WEB_CLIENTS" | translate}}</h3>
                 <qr-code class="my-4 d-block" [value]="netInterfaceUrl" size="250" errorCorrectionLevel="M"></qr-code>
                 <select [(ngModel)]="netInterfaceUrl" class="form-select d-inline w-unset">
-                    <option [value]="localNetInterfaceUrl">localhost (Local)</option>
-                    <option *ngIf="socketService.externalAddress !== 'http://0.0.0.0:4455/#/tally'" [value]= "socketService.externalAddress">External Address</option>
+                    <option [value]="localNetInterfaceUrl">{{"HOME.LOCALHOST" | translate}}</option>
+                    <option *ngIf="socketService.externalAddress !== 'http://0.0.0.0:4455/#/tally'" [value]= "socketService.externalAddress">{{"HOME.EXTERNAL_ADDRESS" | translate}}</option>
                     <option *ngFor="let netInterface of socketService.interfaces" [ngValue]="netInterface.url">
                         {{netInterface.address}} ({{netInterface.name}})
                     </option>
                 </select>
-                <p>Scan the QR Code with your Phone or open one of the following URLs:</p>
+                <p>{{"HOME.QR_INFO" | translate}}</p>
                 <ul>
                     <li *ngFor="let net_interface of socketService.interfaces">
                         <a target="_blank" [href]="net_interface.url">{{net_interface.url}}</a>
                     </li>
                     <li *ngIf="socketService.externalAddress !== 'http://0.0.0.0:4455/#/tally'">
-                        <a target="_blank" [href]="socketService.externalAddress">{{socketService.externalAddress}}</a> (External Address)
+                        <a target="_blank" [href]="socketService.externalAddress">{{socketService.externalAddress}}</a> ({{"HOME.EXTERNAL_ADDRESS" | translate}})
                     </li>
                 </ul>
             </div>
         </div>
         <div class="col">
 			<div class="rounded bg-light p-3">
-                <h3><i class="fas fa-book-open"></i> Documentation</h3>
-                <p>View the documentation and usage instructions online if you need help along the way.</p>
-                <a class="btn btn-outline-primary" href="https://josephdadams.github.io/TallyArbiter/" target="_blank">Documentation Link</a>
+                <h3><i class="fas fa-book-open"></i> {{"GENERAL.DOCS" | translate}}</h3>
+                <p>{{"HOME.DOCS_INFO" | translate}}</p>
+                <a class="btn btn-outline-primary" href="https://josephdadams.github.io/TallyArbiter/" target="_blank">{{"HOME.DOCS_LINK" | translate}}</a>
             </div>
             <div class="rounded bg-light mt-5 p-3">
-                <h3><i class="fas fa-tasks"></i> Producer</h3>
-                <p>On the Producer page you get an overview of all connected devices and Tally clients.</p>
-                <a class="btn btn-outline-primary" routerLink="/producer">Producer Page</a>
+                <h3><i class="fas fa-tasks"></i> {{"GENERAL.PRODUCER" | translate}}</h3>
+                <p>{{"HOME.PRODUCER_INFO" | translate}}</p>
+                <a class="btn btn-outline-primary" routerLink="/producer">{{"HOME.PRODUCER_LINK" | translate}}</a>
             </div>
             <div class="rounded bg-light mt-5 p-3">
-                <h3><i class="fas fa-cogs"></i> Settings</h3>
-                <p>Here you can configure and setup all sources, devices, Tally clients and more.</p>
-                <a class="btn btn-outline-primary" routerLink="/settings">Settings</a>
+                <h3><i class="fas fa-cogs"></i> {{"GENERAL.SETTINGS" | translate}}</h3>
+                <p>{{"HOME.SETTINGS_INFO" | translate}}</p>
+                <a class="btn btn-outline-primary" routerLink="/settings">{{"GENERAL.SETTINGS" | translate}}</a>
             </div>
         </div>
     </div>

--- a/UI/src/app/_components/login/login.component.html
+++ b/UI/src/app/_components/login/login.component.html
@@ -1,17 +1,17 @@
 <div class="container text-center d-flex justify-content-center mt-5 pt-5">
     <main class="form-signin">
-        <h1 class="h3 mb-3 fw-normal">Please sign in</h1>
+        <h1 class="h3 mb-3 fw-normal">{{"LOGIN.HEADLINE" | translate}}</h1>
         <div class="my-2 text-danger" *ngIf="!loginResponse.loginOk">{{ loginResponse.message }}</div>
         <div class="form-floating">
-            <input type="text" class="form-control" (keydown.enter)="inputPassword.focus()" [(ngModel)]="username" id="username" placeholder="Username">
-            <label for="username">Username</label>
+            <input type="text" class="form-control" (keydown.enter)="inputPassword.focus()" [(ngModel)]="username" id="username" [placeholder]="'GENERAL.USERNAME' | translate">
+            <label for="username">{{"GENERAL.USERNAME" | translate}}</label>
         </div>
         <div class="form-floating">
-            <input type="password" class="form-control" (keydown.enter)="login()" [(ngModel)]="password" id="password" placeholder="Password" #inputPassword>
-            <label for="password">Password</label>
+            <input type="password" class="form-control" (keydown.enter)="login()" [(ngModel)]="password" id="password" [placeholder]="'GENERAL.PASSWORD' | translate" #inputPassword>
+            <label for="password">{{"GENERAL.PASSWORD" | translate}}</label>
         </div>
         <button class="w-100 btn btn-lg btn-primary" (click)="login()" [disabled]="loading">
-            <span *ngIf="!loading">Login</span>
+            <span *ngIf="!loading">{{"GENERAL.LOGIN" | translate}}</span>
             <div class="spinner-border spinner-border-sm text-white" *ngIf="loading"></div>
         </button>
     </main>

--- a/UI/src/app/_components/producer/producer.component.html
+++ b/UI/src/app/_components/producer/producer.component.html
@@ -1,17 +1,17 @@
 <div class="container pt-3">
   <div class="row">
     <div class="col-md-6">
-    <h2>Devices</h2>
-    <span class="text-muted mt-3" *ngIf="socketService.devices.length == 0">No devices configured.</span>
+    <h2>{{"GENERAL.DEVICES" | translate}}</h2>
+    <span class="text-muted mt-3" *ngIf="socketService.devices.length == 0">{{"GENERAL.NO_DEVICES_CONFIGURED" | translate}}</span>
     <table class="table table-hover" *ngIf="socketService.devices.length > 0">
         <thead>
           <tr>
-            <th>PVW</th>
-            <th>PGM</th>
-            <th>Name</th>
+            <th>{{"GENERAL.BUSSES.PREVIEW_SHORT" | translate}}</th>
+            <th>{{"GENERAL.BUSSES.PROGRAM_SHORT" | translate}}</th>
+            <th>{{"GENERAL.NAME" | translate}}</th>
             <th></th>
-            <th>Description</th>
-            <th>Active Listeners</th>
+            <th>{{"GENERAL.DESCRIPTION" | translate}}</th>
+            <th>{{"GENERAL.ACTIVE_LISTENERS" | translate}}</th>
           </tr>
         </thead>
         <tbody>
@@ -26,16 +26,16 @@
         </tbody>
       </table>
       <hr class="my-5" />
-      <h2>Clients</h2>
-      <span class="text-muted mt-3" *ngIf="socketService.listenerClients.length == 0">No clients connected.</span>
+      <h2>{{"GENERAL.CLIENTS" | translate}}</h2>
+      <span class="text-muted mt-3" *ngIf="socketService.listenerClients.length == 0">{{"CLIENTS.NO_CLIENTS_CONNECTED" | translate}}</span>
       <table class="table table-hover" *ngIf="socketService.listenerClients.length > 0">
         <thead>
           <tr>
             <th></th>
-            <th>IP</th>
-            <th>Type</th>
+            <th>{{"GENERAL.IP" | translate}}</th>
+            <th>{{"GENERAL.TYPE" | translate}}</th>
             <th></th>
-            <th>Device</th>
+            <th>{{"GENERAL.DEVICE" | translate}}</th>
             <th></th>
           </tr>
         </thead>
@@ -46,13 +46,13 @@
             <td>{{listenerClient.listenerType}}</td>
             <td><i class="fas fa-cloud text-muted" *ngIf="listenerClient.cloudConnection"></i></td>
             <td>{{listenerClient.device?.name}}</td>
-            <td><button *ngIf="!listenerClient.inactive && listenerClient.canBeFlashed" class="btn btn-outline-dark" (click)="socketService.flashListener(listenerClient)">Flash</button></td>
+            <td><button *ngIf="!listenerClient.inactive && listenerClient.canBeFlashed" class="btn btn-outline-dark" (click)="socketService.flashListener(listenerClient)">{{"GENERAL.FLASH" | translate}}</button></td>
           </tr>
         </tbody>
       </table>
     </div>
     <div class="col-md-6 chat">
-        <h3>Chat</h3>
+        <h3>{{"GENERAL.CHAT" | translate}}</h3>
         <app-chat type="producer"></app-chat>
     </div>
   </div>

--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -286,6 +286,13 @@
                             </tbody>
                         </table>
                     </div>
+                    <hr class="my-4">
+                    <div>
+                        <h2>Language</h2>
+                        <select class="form-select" [ngModel]="socketService.language | async" (change)="updateLanguage($event)">
+                            <option *ngFor="let language of languages | keyvalue" [value]="language.key">{{language.value}}</option>
+                        </select>
+                    </div>
                 </div>
             </ng-template>
         </ng-container>

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -33,6 +33,11 @@ export class SettingsComponent {
 	@ViewChild('logsContainer') private logsContainer!: ElementRef;
 	@ViewChild('tallyDataContainer') private tallyDataContainer!: ElementRef;
 
+	public languages = {
+		en: "English",
+		de: "German"
+	}
+
 	public logLevels: LogLevel[] = [
 	{ title: "Error", id: "error" },
 	{ title: "Console", id: "console-action" },
@@ -139,6 +144,10 @@ export class SettingsComponent {
 
 	public ngOnInit() {
 		this.setLogLevel(this.currentLogLevel);
+	}
+
+	public updateLanguage(event: any) {
+		this.socketService.socket.emit("setLanguage", event.target.value);
 	}
 
 	public saveDeviceSource() {

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -35,7 +35,8 @@ export class SettingsComponent {
 
 	public languages = {
 		en: "English",
-		de: "German"
+		de: "German",
+		it: "Italiano"
 	}
 
 	public logLevels: LogLevel[] = [

--- a/UI/src/app/_components/tally/tally.component.html
+++ b/UI/src/app/_components/tally/tally.component.html
@@ -5,11 +5,11 @@
     <div class="container mt-5" *ngIf="currentDeviceIdx === undefined">
         <div class="form-group" *ngIf="socketService.devices.length > 0">
             <select class='form-control col-xs-6 col-md-3' (change)="selectDevice($event)">
-                <option disabled selected>-- Select a device --</option>
+                <option disabled selected>-- {{"DEVICES.SELECT_DEVICE" | translate}} --</option>
                 <option [value]="device.id" *ngFor="let device of socketService.devices">{{device.name}}</option>
             </select>
         </div>
-        <h2 class="lead mt-5" *ngIf="socketService.devices.length == 0">No devices are available for tally monitoring at this time.</h2>
+        <h2 class="lead mt-5" *ngIf="socketService.devices.length == 0">{{"DEVICES.NO_DEVICES_AVAILABLE" | translate}}</h2>
     </div>
 
     <div class="d-flex flex-column max-height container-fluid pt-5 text-center" [class.text-white]="!currentBus?.color" [style.background-color]="currentBus?.color || COLORS.DARK_GREY" *ngIf="currentDeviceIdx !== undefined && socketService.devices[currentDeviceIdx]">

--- a/UI/src/app/_services/socket.service.ts
+++ b/UI/src/app/_services/socket.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { io, Socket } from 'socket.io-client';
 import { BusOption } from '../_models/BusOption';
 import { CloudClient } from '../_models/CloudClient';
@@ -61,6 +61,7 @@ export class SocketService {
   public portsInUse: Port[] = [];
   public messages: Message[] = [];
   public errorReports: ErrorReportsListElement[] = [] as ErrorReportsListElement[];
+  public language: BehaviorSubject<string> = new BehaviorSubject("en");
 
   public dataLoaded = new Promise<void>((resolve) => this._resolveDataLoadedPromise = resolve);
   private _resolveDataLoadedPromise!: () => void;
@@ -74,6 +75,9 @@ export class SocketService {
 
   constructor() {
     this.socket = io();
+    this.socket.on('language', (language: string) => {
+      this.language.next(language);
+    });
     this.socket.on('sources', (sources: Source[]) => {
       this.sources = this.prepareSources(sources);
     });

--- a/UI/src/app/app.component.html
+++ b/UI/src/app/app.component.html
@@ -8,21 +8,21 @@
     <div class="collapse navbar-collapse" id="navbarCollapse" [class.show]="showMenu">
       <ul class="navbar-nav me-auto mb-2 mb-md-0">
         <li class="nav-item">
-          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/home">Home</a>
+          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/home">{{"GENERAL.HOME" | translate}}</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/tally">Tally View</a>
+          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/tally">{{"GENERAL.TALLY_VIEW" | translate}}</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/producer">Producer</a>
+          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/producer">{{"GENERAL.PRODUCER" | translate}}</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/settings">Settings</a>
+          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/settings">{{"GENERAL.SETTINGS" | translate}}</a>
         </li>
       </ul>
       <ul class="navbar-nav mb-2 mb-md-0">  
         <li class="nav-item">
-          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/about">About</a>
+          <a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/about">{{"GENERAL.ABOUT" | translate}}</a>
         </li>
       </ul>
     </div>

--- a/UI/src/app/app.component.ts
+++ b/UI/src/app/app.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 import { WakeLockService } from './_services/wake-lock.service';
 import { NavbarVisibilityService } from './_services/navbar-visibility.service';
 import { LocationBackService } from 'src/app/_services/locationBack.service';
+import {TranslateService} from '@ngx-translate/core';
+import { SocketService } from './_services/socket.service';
 
 @Component({
   selector: 'app-root',
@@ -14,8 +16,14 @@ export class AppComponent {
   constructor(
     private wakeLockService: WakeLockService,
     public navbarVisibilityService: NavbarVisibilityService,
-    private locationBackService: LocationBackService
+    private locationBackService: LocationBackService,
+    private translateService: TranslateService,
+    private socketService: SocketService,
   ) {
     wakeLockService.init();
+    translateService.setDefaultLang("en");
+    socketService.language.subscribe((l) => {
+      translateService.use(l);
+    });
   }
 }

--- a/UI/src/app/app.module.ts
+++ b/UI/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { QrCodeModule } from 'ng-qrcode';
-
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './_components/home/home.component';
@@ -17,34 +16,50 @@ import { ChatComponent } from './_components/chat/chat.component';
 import { ErrorReportComponent } from './_components/error-report/error-report.component';
 import { ErrorReportsListComponent } from './_components/error-reports-list/error-reports-list.component';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import {TranslateModule, TranslateLoader} from '@ngx-translate/core';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+export function HttpLoaderFactory(http: HttpClient) {
+    return new TranslateHttpLoader(http);
+}
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    HomeComponent,
-    ProducerComponent,
-    SettingsComponent,
-    TallyComponent,
-    AboutComponent,
-    LoginComponent,
-    ChatComponent,
-    ErrorReportComponent,
-    ErrorReportsListComponent
-  ],
-  imports: [
-    BrowserModule,
-    AppRoutingModule,
-    QrCodeModule,
-    NgbNavModule,
-    FormsModule,
-    ServiceWorkerModule.register('ngsw-worker.js', {
-      enabled: environment.production,
-      // Register the ServiceWorker as soon as the app is stable
-      // or after 30 seconds (whichever comes first).
-      registrationStrategy: 'registerWhenStable:30000'
-    }),
-  ],
-  providers: [],
-  bootstrap: [AppComponent]
+    declarations: [
+        AppComponent,
+        HomeComponent,
+        ProducerComponent,
+        SettingsComponent,
+        TallyComponent,
+        AboutComponent,
+        LoginComponent,
+        ChatComponent,
+        ErrorReportComponent,
+        ErrorReportsListComponent
+    ],
+    imports: [
+        BrowserModule,
+        AppRoutingModule,
+        QrCodeModule,
+        HttpClientModule,
+        NgbNavModule,
+        FormsModule,
+        TranslateModule.forRoot({
+            loader: {
+                provide: TranslateLoader,
+                useFactory: HttpLoaderFactory,
+                deps: [HttpClient]
+            },
+            defaultLanguage: 'en'
+        }),
+        ServiceWorkerModule.register('ngsw-worker.js', {
+            enabled: environment.production,
+            // Register the ServiceWorker as soon as the app is stable
+            // or after 30 seconds (whichever comes first).
+            registrationStrategy: 'registerWhenStable:30000'
+        }),
+    ],
+    providers: [],
+    bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/UI/src/assets/i18n/de.json
+++ b/UI/src/assets/i18n/de.json
@@ -1,0 +1,68 @@
+{
+    "HOME": {
+        "HOME": "Willkommen zu Tally Arbiter!",
+        "TALLY_WEB_CLIENTS": "Tally Web Clients",
+        "EXTERNAL_ADDRESS": "Externe Adresse",
+        "QR_INFO": "Scanne den QR Code mit Deinem Handy oder öffne eine der folgenden URLs:",
+        "LOCALHOST": "localhost (lokal)",
+        "DOCS_INFO": "Schau Dir die Dokumentation und Anleitungen an, wenn Du Hilfe benötigst.",
+        "PRODUCER_INFO": "In der Produzenten-Ansicht bekommst Du einen Überblück über alle verbundenen Geräte und Clients.",
+        "DOCS_LINK": "Zur Dokumentation",
+        "PRODUCER_LINK": "Zur Produzenten-Ansicht",
+        "SETTINGS_INFO": "Hier kannst Du alle Geräte, Quellen usw. einrichten."
+    },
+    "GENERAL": {
+        "SETTINGS": "Einstellungen",
+        "DOCS": "Dokumentation",
+        "HOME": "Home",
+        "TALLY_VIEW": "Tally",
+        "PRODUCER": "Produzent",
+        "ABOUT": "Über",
+        "VERSION": "Version",
+        "BACK": "Zurück",
+        "LOGS": "Logs",
+        "USERNAME": "Benutzername",
+        "PASSWORD": "Passwort",
+        "LOGIN": "Login",
+        "DEVICES": "Geräte",
+        "DEVICE": "Ger#t",
+        "IP": "IP",
+        "FLASH": "Blitzen",
+        "CHAT": "Chat",
+        "TYPE": "Typ",
+        "BUSSES": {
+            "PREVIEW_SHORT": "PVW",
+            "PROGRAM_SHORT": "PGM"
+        },
+        "NAME": "Name",
+        "DESCRIPTION": "Beschreibung",
+        "ACTIVE_LISTENERS": "Aktive Listener",
+        "CLIENTS": "Clients"
+    },
+    "DEVICES": {
+        "NO_DEVICES_CONFIGURED": "Keine Geräte konfiguriert.",
+        "SELECT_DEVICE": "Wähle ein Gerät aus",
+        "NO_DEVICES_AVAILABLE": "Aktuell sind keine Geräte verfügbar."
+    },
+    "CHAT": {
+        "TYPE_MESSAGE": "Gib eine Nachricht ein"
+    },
+    "CLIENTS": {
+        "NO_CLIENTS_CONNECTED": "Keine Clients verbunden."
+    },
+    "ERRORS": {
+        "UNEXPECTED_ERROR": "Leider gab es einen unerwarteten Fehler. Bitte erstelle einen Fehlerbericht auf der GitHub Seite von Tally Arbiter oder kontaktiere einen der Entwickler.",
+        "OPEN_BUG_REPORT": "Fehlerbericht auf GitHub erstellen",
+        "DATE": "Datum",
+        "CONFIG_FILE": "Konfigurationsdatei",
+        "STACKTRACE": "Stacktrace",
+        "ERROR_REPORT_NOT_FOUND": "Der Fehlerbericht wurde nicht gefunden.",
+        "MARK_ALL_AS_READ": "Alle als gelesen markieren",
+        "NO_ERROR_REPORTS_FOUND": "Hurra! Keine Fehlerberichte gefunden.",
+        "DELETE_ALL_ERROR_REPORTS": "Alle Fehlerberichte löschen",
+        "SELECT_ERROR_REPORT": "Wähle einen Fehlerbericht aus"
+    },
+    "LOGIN": {
+        "HEADLINE": "Bitte anmelden"
+    }
+}

--- a/UI/src/assets/i18n/en.json
+++ b/UI/src/assets/i18n/en.json
@@ -1,0 +1,68 @@
+{
+    "HOME": {
+        "HOME": "Welcome to Tally Arbiter!",
+        "TALLY_WEB_CLIENTS": "Tally Web Clients",
+        "EXTERNAL_ADDRESS": "External Address",
+        "QR_INFO": "Scan the QR Code with your Phone or open one of the following URLs:",
+        "LOCALHOST": "localhost (Local)",
+        "DOCS_INFO": "View the documentation and usage instructions online if you need help along the way.",
+        "PRODUCER_INFO": "On the Producer page you get an overview of all connected devices and Tally clients.",
+        "DOCS_LINK": "Go to Docs",
+        "PRODUCER_LINK": "Go to Producer",
+        "SETTINGS_INFO": "Here you can configure and setup all sources, devices, Tally clients and more."
+    },
+    "GENERAL": {
+        "SETTINGS": "Settings",
+        "DOCS": "Documentation",
+        "HOME": "Home",
+        "TALLY_VIEW": "Tally View",
+        "PRODUCER": "Producer",
+        "ABOUT": "About",
+        "VERSION": "Version",
+        "BACK": "Back",
+        "LOGS": "Logs",
+        "USERNAME": "Username",
+        "PASSWORD": "Password",
+        "LOGIN": "Login",
+        "DEVICES": "Devices",
+        "DEVICE": "Device",
+        "IP": "IP",
+        "FLASH": "Flash",
+        "CHAT": "Chat",
+        "TYPE": "Type",
+        "BUSSES": {
+            "PREVIEW_SHORT": "PVW",
+            "PROGRAM_SHORT": "PGM"
+        },
+        "NAME": "Name",
+        "DESCRIPTION": "Description",
+        "ACTIVE_LISTENERS": "Active Listeners",
+        "CLIENTS": "Clients"
+    },
+    "DEVICES": {
+        "NO_DEVICES_CONFIGURED": "No devices configured.",
+        "SELECT_DEVICE": "Select a device",
+        "NO_DEVICES_AVAILABLE": "No devices are available for tally monitoring at this time."
+    },
+    "CHAT": {
+        "TYPE_MESSAGE": "Type a message"
+    },
+    "CLIENTS": {
+        "NO_CLIENTS_CONNECTED": "No clients connected."
+    },
+    "ERRORS": {
+        "UNEXPECTED_ERROR": "There was an unexpected error. Please open a bug report on the project's Github page or contact one of the developers.",
+        "OPEN_BUG_REPORT": "Open a bug report on Github",
+        "DATE": "Date",
+        "CONFIG_FILE": "Config File",
+        "STACKTRACE": "Stacktrace",
+        "ERROR_REPORT_NOT_FOUND": "Error report not found.",
+        "MARK_ALL_AS_READ": "Mark all as read",
+        "NO_ERROR_REPORTS_FOUND": "Hurray! No error report detected.",
+        "DELETE_ALL_ERROR_REPORTS": "Permanently delete every bug report from disk",
+        "SELECT_ERROR_REPORT": "Select an error report"
+    },
+    "LOGIN": {
+        "HEADLINE": "Please sign in"
+    }
+}

--- a/UI/src/assets/i18n/it.json
+++ b/UI/src/assets/i18n/it.json
@@ -1,0 +1,68 @@
+{
+    "HOME": {
+        "HOME": "Benvenuto su Tally Arbiter!",
+        "TALLY_WEB_CLIENTS": "Clients Web Tally",
+        "EXTERNAL_ADDRESS": "Indirizzo Esterno",
+        "QR_INFO": "Scansiona il QR Code con il tuo telefono o apri uno dei seguenti collegamenti:",
+        "LOCALHOST": "localhost (Locale)",
+        "DOCS_INFO": "Visualizza la documentazione le istruzioni d'uso online se hai bisogno di aiuto durante l'uso.",
+        "PRODUCER_INFO": "Nella pagina di Regia è possibile osservare un elenco con lo stato dei dispositivi tally configurati.",
+        "DOCS_LINK": "Vai alla Documentazione",
+        "PRODUCER_LINK": "Vai alla pagina di Regia",
+        "SETTINGS_INFO": "Qui è possibile configurare sorgenti, dispositivi, clients Tally e molto altro."
+    },
+    "GENERAL": {
+        "SETTINGS": "Impostazioni",
+        "DOCS": "Documentazione",
+        "HOME": "Home",
+        "TALLY_VIEW": "Elenco Tally",
+        "PRODUCER": "Regia",
+        "ABOUT": "Informazioni",
+        "VERSION": "Versione",
+        "BACK": "Torna indietro",
+        "LOGS": "Logs",
+        "USERNAME": "Username",
+        "PASSWORD": "Password",
+        "LOGIN": "Login",
+        "DEVICES": "Dispositivi",
+        "DEVICE": "Dispositivo",
+        "IP": "IP",
+        "FLASH": "Lampeggia",
+        "CHAT": "Chat",
+        "TYPE": "Tipo",
+        "BUSSES": {
+            "PREVIEW_SHORT": "PVW",
+            "PROGRAM_SHORT": "PGM"
+        },
+        "NAME": "Nome",
+        "DESCRIPTION": "Descrizione",
+        "ACTIVE_LISTENERS": "Clients Attivi",
+        "CLIENTS": "Clients"
+    },
+    "DEVICES": {
+        "NO_DEVICES_CONFIGURED": "Nessun dispositivo configurato.",
+        "SELECT_DEVICE": "Seleziona un dispositivo",
+        "NO_DEVICES_AVAILABLE": "Nessun dispositivo è attualmente disponibile per la visione dello stato."
+    },
+    "CHAT": {
+        "TYPE_MESSAGE": "Scrivi un messaggio"
+    },
+    "CLIENTS": {
+        "NO_CLIENTS_CONNECTED": "Nessun client connesso."
+    },
+    "ERRORS": {
+        "UNEXPECTED_ERROR": "C'è stato un errore inaspettato. Per favore, apri una segnalazione alla pagina Github del progetto o contatta uno sviluppatore.",
+        "OPEN_BUG_REPORT": "Apri una segnalazione su Github",
+        "DATE": "Data",
+        "CONFIG_FILE": "File di Configurazione",
+        "STACKTRACE": "Stacktrace",
+        "ERROR_REPORT_NOT_FOUND": "Rapporto di errore non trovato.",
+        "MARK_ALL_AS_READ": "Segna tutti come letti",
+        "NO_ERROR_REPORTS_FOUND": "Evviva! Nessun rapporto di errore rilevato.",
+        "DELETE_ALL_ERROR_REPORTS": "Cancella permanentemente i rapporti di errore dal disco",
+        "SELECT_ERROR_REPORT": "Seleziona un rapporto di errore"
+    },
+    "LOGIN": {
+        "HEADLINE": "Per favore, esegui il login."
+    }
+}

--- a/src/_helpers/config.ts
+++ b/src/_helpers/config.ts
@@ -39,7 +39,8 @@ export const ConfigDefaults: Config = {
         { id: '12c8d689', label: 'Aux 2', type: 'aux', color: '#0000FF', priority: 100}
     ],
     externalAddress: "http://0.0.0.0:4455/#/tally",
-	uuid: uuidv4()
+	uuid: uuidv4(),
+	language: "en"
 }
 
 export let currentConfig: Config = clone(ConfigDefaults);

--- a/src/_models/Config.ts
+++ b/src/_models/Config.ts
@@ -20,4 +20,5 @@ export interface Config {
     cloud_destinations: CloudDestination[];
     cloud_keys: string[];
     bus_options: BusOption[];
+    language: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,8 @@ function initialSetup() {
 	io.sockets.on('connection', (socket) => {
 		const ipAddr = socket.handshake.address;
 
+		socket.emit("language", currentConfig.language);
+
 		socket.on('login', (type: "settings" | "producer", username: string, password: string) => {
 			if((type === "producer" && username == currentConfig.security.username_producer && password == currentConfig.security.password_producer)
 			|| (type === "settings" && username == currentConfig.security.username_settings && password == currentConfig.security.password_settings)) {
@@ -229,6 +231,12 @@ function initialSetup() {
 
 		socket.on('externalAddress', () => {
 			socket.emit('externalAddress', currentConfig.externalAddress);
+		});
+
+		socket.on('setLanguage', (language: string) => {
+			currentConfig.language = language;
+			SaveConfig();
+			socket.emit('language', language);
 		});
 
 		socket.on('interfaces', () =>  {


### PR DESCRIPTION
fixes #216 

Currently English and German are supported. Adding a new language is really easy:
1. Duplicate `UI/src/assets/i18n/en.json` 
2. Rename appropriately (2-letter language code)
3. Translate the contents
4. Add the language to the dropdown in the settings page by adding it to the [languages object here](https://github.com/josephdadams/TallyArbiter/blob/6de58ba5c8272b9a0db09cd533d5e7e6775a53f2/UI/src/app/_components/settings/settings.component.ts#L36-L39).


ToDo:

- [ ] Translate messages generated by the backend
- [ ] Translate the Settings page