### PR TITLE
Change typescript 4.6.4 to 5.1.6 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
         "electron-builder": "^23.0.3",
         "redundancyjs": "^0.1.0",
         "ts-node-dev": "^1.1.8",
-        "typescript": "^4.6.4"
+        "typescript": "^5.1.6"
     }
 }


### PR DESCRIPTION
Updated typescript from 4.6.4 to5.1.6 in devDependencies in package.json to solve failure in automatic build checks.