### PR TITLE
 Updates in workspace to solve errors and warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       uses: docker/setup-buildx-action@master
     - name: Get Docker meta
       id: meta
-      uses: crazy-max/ghaction-docker-meta@v3
+      uses: docker/metadata-action@v5
       with:
         images: josephdadams/tallyarbiter
         tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       run: npm pack
     - name: NPM Publish
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: JS-DevTools/npm-publish@v1
+      uses: JS-DevTools/npm-publish@v3
       with:
         token: ${{ secrets.NPM_ACCESS_TOKEN }}
 ##    - uses: Saionaro/extract-package-version@v1.0.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         push: ${{ startsWith(github.ref, 'refs/tags/v') }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6
+        platforms: linux/amd64,linux/arm64,linux/s390x,linux/arm/v7,linux/arm/v6
 
   build_desktop:
     name: Build Desktop on ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       uses: docker/setup-buildx-action@master
     - name: Get Docker meta
       id: meta
-      uses: crazy-max/ghaction-docker-meta@v2
+      uses: crazy-max/ghaction-docker-meta@v3
       with:
         images: josephdadams/tallyarbiter
         tags: |
@@ -66,7 +66,7 @@ jobs:
           latest=false
     - name: Login to DockerHub
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
         echo SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> .env
     - name: Build and push
       if: startsWith(github.ref, 'refs/tags/v') != true
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -85,7 +85,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
     - name: Build and push (multiarch)
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: .

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -33,7 +33,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 14
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,10 +56,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 18
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -41,7 +41,7 @@ jobs:
       run: npm i -f
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   analyze_docker:
     name: Analyze Docker
@@ -84,6 +84,6 @@ jobs:
         vuln-type: 'os'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Updates in workspaces for **Build** and **CodeQL code scanning**.

### build.yaml
**Build CLI on Ubuntu**
JS-DevTools/npm-publish@v1 changed to JS-DevTools/npm-publish@v3
to solve:
The following actions uses node12 which is deprecated and will be forced to run on node16: JS-DevTools/npm-publish@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

**Build Docker image on Ubuntu**
crazy-max/ghaction-docker-meta@v2 changed to crazy-max/ghaction-docker-meta@v3
docker/login-action@v1 changed to docker/login-action@v3
docker/build-push-action@v2 changed to docker/build-push-action@v5
docker/build-push-action@v2 changed to docker/build-push-action@v5
to solve:

> The following actions uses node12 which is deprecated and will be forced to run on node16: crazy-max/ghaction-docker-meta@v2, docker/login-action@v1, docker/build-push-action@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

crazy-max/ghaction-docker-meta@v3 changed to docker/metadata-action@v5
to solve:

> Repository has been moved to docker org. Replace crazy-max/ghaction-docker-meta@v2 with docker/metadata-action@v5

Removed platform linux/ppc64le from "Build Docker image on Ubuntu" in an attempt to make docker builds successfull.
It previously failed with:

> https://github.com/josephdadams/TallyArbiter/issues/38 [linux/arm64 5/5] RUN apk add --update nodejs npm     && apk add --no-cache --virtual .build-deps alpine-sdk python3     && npm install node-gyp -g     && npm i --ignore-script --omit=dev     && npm uninstall bcrypt     && npm install bcrypt     && npm uninstall node-gyp -g     && apk del .build-deps
> https://github.com/josephdadams/TallyArbiter/issues/38 209.3
> https://github.com/josephdadams/TallyArbiter/issues/38 209.3 added 341 packages, and audited 342 packages in 2m
> https://github.com/josephdadams/TallyArbiter/issues/38 209.3
> https://github.com/josephdadams/TallyArbiter/issues/38 209.3 30 packages are looking for funding
> https://github.com/josephdadams/TallyArbiter/issues/38 209.3   run `npm fund` for details
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4 1 high severity vulnerability
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4 To address all issues, run:
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4   npm audit fix
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4
> https://github.com/josephdadams/TallyArbiter/issues/38 209.4 Run `npm audit` for details.
> https://github.com/josephdadams/TallyArbiter/issues/38 ...

With this removal we hope that the docker image once again will be built so that a new docker release can be built with code fixes that hopefully solves issue https://github.com/josephdadams/TallyArbiter/issues/603.

### codeql-analysis.yml
github/codeql-action/init@v1 changed togithub/codeql-action/init@v2
github/codeql-action/analyze@v1 changed to github/codeql-action/analyze@v2
github/codeql-action/upload-sarif@v1 changed to github/codeql-action/upload-sarif@v2

actions/checkout@v2 changed to actions/checkout@v4
actions/setup-node@v1 changed to actions/setup-node@v4

to solve:
> This version of the CodeQL Action was deprecated on January 18th, 2023, and is no longer updated or supported. For better performance, improved security, and new features, upgrade to v2. For more information, see https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

### Not solved
What remains to solved is that the usage of samuelmeuli/action-electron-builder@v1.6.0 forces usage of node12. This will not be part of this PR.