### PR TITLE
Initial support for Livestream Studio6

### DIFF
--- a/src/sources/LivestreamStudio6.ts
+++ b/src/sources/LivestreamStudio6.ts
@@ -1,0 +1,19 @@
+import { logger } from "..";
+import { RegisterTallyInput } from "../_decorators/RegisterTallyInput.decorator";
+import { Source } from '../_models/Source';
+import { TallyInput } from './_Source';
+import net from "net";
+
+@RegisterTallyInput("934b5102", "Livestream Studio6", "", [
+    { fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+])
+export class LivestreamStudio6Source extends TallyInput {
+    constructor(source: Source) {
+        super(source);
+        this.connected.next(true);
+    }
+
+    public exit(): void {
+        super.exit();
+    }
+}

--- a/src/sources/LivestreamStudio6.ts
+++ b/src/sources/LivestreamStudio6.ts
@@ -62,11 +62,12 @@ export class LivestreamStudio6Source extends TallyInput {
             }
         });
 
-        this.client.connect(this.ip, this.port);
+        //TODO: fix this (see ATEM Videohub source)
+        //this.client.connect(this.ip, this.port);
     }
 
     public reconnect() {
-        this.client.connect(this.ip, this.port);
+        //this.client.connect(this.ip, this.port);
     }
 
     public exit(): void {

--- a/src/sources/LivestreamStudio6.ts
+++ b/src/sources/LivestreamStudio6.ts
@@ -4,16 +4,73 @@ import { Source } from '../_models/Source';
 import { TallyInput } from './_Source';
 import net from "net";
 
+//Based on https://github.com/bitfocus/companion-module-vimeo-livestreamstudio6/blob/main/src/index.js
+//Thanks to @ChgoChad
+
 @RegisterTallyInput("934b5102", "Livestream Studio6", "", [
-    { fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+    { fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' }
 ])
 export class LivestreamStudio6Source extends TallyInput {
+    private client: net.Socket;
+    private ip: string;
+    private port: number;
+
     constructor(source: Source) {
         super(source);
-        this.connected.next(true);
+
+        this.ip = source.data.ip;
+        this.port = 9923;
+
+        this.client = new net.Socket();
+
+        this.client.on('error', (err) => {
+            this.connected.next(false);
+        });
+
+        this.client.on('connect', () => {
+            this.connected.next(true);
+        });
+
+        // separate buffered stream into lines with responses
+        this.client.on('data', (chunk) => {
+            let i = 0;
+            let line = '';
+            let offset = 0;
+            receiveBuffer += chunk
+            while ((i = receiveBuffer.indexOf('\n', offset)) !== -1) {
+                line = receiveBuffer.substr(offset, i - offset)
+                offset = i + 1
+                this.client.emit('receiveline', line.toString())
+            }
+            receiveBuffer = receiveBuffer.substr(offset)
+        });
+
+        this.client.on('receiveline', (line) => {
+            if (line !== undefined || line !== '') {
+                // If verbose send received string to the log, except in the case of TrMSp & AVC
+                // both of which return large amounts of data that would be excessive for the log
+                if (self.config.verbose &&
+                    !line.startsWith('TrMSp') &&
+                    !line.startsWith('TrASp') &&
+                    !line.startsWith('AVC')
+                ) {
+                    logger(`Source: ${source.name}  Data received: ${line}`, 'debug');
+                }
+                //self.parseIncomingAPI(line);
+            } else {
+                logger(`Source: ${source.name}  Data received was undefined or null.`, 'error');
+            }
+        });
+
+        this.client.connect(this.ip, this.port);
+    }
+
+    public reconnect() {
+        this.client.connect(this.ip, this.port);
     }
 
     public exit(): void {
         super.exit();
+        this.client.end();
     }
 }

--- a/src/sources/LivestreamStudio6.ts
+++ b/src/sources/LivestreamStudio6.ts
@@ -5,7 +5,7 @@ import { TallyInput } from './_Source';
 import net from "net";
 
 //Based on https://github.com/bitfocus/companion-module-vimeo-livestreamstudio6/blob/main/src/index.js
-//Thanks to @ChgoChad
+//Thanks to @ChgoChad (https://github.com/ChgoChad)
 
 @RegisterTallyInput("934b5102", "Livestream Studio6", "", [
     { fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' }

--- a/src/sources/LivestreamStudio6.ts
+++ b/src/sources/LivestreamStudio6.ts
@@ -41,18 +41,18 @@ export class LivestreamStudio6Source extends TallyInput {
             let i = 0;
             let line = '';
             let offset = 0;
-            this.receiveBuffer += chunk
+            this.receiveBuffer += chunk;
             while ((i = this.receiveBuffer.indexOf('\n', offset)) !== -1) {
-                line = this.receiveBuffer.substr(offset, i - offset)
+                line = this.receiveBuffer.substr(offset, i - offset);
                 offset = i + 1
-                this.client.emit('receiveline', line.toString())
+                this.client.emit('receiveline', line.toString());
             }
-            this.receiveBuffer = this.receiveBuffer.substr(offset)
+            this.receiveBuffer = this.receiveBuffer.substr(offset);
         });
 
         this.client.on('receiveline', (line) => {
             if (line !== undefined || line !== '') {
-                // If verbose send received string to the log, except in the case of TrMSp & AVC
+                // Send received string to the log, except in the case of TrMSp & AVC
                 // both of which return large amounts of data that would be excessive for the log
                 logger(`Source: ${source.name}  Data received: ${line}`, 'info-quiet');
                 this.parseIncomingAPI(line);


### PR DESCRIPTION
Closes #23 (but it's still WiP).

I'm working on this, thanks to https://github.com/bitfocus/companion-module-vimeo-livestreamstudio6/blob/main/src/index.js by @ChgoChad, but I don't understand how the device reports addresses names, so I need log file (obtained running TallyArbiter from this branch and adding the Livestream Studio6 source or using the Companion module https://github.com/bitfocus/companion-module-vimeo-livestreamstudio6/ and uploading the log file here) from someone who owns a "Livestream Studio6".

@leonelmarbor @josephdadams