### PR TITLE
Remove references to undeclared static IP variables from M5Atom listener

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -608,11 +608,12 @@ void processTallyData() {
 }
 
 void connectToNetwork() {
-  // allow for static IP assignment instead of DHCP if stationIP is defined as something other than 0.0.0.0
-  if (stationIP != IPAddress(0, 0, 0, 0))
-  {
-    wm.setSTAStaticIPConfig(stationIP, stationGW, stationMask); // optional DNS 4th argument 
-  }
+  // allow for static IP assignment instead of DHCP if stationIP is defined as something other than 0.0.0.0.
+  // Uncomment (together with local static IP config above) to enable static IP.
+  // if (stationIP != IPAddress(0, 0, 0, 0))
+  // {
+  // wm.setSTAStaticIPConfig(stationIP, stationGW, stationMask); // optional DNS 4th argument 
+  // }
   
   WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
 


### PR DESCRIPTION
Static IP functionality for the M5 Atom was partly removed (commented) from PR #333, but the subsequent use of the static IP variables remained, preventing the listener from compiling for the last month. This PR comments out those references as well.

I am not well versed in C++ or Git (at all), so feel free to point out better ways to fix this issue.