### PR TITLE
Fix docker commands to correctly save configs

### DIFF
--- a/docs/docs/installation/docker.md
+++ b/docs/docs/installation/docker.md
@@ -10,10 +10,10 @@ You can pull the image from DockerHub using the following command:
 docker pull josephdadams/tallyarbiter:latest
 ```
 
-Then, start it by typing `docker run -p 4455:4455 -v $(pwd)/config.json:/app/config.json --restart unless-stopped josephdadams/tallyarbiter`.
-If you are using traditional Windows CMD, you can use `docker run -p 4455:4455 -v %CD%\config.json:/app/config.json --restart unless-stopped josephdadams/tallyarbiter`.
-If you are using Powershell, you can use `docker run -p 4455:4455 -v $pwd\config.json:/app/config.json --restart unless-stopped josephdadams/tallyarbiter`.
-If you prefer using docker-compose, you can use this configuration:
+Then, start it by typing `docker run -d -p 4455:4455 -v $(pwd):/app/config --env APPDATA=/app/config --restart unless-stopped josephdadams/tallyarbiter`.
+If you are using traditional Windows CMD, you can use `docker run -d -p 4455:4455 -v %CD%:/app/config --env APPDATA=/app/config --restart unless-stopped josephdadams/tallyarbiter`.
+If you are using Powershell, you can use `docker run -d -p 4455:4455 -v $pwd:/app/config --env APPDATA=/app/config --restart unless-stopped josephdadams/tallyarbiter`.
+If you prefer using docker-compose, you can use this configuration (change the `/home/pi` path to your directory of choice):
 ```yaml
 version: '3.3'
 services:
@@ -21,7 +21,9 @@ services:
         ports:
             - '4455:4455'
         volumes:
-            - './config.json:/app/config.json'
+            - /home/pi:/app/config
+        environment:
+            - APPDATA=/app/config
         restart: unless-stopped
         image: josephdadams/tallyarbiter
 ```


### PR DESCRIPTION
Fixes #251 also adds `-d` to daemonize docker and not freeze the console on startup