### PR TITLE
Fixed Tally Extra Output not working

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -352,15 +352,15 @@ void evaluateMode() {
     }
 
     #if TALLY_EXTRA_OUTPUT
-    if (actualType == "preview") {
+    if (actualType == "\"program\"") {
       digitalWrite(led_program, HIGH);
       digitalWrite (led_preview, LOW);
       digitalWrite (led_aux, LOW);
-    } else if (actualType == "preview") {
+    } else if (actualType == "\"preview\"") {
       digitalWrite(led_program, LOW);
       digitalWrite (led_preview, HIGH);
       digitalWrite (led_aux, LOW);
-    } else if (actualType == "aux") {
+    } else if (actualType == "\"aux\"") {
       digitalWrite(led_program, LOW);
       digitalWrite (led_preview, LOW);
       digitalWrite (led_aux, HIGH);
@@ -811,7 +811,7 @@ void setup() {
   ArduinoOTA.begin();
 
   #if TALLY_EXTRA_OUTPUT
-  // Enable interal led for program trigger
+  // Enable external led for program trigger
   pinMode(led_program, OUTPUT);
   digitalWrite(led_program, HIGH);
   pinMode(led_preview, OUTPUT);


### PR DESCRIPTION
actualType is literally the type between "" (ex: "program") so an escape sequence is needed  for the arduino interpreter to acknowledge the quotes when comparing