### PR TITLE
v3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tallyarbiter",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "tallyarbiter",
-            "version": "3.0.4",
+            "version": "3.0.5",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^6.19.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tallyarbiter",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "description": "The flexible and customizable tally system",
     "keywords": [
         "util",
@@ -44,9 +44,16 @@
         "LICENSE"
     ],
     "contributors": [
-        "Andreas H. Thomsen <mc-hauge@hotmail.com>",
-        "Hannes Rüger <hannesrueger@gmx.de>",
-        "Matteo Gheza <me@matteogheza.it>"
+        "Robert Wittek <robo-w@dragon.wien>",
+        "Julian Waller",
+        "Joakim Forsberg",
+        "Matteo Gheza <me@matteogheza.it>",
+        "chanx",
+        "Sam Yoffe",
+        "David Stevens", 
+        "David Prows",
+        "monkzz",
+        "Greg Oseid"
     ],
     "dependencies": {
         "@sentry/node": "^6.19.7",


### PR DESCRIPTION
Input to release info, should cover step (1) in Maintainers list.

Updated list of contributors in package.json based on pull requests since v3.0.4 so anyone involved in code reviews have been missed.

Features:
(relay-listener) Added support for multiple relay boards
(OBS) Added support for OBS 28 (websocket protocol version 5) and preview/program tally for OBS 28
(ui) Added use of device name instead of client only on chat
(ui) Added enable/disable chat options to tally view
(m5AtomMatrix) Added support for password

Fixes:
(build) Updated build environments.
(build) Updated external dependencies.
(gpo-listener) Correction of connection handling and device reassignment
(m5AtomMatrix-listener) Corrected displayed camera number
(m5StickC-listener) Correction to setup the TallyArbiter IP address in the UI and internal LED definition
(relay-listener) Improved error handling
(ui) Improved server reconnection and connection lost status
(Analog Way Livecore)  Added connect()/reconnect() to enable reconnect handling.
(ATEM) Improved Atem source handling
(Blackmagic VideoHub) Removed premature connected status.
(Newtek Tricaster) Added connect()/reconnect() to enable reconnect handling.
(OBS) Removed bug causing infinite reconnect attempts
(Roland VR) Added connect()/reconnect() to enable reconnect handling.
(vMix) Added connect()/reconnect() to enable reconnect handling. Fix for #532. Removed memory leak at connect handling