### PR TITLE
Fix build errors in Build Listener Clients for TTGO listeners

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup TFT_eSPI and select User Setup
       run: |
-        git clone https://github.com/Bodmer/TFT_eSPI/
+        git clone --branch v2.5.33 https://github.com/Bodmer/TFT_eSPI/
         cd TFT_eSPI
         sed -i 's/#include <User_Setup.h>/\/\/#include <User_Setup.h>/g' User_Setup_Select.h
         sed -i 's/\/\/#include <User_Setups\/Setup22_TTGO_T4.h>/#include <User_Setups\/Setup22_TTGO_T4.h>/g' User_Setup_Select.h


### PR DESCRIPTION
In the latest version (currently v2.5.34) of TTF_eSPI was a direct reference added to hal/gpio_11.h. This breaks the build of the TTGO listeners in TallyArbiter, a temporary workaround is to for the build to use v2.5.33.