### PR TITLE
Configurable reconnect handling

### DIFF
--- a/src/_helpers/configSchema.ts
+++ b/src/_helpers/configSchema.ts
@@ -137,9 +137,17 @@ export default {
                     rename: {
                         description: "Enables renaming",
                         type: "boolean"
+                    },
+                    reconnect_intervall: {
+                        description: "Configure reconnect intervall",
+                        type: "number"
+                    },
+                    unlimited_reconnects: {
+                        description: "Enables unlimited reconnect attemps",
+                        type: "boolean"
                     }
                 },
-                required: ["deviceId", "address", "id", "sourceId", "bus", "rename"]
+                required: ["deviceId", "address", "id", "sourceId", "bus", "rename", "reconnect_intervall", "unlimted_reconnects"]
             },
             uniqueItems: true
         },

--- a/src/_helpers/configSchema.ts
+++ b/src/_helpers/configSchema.ts
@@ -138,8 +138,8 @@ export default {
                         description: "Enables renaming",
                         type: "boolean"
                     },
-                    reconnect_intervall: {
-                        description: "Configure reconnect intervall",
+                    reconnect_interval: {
+                        description: "Configure reconnect interval",
                         type: "number"
                     },
                     max_reconnects: {
@@ -147,7 +147,7 @@ export default {
                         type: "number"
                     }
                 },
-                required: ["deviceId", "address", "id", "sourceId", "bus", "rename", "reconnect_intervall", "max_reconnects"]
+                required: ["deviceId", "address", "id", "sourceId", "bus", "rename", "reconnect_interval", "max_reconnects"]
             },
             uniqueItems: true
         },

--- a/src/_helpers/configSchema.ts
+++ b/src/_helpers/configSchema.ts
@@ -142,12 +142,12 @@ export default {
                         description: "Configure reconnect intervall",
                         type: "number"
                     },
-                    unlimited_reconnects: {
-                        description: "Enables unlimited reconnect attemps",
-                        type: "boolean"
+                    max_reconnects: {
+                        description: "Configured number of reconnects",
+                        type: "number"
                     }
                 },
-                required: ["deviceId", "address", "id", "sourceId", "bus", "rename", "reconnect_intervall", "unlimted_reconnects"]
+                required: ["deviceId", "address", "id", "sourceId", "bus", "rename", "reconnect_intervall", "max_reconnects"]
             },
             uniqueItems: true
         },

