### PR TITLE
Upgrade dependency for Listener GitHub Actions

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -24,8 +24,8 @@ jobs:
             source-url: https://dl.espressif.com/dl/package_esp32_index.json
         fqbn: 'esp32:esp32:m5stick-c'
         libraries: |
-          - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.2.4.zip
-          - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.0.4.zip
+          - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.2.9.zip
+          - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
           - name: WebSockets
           - name: WiFiManager
           - name: MultiButton
@@ -53,7 +53,7 @@ jobs:
             source-url: https://dl.espressif.com/dl/package_esp32_index.json
         fqbn: 'esp32:esp32:m5stack-atom'
         libraries: |
-          - source-url: https://github.com/m5stack/M5Atom/archive/refs/tags/0.0.6.zip
+          - source-url: https://github.com/m5stack/M5Atom/archive/refs/tags/0.1.2.zip
           - name: WebSockets
           - name: WiFiManager
           - name: MultiButton

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build M5StickC Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: arduino/compile-sketches@v1
       with:
         platforms: |
@@ -36,7 +36,7 @@ jobs:
           - listener_clients/m5stickc-listener
         enable-deltas-report: true
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'TallyArbiter-Listener-M5StickC'
         path: 'listener_clients/m5stickc-listener/build/esp32.esp32.m5stick-c'
@@ -45,7 +45,7 @@ jobs:
     name: Build M5Atom Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: arduino/compile-sketches@v1
       with:
         platforms: |
@@ -65,7 +65,7 @@ jobs:
           - listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom
         enable-deltas-report: true
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'TallyArbiter-Listener-M5Atom'
         path: 'listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/build/esp32.esp32.m5stack-atom'
@@ -74,7 +74,7 @@ jobs:
     name: Build ESP32 NeoPixel Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: arduino/compile-sketches@v1
       with:
         platforms: |
@@ -93,7 +93,7 @@ jobs:
           - listener_clients/esp32-neopixel-listener
         enable-deltas-report: true
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'TallyArbiter-Listener-ESP32-NeoPixel'
         path: 'listener_clients/esp32-neopixel-listener/build/esp32.esp32.esp32'
@@ -114,7 +114,7 @@ jobs:
     name: Build ${{ matrix.board.name }} Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Setup TFT_eSPI and select User Setup
       run: |
         git clone https://github.com/Bodmer/TFT_eSPI/
@@ -144,7 +144,7 @@ jobs:
         FQBN_REPLACED=$(echo $RAW_FQBN | sed 's/:/./g')
         echo "FQBN_REPLACED=$FQBN_REPLACED" >> $GITHUB_ENV
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'TallyArbiter-Listener-${{ matrix.board.name }}'
         path: 'listener_clients/TTGO_T-listener/build/${{ env.FQBN_REPLACED }}'
@@ -153,7 +153,7 @@ jobs:
     name: Analyse Blink1 Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install prosepector
       run: pip install prospector[with_everything]
     - name: Analyse
@@ -164,7 +164,7 @@ jobs:
     name: Analyse Pimoroni Blinkt Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install prosepector
       run: pip install prospector[with_everything]
     - name: Analyse
@@ -175,7 +175,7 @@ jobs:
     name: Analyse GPO Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install prosepector
       run: pip install prospector[with_everything]
     - name: Analyse
@@ -186,7 +186,7 @@ jobs:
     name: Analyse Relay Listener
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     #- name: Install dependencies
     #  working-directory: listener_clients/relay-listener
     #  run: |


### PR DESCRIPTION
Upgraded:
* Dependencies to M5 libraries to the latest versions
* Latest GitHub actions in order to use node version 20. Removes the deprecation warnings when running the actions.