### PR TITLE
Update techministry.blog references

### DIFF
--- a/UI/src/app/_components/about/about.component.html
+++ b/UI/src/app/_components/about/about.component.html
@@ -9,8 +9,9 @@
             <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
             <p> THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
             <p>It is not sold, authorized, or associated with any other company or product.</p>
-            <p>To contact the author or for more information, please visit <a id='bloglink' target="_blank" href='http://www.techministry.blog'>www.techministry.blog</a>.</p>
-    
+            <hr>
+            <p>To <a href="https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+">report a bug</a> or open a <a href="https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+">feature request</a>, please go to our <a href="https://github.com/josephdadams/TallyArbiter/issues/new/choose">issues</a> page.</p>
+            <p>If you would like to see more of Joseph Adams' projects or send a word of encouragement his way, please visit <a id='bloglink' target="_blank" href='https://www.techministry.blog'>techministry.blog</a>.</p>
         </div>
     </div>
     <div class="col">

--- a/listener_clients/M5AtomMatrix-listener/README.md
+++ b/listener_clients/M5AtomMatrix-listener/README.md
@@ -4,7 +4,8 @@ To learn more about the Tally Arbiter project, [click here](http://github.com/jo
   
 It is not sold, authorized, or associated with any other company or product.
   
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
   
 You can buy an M5 ATOM Matrix here:
 https://m5stack.com/collections/m5-atom/products/atom-matrix-esp32-development-kit
@@ -64,4 +65,4 @@ If you receive an error similar to `ImportError: No module named serial` referen
 
 # Improvements and Suggestions
 We are welcome to improvements and suggestions.
-You can submit issues and pull requests on this repo, or contact Joseph Adams through the *"Contact"* page on the [techministry blog](http://www.techministry.blog).
+Feel free to contact us on Github Discussions or open a PR.

--- a/listener_clients/TTGO_T-listener/README.md
+++ b/listener_clients/TTGO_T-listener/README.md
@@ -5,7 +5,8 @@ To learn more about the Tally Arbiter project, [click here](http://github.com/jo
 
 It is not sold, authorized, or associated with any other company or product.
 
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
 
 ## Assembling the device
 I have added a 3 color LED (connected with 3x 270 Ohm resistors) and an on/off switch for the battery.
@@ -51,7 +52,8 @@ node /home/pi/tallyarbiter/index.js &
 pm2 didn't work for me.
 
 # Improvements and Suggestions
-I welcome all improvements and suggestions. You can submit issues and pull requests.
+We are welcome to improvements and suggestions.
+Feel free to contact us on Github Discussions or open a PR.
 
 ## Thanks
 Thank you to peterfdej for this listener client!

--- a/listener_clients/blink1-listener/README.md
+++ b/listener_clients/blink1-listener/README.md
@@ -16,7 +16,8 @@ You can buy a Blink(1) here:
 
 
 
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
 
 ## Getting Started
 A lot of these instructions on getting started are available all over the internet. Some highlights are listed here that should cover it from a top-level:
@@ -75,4 +76,4 @@ The program should now launch every time the Pi boots up, and automatically conn
 
 # Improvements and Suggestions
 We are welcome to improvements and suggestions.
-You can submit issues and pull requests on this repo, or contact Joseph Adams through the *"Contact"* page on the [techministry blog](http://www.techministry.blog/contact).
+Feel free to contact us on Github Discussions or open a PR.

--- a/listener_clients/esp32-neopixel-listener/README.md
+++ b/listener_clients/esp32-neopixel-listener/README.md
@@ -4,7 +4,8 @@ To learn more about the Tally Arbiter project, [click here](http://github.com/jo
   
 It is not sold, authorized, or associated with any other company or product.
   
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
   
 You can buy an NeoPixel here:
 https://shop.m5stack.com/collections/stick-series/products/m5stickc-neofalsh-hat
@@ -60,4 +61,4 @@ If you receive an error similar to `ImportError: No module named serial` referen
 
 # Improvements and Suggestions
 We are welcome to improvements and suggestions.
-You can submit issues and pull requests on this repo, or contact Joseph Adams through the *"Contact"* page on the [techministry blog](https://techministry.blog/contact/).
+Feel free to contact us on Github Discussions or open a PR.

--- a/listener_clients/gpo-listener/README.md
+++ b/listener_clients/gpo-listener/README.md
@@ -12,7 +12,8 @@ You can buy a Raspberry Pi here:
 [Raspberry Pi4](https://www.amazon.com/LoveRPi-Raspberry-Computer-Heatsinks-4GB/dp/B07WHZW881/), or 
 [Raspberry Pi Zero](https://www.amazon.com/CanaKit-Raspberry-Wireless-Complete-Starter/dp/B072N3X39J/).
 
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
 
 # Installing Python Libraries and Script
 The Tally Arbiter GPO Listener Client uses the following libraries:
@@ -103,4 +104,4 @@ Once your configuration file is created and you've made the physical connections
 
 # Improvements and Suggestions
 We are welcome to improvements and suggestions.
-You can submit issues and pull requests on this repo, or contact Joseph Adams through the *"Contact"* page on the [techministry blog](http://www.techministry.blog/contact).
+Feel free to contact us on Github Discussions or open a PR.

--- a/listener_clients/m5stickc-listener/README.md
+++ b/listener_clients/m5stickc-listener/README.md
@@ -4,7 +4,8 @@ To learn more about the Tally Arbiter project, [click here](http://github.com/jo
   
 It is not sold, authorized, or associated with any other company or product.
   
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
   
 You can buy an M5 Stick-C here:
 https://shop.m5stack.com/collections/stick-series/products/m5stickc-plus-esp32-pico-mini-iot-development-kit
@@ -59,4 +60,4 @@ If you receive an error similar to `ImportError: No module named serial` referen
 
 # Improvements and Suggestions
 We are welcome to improvements and suggestions.
-You can submit issues and pull requests on this repo, or contact Joseph Adams through the *"Contact"* page on the [techministry blog](http://www.techministry.blog/contact).
+Feel free to contact us on Github Discussions or open a PR.

--- a/listener_clients/relay-listener/README.md
+++ b/listener_clients/relay-listener/README.md
@@ -12,7 +12,8 @@ You can buy a USB relay here:
 [4 Channel](https://www.amazon.com/Diyeeni-4-Channel-Controller-Expansion-Automation/dp/B084TNPG8T/), or 
 [8 Channel](https://www.amazon.com/Zer-one-8-Channel-Computer-Intelligent/dp/B07XPFK1ZM/).
 
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
 
 # Running the software
 The software is written in Node.js and is therefore cross-platform and can be run on MacOS, Linux, or Windows.
@@ -88,4 +89,4 @@ Once your configuration file is created and you've made the physical connections
 
 # Improvements and Suggestions
 We are welcome to improvements and suggestions.
-You can submit issues and pull requests on this repo, or contact Joseph Adams through the *"Contact"* page on the [techministry blog](http://www.techministry.blog/contact).
+Feel free to contact us on Github Discussions or open a PR.

--- a/readme.md
+++ b/readme.md
@@ -56,5 +56,6 @@ Tally Arbiter was written by Joseph Adams and is distributed under the MIT Licen
 
 It is not sold, authorized, or associated with any other company or product.
 
-To contact the author or for more information, please visit [www.techministry.blog](http://www.techministry.blog).
+To [report a bug](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=bug&template=bug.yaml&title=%5BBug%5D%3A+) or open a [feature request](https://github.com/josephdadams/TallyArbiter/issues/new?assignees=JTF4&labels=feature&template=feature.yaml&title=%5BFeature+Request%5D%3A+), please go to our [issues](https://github.com/josephdadams/TallyArbiter/issues/new/choose) page.
+If you would like to see more of @josephdadams's projects or send a word of encouragement his way, please visit [techministry.blog](https://techministry.blog/).
 


### PR DESCRIPTION
Closes #363
I tried to replace every reference to the blog in contact information and in the "about" section of the UI, as suggested by @JTF4.