--- a/src/_models/DeviceSource.ts
+++ b/src/_models/DeviceSource.ts
@@ -5,7 +5,7 @@ export interface DeviceSource {
     sourceId: string;
 	bus: string;
     rename: boolean;
-    reconnect_intervall: number;
+    reconnect_interval: number;
     max_reconnects: number;
     
     // Volatile

--- a/src/_models/DeviceSource.ts
+++ b/src/_models/DeviceSource.ts
@@ -4,7 +4,9 @@ export interface DeviceSource {
     id: string;
     sourceId: string;
 	bus: string;
-	rename: boolean;
+    rename: boolean;
+    reconnect_intervall: number;
+    unlimited_reconnects: boolean;
     
     // Volatile
 	cloudConnection?: any;

--- a/src/_models/DeviceSource.ts
+++ b/src/_models/DeviceSource.ts
@@ -6,7 +6,7 @@ export interface DeviceSource {
 	bus: string;
     rename: boolean;
     reconnect_intervall: number;
-    unlimited_reconnects: boolean;
+    max_reconnects: number;
     
     // Volatile
 	cloudConnection?: any;

--- a/src/_models/Source.ts
+++ b/src/_models/Source.ts
@@ -6,7 +6,7 @@ export interface Source {
     reconnect: boolean;
     sourceTypeId: string;
     data: Record<string, any>;
-    reconnect_intervall: number;
+    reconnect_interval: number;
     max_reconnects: number;
 
     // Volatile

--- a/src/_models/Source.ts
+++ b/src/_models/Source.ts
@@ -6,6 +6,8 @@ export interface Source {
     reconnect: boolean;
     sourceTypeId: string;
     data: Record<string, any>;
+    reconnect_intervall: number;
+    unlimited_reconnects: boolean;
 
     // Volatile
 	cloudClientId?: any;

--- a/src/_models/Source.ts
+++ b/src/_models/Source.ts
@@ -7,7 +7,7 @@ export interface Source {
     sourceTypeId: string;
     data: Record<string, any>;
     reconnect_intervall: number;
-    unlimited_reconnects: boolean;
+    max_reconnects: number;
 
     // Volatile
 	cloudClientId?: any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -973,7 +973,7 @@ function ToggleTestMode(enabled: boolean) {
 				data: {
 					addressesNumber: devices.length,
 				},
-				reconnect_intervall: 5000,
+				reconnect_interval: 5000,
 				max_reconnects: 5,
 			};
 			//turn on test mode
@@ -988,7 +988,7 @@ function ToggleTestMode(enabled: boolean) {
 					sourceId: testModeSource.id,
 					bus: "",
 					rename: false,
-					reconnect_intervall: 5000,
+					reconnect_interval: 5000,
 					max_reconnects: 5,
 				});
 			}
@@ -1565,7 +1565,7 @@ function TallyArbiter_Edit_Source(obj: Manage): ManageResponse {
 			sources[i].data = sourceObj.data;
 			sourceTypeId = sources[i].sourceTypeId;
 			connected = sources[i].connected;
-			sources[i].reconnect_intervall = sourceObj.reconnect_intervall;
+			sources[i].reconnect_interval = sourceObj.reconnect_interval;
 			sources[i].max_reconnects = sourceObj.max_reconnects;
 		}
 	}
@@ -1728,7 +1728,7 @@ function TallyArbiter_Edit_Device_Source(obj: Manage): ManageResponse {
 			device_sources[i].bus = deviceSourceObj.bus;
 		}
 		device_sources[i].rename = deviceSourceObj.rename;
-		device_sources[i].reconnect_intervall = deviceSourceObj.reconnect_intervall;
+		device_sources[i].reconnect_interval = deviceSourceObj.reconnect_interval;
 		device_sources[i].max_reconnects = deviceSourceObj.max_reconnects;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -973,8 +973,8 @@ function ToggleTestMode(enabled: boolean) {
 				data: {
 					addressesNumber: devices.length,
 				},
-				reconnect_intervall: 5000, // NEW
-				unlimited_reconnects: true, // NEW
+				reconnect_intervall: 5000,
+				max_reconnects: 5,
 			};
 			//turn on test mode
             sources.push(testModeSource);
@@ -988,8 +988,8 @@ function ToggleTestMode(enabled: boolean) {
 					sourceId: testModeSource.id,
 					bus: "",
 					rename: false,
-					reconnect_intervall: 5000, // NEW
-					unlimited_reconnects: false, // NEW
+					reconnect_intervall: 5000,
+					max_reconnects: 5,
 				});
 			}
 
@@ -1565,8 +1565,8 @@ function TallyArbiter_Edit_Source(obj: Manage): ManageResponse {
 			sources[i].data = sourceObj.data;
 			sourceTypeId = sources[i].sourceTypeId;
 			connected = sources[i].connected;
-			sources[i].reconnect_intervall = sourceObj.reconnect_intervall; // NEW
-			sources[i].unlimited_reconnects = sourceObj.unlimited_reconnects; // NEW
+			sources[i].reconnect_intervall = sourceObj.reconnect_intervall;
+			sources[i].max_reconnects = sourceObj.max_reconnects;
 		}
 	}
 
@@ -1728,8 +1728,8 @@ function TallyArbiter_Edit_Device_Source(obj: Manage): ManageResponse {
 			device_sources[i].bus = deviceSourceObj.bus;
 		}
 		device_sources[i].rename = deviceSourceObj.rename;
