### PR TITLE
Only clear Tricaster program or preview when new tally data is received

### DIFF
--- a/src/sources/NewtekTricaster.ts
+++ b/src/sources/NewtekTricaster.ts
@@ -37,10 +37,6 @@ export class NewtekTricasterSource extends TallyInput {
                     else {
                         let shortcut_states = Object.entries(result['data']['shortcut_states']);
 
-                        // Clear the busses before we update based on Tricast input
-                        this.removeBusFromAllAddresses("program");
-                        this.removeBusFromAllAddresses("preview");
-
                         // Loop through the data and set preview and program based on received data.
                         // Example input from page 62: https://downloads.newtek.com/LiveProductionSystems/VMC1/Automation%20and%20Integration%20Guide.pdf
                         //
@@ -90,6 +86,18 @@ export class NewtekTricasterSource extends TallyInput {
 
     
     public processTricasterTally(sourceId, sourceArray, tallyType?) {
+        // Clear the busses before we update based on received Tricast input
+        switch(tallyType) {
+            case 'preview_tally':
+                this.removeBusFromAllAddresses("preview");
+                break;
+            case 'program_tally':
+                this.removeBusFromAllAddresses("program");
+                break;
+            default:
+                break;
+        }
+
         for (let i = 0; i < sourceArray.length; i++) {
             let tricasterSourceFound = false;
             for (let j = 0; j < this.tallydata_TC.length; j++) {


### PR DESCRIPTION
The bus clearing is now only done for preview or program based on the received Tricaster input. So one at a time can be updated/cleared.

The testing when pushing the Tricaster fix was not done with a single preview or program status update, now it works. This is a fix for https://github.com/josephdadams/TallyArbiter/issues/623.