### PR TITLE
Fix off by one error and unhandled undefined in relay-listener

### DIFF
--- a/listener_clients/relay-listener/index.js
+++ b/listener_clients/relay-listener/index.js
@@ -258,7 +258,7 @@ function getBusTypeById(busId) {
 
 function getRelayGroupById(deviceId) {
 	let groupIndex;
-	for (i = 0; i <= relay_groups.length; i++) {
+	for (i = 0; i < relay_groups.length; i++) {
 		if (relay_groups[i].deviceId == deviceId) {
 			groupIndex = i;
 			break;
@@ -277,7 +277,7 @@ function ProcessTallyData(states) {
 			if (device_state.sources.length > 0) {
 				logger(device_state.deviceId + " " + getBusTypeById(device_state.busId), 'debug');
 				let relay_group = getRelayGroupById(device_state.deviceId);
-				if (device_state.deviceId === relay_group.deviceId) {
+				if (typeof relay_group !== 'undefined' && device_state.deviceId === relay_group.deviceId) {
 					relay_group.relays.forEach((currentRelay) => {
 						if (currentRelay.busType === getBusTypeById(device_state.busId)) {
 							logger("Relay " + currentRelay.relayNumber + " is on", 'debug');


### PR DESCRIPTION
While trying to get relays configured properly and working on a fresh system I came across a state where ProcessTallyData was calling getRelayGroupById with a deviceId that didn't match any of the relay groups. The for loop in getRelayGroupById went through 5 of my 4 relay groups which resulted in comparing the deviceId property on an undefined item from the array and errored out.

After fixing the off by one, the getRelayGroupById function was returning undefined due to the deviceId not matching any groups and ProcessTallyData errored out when trying to compare property deviceId on undefined.