-		device_sources[i].reconnect_intervall = deviceSourceObj.reconnect_intervall; // NEW
-		device_sources[i].unlimited_reconnects = deviceSourceObj.unlimited_reconnects; // NEW
+		device_sources[i].reconnect_intervall = deviceSourceObj.reconnect_intervall;
+		device_sources[i].max_reconnects = deviceSourceObj.max_reconnects;
 	}
 
 	let deviceName = GetDeviceByDeviceId(deviceId).name;

--- a/src/index.ts
+++ b/src/index.ts
@@ -973,6 +973,8 @@ function ToggleTestMode(enabled: boolean) {
 				data: {
 					addressesNumber: devices.length,
 				},
+				reconnect_intervall: 5000, // NEW
+				unlimited_reconnects: true, // NEW
 			};
 			//turn on test mode
             sources.push(testModeSource);
@@ -986,6 +988,8 @@ function ToggleTestMode(enabled: boolean) {
 					sourceId: testModeSource.id,
 					bus: "",
 					rename: false,
+					reconnect_intervall: 5000, // NEW
+					unlimited_reconnects: false, // NEW
 				});
 			}
 
@@ -1561,6 +1565,8 @@ function TallyArbiter_Edit_Source(obj: Manage): ManageResponse {
 			sources[i].data = sourceObj.data;
 			sourceTypeId = sources[i].sourceTypeId;
 			connected = sources[i].connected;
+			sources[i].reconnect_intervall = sourceObj.reconnect_intervall; // NEW
+			sources[i].unlimited_reconnects = sourceObj.unlimited_reconnects; // NEW
 		}
 	}
 
@@ -1722,6 +1728,8 @@ function TallyArbiter_Edit_Device_Source(obj: Manage): ManageResponse {
 			device_sources[i].bus = deviceSourceObj.bus;
 		}
 		device_sources[i].rename = deviceSourceObj.rename;
+		device_sources[i].reconnect_intervall = deviceSourceObj.reconnect_intervall; // NEW
+		device_sources[i].unlimited_reconnects = deviceSourceObj.unlimited_reconnects; // NEW
 	}
 
 	let deviceName = GetDeviceByDeviceId(deviceId).name;

