### PR TITLE
RGB to GRB bug correction

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -340,7 +340,7 @@ void evaluateMode() {
     int b = colorNumber & 0xFF;
     
     if (actualType != "") {
-      int backgroundColor = 0x10000 * r + 0x100 * g + b;
+      int backgroundColor = 0x10000 * g + 0x100 * r + b;
       int currColor[] = {backgroundColor, numbercolor};
       logger("Current color: " + String(backgroundColor), "info");
       //logger("Current camNumber: " + String(camNumber), "info");


### PR DESCRIPTION
The code wasn't converting the RGB to GRB.
It maintained the RGB in original code and displayed the colors Green and Red swapped.

With this correction the colors are now in GRB form and displayed correctly.