### PR TITLE
Some UI Change on Tally View pages and chat components

### DIFF
--- a/UI/src/app/_components/chat/chat.component.ts
+++ b/UI/src/app/_components/chat/chat.component.ts
@@ -8,7 +8,7 @@ import { SocketService } from 'src/app/_services/socket.service';
 })
 export class ChatComponent {
   public message = "";
-  @Input() type: "producer" | "client" = "client";
+  @Input() type: "producer" | any;
   @ViewChild('chatContainer') private chatContainer!: ElementRef;
   constructor(public socketService: SocketService) {
     this.socketService.scrollChatSubject.subscribe(() => {

--- a/UI/src/app/_components/tally/tally.component.html
+++ b/UI/src/app/_components/tally/tally.component.html
@@ -21,7 +21,7 @@
             <small>{{socketService.devices[currentDeviceIdx].description }}</small>
         </div>
         <div class="container flex-fill py-4" style="min-height: 50px;">
-            <app-chat *ngIf="route.snapshot.queryParams.chat !== 'false'" type="client"></app-chat>
+            <app-chat *ngIf="route.snapshot.queryParams.chat !== 'false'" [type]="socketService.devices[currentDeviceIdx].name"></app-chat>
         </div>
     </div>
 </div>

--- a/UI/src/app/_components/tally/tally.component.html
+++ b/UI/src/app/_components/tally/tally.component.html
@@ -9,6 +9,9 @@
                 <option [value]="device.id" *ngFor="let device of socketService.devices">{{device.name}}</option>
             </select>
         </div>
+        <div class="form-group" >
+            <input type="checkbox" [(ngModel)]="enableChatOptions"/> Enable Chat
+        </div>
         <h2 class="lead mt-5" *ngIf="socketService.devices.length == 0">No devices are available for tally monitoring at this time.</h2>
     </div>
 

--- a/UI/src/app/_components/tally/tally.component.ts
+++ b/UI/src/app/_components/tally/tally.component.ts
@@ -13,11 +13,13 @@ export class TallyComponent {
   public currentDeviceIdx?: number;
   public currentBus?: BusOption;
   private supportsVibrate?: boolean = false;
-  
+
   public COLORS = {
     DARK_GREY: "#212529",
   }
-  
+
+  public enableChatOptions = true;
+
   constructor(
     private router: Router,
     public route: ActivatedRoute,
@@ -78,7 +80,16 @@ export class TallyComponent {
   }
 
   public selectDevice(id: any) {
-    this.router.navigate(["/", "tally", id.target.value]);
+    let navUrl = `/tally/${id.target.value}`;
+    if (this.enableChatOptions) {
+      this.router.navigate([navUrl]);
+    } else {
+      this.router.navigate([navUrl], {
+        queryParams: {
+          chat: 'false'
+        }
+      })
+    }
   }
 
   public ngOnDestroy() {


### PR DESCRIPTION
Tally View - Add Checkbox for Enable Chat/Disable Chat and automatically add ?chat=false as query params to url

Chat components can use device name instead of client only, so producer and other client can differentiate the chat is come from who.