### PR TITLE
run workflows on `pull_request` event

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -1,6 +1,6 @@
 name: Build Listener Clients
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_m5stickc-listener:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_cli:


### PR DESCRIPTION
This is to make sure that new PRs don't break the CI once they are merged (at least we'll see that jobs fail before merging).
That is probably a good idea also to ensure that workflows don't intruduce build problems.

Created because of #333 which looked ok with the workflows that did run, but once merged it broke ;-)