### PR TITLE
fix(m5stick): tally-arbiter fields not showing in setup interface

### DIFF
--- a/listener_clients/m5stickc-listener/README.md
+++ b/listener_clients/m5stickc-listener/README.md
@@ -47,6 +47,8 @@ Done! Now your board is running the latest listener client firmware version. Go 
 5. Go back, then go to the "Configure WiFi" page and set your WiFi credentials. The board should reboot.
 6. If the connection is successful a WiFi animation and a green tick mark will show. If not a red cross will be shown and you can reboot the device to try again.
 
+When powering the device, if it cannot find the WiFi AP you have defined, it will broadcast its setup wifi for 120s.
+At any point, you can press and hold the menu button for 2 seconds to re-enable the configuration ui, over whatever WiFi connection it has available.
 
 # Troubleshooting
 ### macOS build error

--- a/listener_clients/m5stickc-listener/m5stickc-listener.ino
+++ b/listener_clients/m5stickc-listener/m5stickc-listener.ino
@@ -264,6 +264,9 @@ void logger(String strLog, String strType) {
   */
 }
 
+WiFiManagerParameter* custom_taServer;
+WiFiManagerParameter* custom_taPort;
+
 void connectToNetwork() {
   WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
 
@@ -272,11 +275,11 @@ void connectToNetwork() {
   //reset settings - wipe credentials for testing
   //wm.resetSettings();
 
-  WiFiManagerParameter custom_taServer("taHostIP", "Tally Arbiter Server", tallyarbiter_host, 40);
-  WiFiManagerParameter custom_taPort("taHostPort", "Port", tallyarbiter_port, 6);
+  custom_taServer = new WiFiManagerParameter("taHostIP", "Tally Arbiter Server", tallyarbiter_host, 40);
+  custom_taPort = new WiFiManagerParameter("taHostPort", "Port", tallyarbiter_port, 6);
 
-  wm.addParameter(&custom_taServer);
-  wm.addParameter(&custom_taPort);
+  wm.addParameter(custom_taServer);
+  wm.addParameter(custom_taPort);
 
   wm.setSaveParamsCallback(saveParamCallback);
 


### PR DESCRIPTION
When trying to use a M5StickC, I found that I was unable to setup the tallyarbiter ip address in the UI. 
In the Serial Monitor it wrote `WiFiManagerParameter is out of scope` which took me to https://github.com/tzapu/WiFiManager/issues/1615.
The change in this PR fixed it for me.

I have also added to the documentation for this listener some additional notes about reconfiguring a device, to clarify it is possible to reconfigure without needing to reflash the device.