--- a/src/sources/_Source.ts
+++ b/src/sources/_Source.ts
@@ -25,18 +25,18 @@ export class TallyInput extends EventEmitter {
         this.connected.subscribe((connected) => {
             if (connected) {
                 // Connected, no more reconnects for now
-                console.log("status: connected", this.source.name);
+                logger(`Source: ${this.source.name} Connected.`, 'info-quiet');
                 this.tryReconnecting = true;
                 this.reconnectFailureCounter = 0;
             } else {
                 if (!this.tryReconnecting) {
                     // Connection attempt at startup
-                    console.log("Source:", this.source.name, "connect triggered at startup");
+                    logger(`Source: ${this.source.name} Connect triggered at startup.`, 'info-quiet');
                     
                     if (this.source.unlimited_reconnects) {
-                        console.log("Source:", this.source.name, "infinite reconnect attempts");
+                        logger(`Source: ${this.source.name} Inifinite reconnect attempts.`, 'info-quiet');
                     } else {
-                        console.log("Source:", this.source.name, "max default reconnect attempts", MAX_FAILED_RECONNECTS);
+                        logger(`Source: ${this.source.name} Max default reconnect attempts ${MAX_FAILED_RECONNECTS}.`, 'info-quiet');
                     }
                     this.tryReconnecting = true;
                     return;
@@ -47,31 +47,31 @@ export class TallyInput extends EventEmitter {
                 if ((this.tryReconnecting && this.reconnectFailureCounter < MAX_FAILED_RECONNECTS) ||
                     (this.tryReconnecting && this.source.unlimited_reconnects)) {
                     if (this.reconnectTimeout) {
-                        console.log("Source:", this.source.name, "reconnect timeout not set")
+                        logger(`Source: ${this.source.name} Reconnect timeout not set.`, 'info-quiet');
                         return;
                     }
 
                     this.reconnectFailureCounter++;
-                    console.log("Source:", this.source.name, "reconnect attempt:", this.reconnectFailureCounter);
+                    logger(`Source: ${this.source.name} Reconnect attempt: ${this.reconnectFailureCounter}.`, 'info-quiet');
 
                     // Use configured timeout only if larger then tally arbiter default
                     if (this.source.reconnect_intervall > RECONNECT_INTERVAL) {
-                        console.log("Source:", this.source.name, "specific reconnect timeout", this.source.reconnect_intervall);
+                        logger(`Source: ${this.source.name} Specific reconnect timeout: ${this.source.reconnect_intervall}.`, 'info-quiet');
                         this.reconnectTimeout = setTimeout(() => {
                             this.reconnectTimeout = undefined;
                             this.reconnect();
                         }, this.source.reconnect_intervall);
                     } else {
-                        console.log("Source:", this.source.name, "default reconnect timeout", RECONNECT_INTERVAL);
+                        logger(`Source: ${this.source.name} Default reconnect timeout ${RECONNECT_INTERVAL}.`, 'info-quiet');
                         this.reconnectTimeout = setTimeout(() => {
-                            console.log("Source:", this.source.name, "default timeout");
+                            logger(`Source: ${this.source.name} Default timeout.`, 'info-quiet');
                             this.reconnectTimeout = undefined;
                             this.reconnect();
                         }, RECONNECT_INTERVAL);
 
                     }
                 } else {
-                    console.log("Source:", this.source.name, "no more reconnects");
+                    logger(`Source: ${this.source.name} No more reconnects.`, 'info-quiet');
                 }
             }
         });

--- a/src/sources/_Source.ts
+++ b/src/sources/_Source.ts
@@ -38,8 +38,8 @@ export class TallyInput extends EventEmitter {
 
         // Log reconnect timeout
         // Configured timeout only used if larger then RECONNECT_INTERVAL
-        if (this.source.reconnect_intervall > RECONNECT_INTERVAL) {
-            logger(`Source: ${this.source.name} Configured reconnect timeout: ${this.source.reconnect_intervall}.`, 'info-quiet');
+        if (this.source.reconnect_interval > RECONNECT_INTERVAL) {
+            logger(`Source: ${this.source.name} Configured reconnect timeout: ${this.source.reconnect_interval}.`, 'info-quiet');
         } else {
             logger(`Source: ${this.source.name} Default reconnect timeout: ${RECONNECT_INTERVAL}.`, 'info-quiet');
         }
@@ -70,11 +70,11 @@ export class TallyInput extends EventEmitter {
                     logger(`Source: ${this.source.name} Reconnect attempt: ${this.reconnectFailureCounter}.`, 'info-quiet');
 
                     // Use configured timeout only if larger then RECONNECT_INTERVAL
-                    if (this.source.reconnect_intervall > RECONNECT_INTERVAL) {
+                    if (this.source.reconnect_interval > RECONNECT_INTERVAL) {
                         this.reconnectTimeout = setTimeout(() => {
                             this.reconnectTimeout = undefined;
                             this.reconnect();
-                        }, this.source.reconnect_intervall);
+                        }, this.source.reconnect_interval);
                     } else {
                         this.reconnectTimeout = setTimeout(() => {
                             logger(`Source: ${this.source.name} Default timeout.`, 'info-quiet');


### PR DESCRIPTION
The reconnect handling for device sources has been extended with the options:
- reconnect_intervall (number)
- unlimited_reconnects (boolean)

**Reconnect_intervall** is only used if larger than the constant RECONNECT_INTERVAL. 
**Unlimited_reconnects** is only used if set to true. If false or not set the default MAX_FAILED_RECONNECTS is used.

NB: Additional console printouts for easier troubleshooting was included.