### PR TITLE
Replacing bcrypt with bcryptjs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
   - name: Server
-    init: npm i -g npm redundancyjs; cd UI; npm i --ignore-scripts; npm run build; cd ..; npm i --ignore-scripts; npm rebuild bcrypt; gp sync-done server
+    init: npm i -g npm redundancyjs; cd UI; npm i --ignore-scripts; npm run build; cd ..; npm i --ignore-scripts; gp sync-done server
     command: npm start
   - name: Angular serve
     init: gp sync-await server

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add --update nodejs npm \
     && apk add --no-cache --virtual .build-deps alpine-sdk python3 \
     && npm install node-gyp -g \
     && npm i --ignore-script --omit=dev \
-    && npm uninstall bcrypt \
-    && npm install bcrypt \
+    && npm uninstall bcryptjs \
+    && npm install bcryptjs \
     && npm uninstall node-gyp -g \
     && apk del .build-deps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tallyarbiter",
-    "version": "3.0.6",
+    "version": "3.0.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "tallyarbiter",
-            "version": "3.0.6",
+            "version": "3.0.7",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^6.19.7",
@@ -14,7 +14,7 @@
                 "ajv": "^8.11.0",
                 "atem-connection": "3.4.0",
                 "axios": "^1.6.0",
-                "bcrypt": "^5.0.1",
+                "bcryptjs": "^2.4.0",
                 "bonjour-service": "^1.0.12",
                 "compression": "^1.7.4",
                 "dotenv": "^16.0.0",
@@ -533,94 +533,6 @@
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.6.tgz",
-            "integrity": "sha512-qK1ECws8UxuPqOA8F5LFD90vyVU33W7N3hGfgsOVfrJaRVc8McC3JClTDHpeSbL9CBrOHly/4GsNPAvIgNZE+g==",
-            "dependencies": {
-                "detect-libc": "^1.0.3",
-                "https-proxy-agent": "^5.0.0",
-                "make-dir": "^3.1.0",
-                "node-fetch": "^2.6.5",
-                "nopt": "^5.0.0",
-                "npmlog": "^5.0.1",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.11"
-            },
-            "bin": {
-                "node-pre-gyp": "bin/node-pre-gyp"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-            "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
-            "integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
-            "dependencies": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.2",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.1",
-                "object-assign": "^4.1.1",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1 || ^2.0.0",
-                "strip-ansi": "^3.0.1 || ^4.0.0",
-                "wide-align": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-            "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-            "dependencies": {
-                "are-we-there-yet": "^2.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^3.0.0",
-                "set-blocking": "^2.0.0"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
             },
             "engines": {
                 "node": ">=10"
@@ -1186,11 +1098,6 @@
             "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
             "dev": true
         },
-        "node_modules/abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1235,14 +1142,6 @@
             "integrity": "sha512-W3bWBB7MwTNGALlAKbOxe+tMNW9DpqGsv1V1idGPzctnBH++eS+Dx3UuucHNe5nk38WvAuy0sgMAbS5idHCArw==",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/ansi-styles": {
@@ -1365,11 +1264,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "node_modules/arg": {
             "version": "4.1.3",
@@ -1511,23 +1405,10 @@
                 "node": "^4.5.0 || >= 5.9"
             }
         },
-        "node_modules/bcrypt": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.1.tgz",
-            "integrity": "sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@mapbox/node-pre-gyp": "^1.0.0",
-                "node-addon-api": "^3.1.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/bcrypt/node_modules/node-addon-api": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+        "node_modules/bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -2029,14 +1910,6 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
-        "node_modules/color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "bin": {
-                "color-support": "bin.js"
-            }
-        },
         "node_modules/color/node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2164,11 +2037,6 @@
             "engines": {
                 "node": ">=4.2.0"
             }
-        },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
@@ -2316,11 +2184,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2336,17 +2199,6 @@
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/detect-node": {
@@ -3187,6 +3039,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
             "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -3354,11 +3207,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
@@ -3568,14 +3416,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/is-glob": {
@@ -3836,20 +3676,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -3951,6 +3777,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
             "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -3962,6 +3789,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
             "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
             "dependencies": {
                 "minipass": "^3.0.0",
                 "yallist": "^4.0.0"
@@ -4012,25 +3840,6 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/node-gyp-build": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
@@ -4040,20 +3849,6 @@
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
                 "node-gyp-build-test": "build-test.js"
-            }
-        },
-        "node_modules/nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/normalize-path": {
@@ -4688,6 +4483,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -4809,11 +4605,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -4864,11 +4655,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/signal-exit": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-            "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
@@ -5075,48 +4861,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dependencies": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/string-width/node_modules/strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-            "dependencies": {
-                "ansi-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5163,6 +4907,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
             "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+            "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
@@ -5179,6 +4924,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
             "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -5187,6 +4933,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
             "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5195,6 +4942,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
             "bin": {
                 "mkdirp": "bin/cmd.js"
             },
@@ -5281,11 +5029,6 @@
             "engines": {
                 "node": ">=0.6"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -5609,20 +5352,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5636,14 +5365,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "dependencies": {
-                "string-width": "^1.0.2 || 2"
             }
         },
         "node_modules/winston": {
@@ -6308,78 +6029,6 @@
                 }
             }
         },
-        "@mapbox/node-pre-gyp": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.6.tgz",
-            "integrity": "sha512-qK1ECws8UxuPqOA8F5LFD90vyVU33W7N3hGfgsOVfrJaRVc8McC3JClTDHpeSbL9CBrOHly/4GsNPAvIgNZE+g==",
-            "requires": {
-                "detect-libc": "^1.0.3",
-                "https-proxy-agent": "^5.0.0",
-                "make-dir": "^3.1.0",
-                "node-fetch": "^2.6.5",
-                "nopt": "^5.0.0",
-                "npmlog": "^5.0.1",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.11"
-            },
-            "dependencies": {
-                "are-we-there-yet": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-                    "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^3.6.0"
-                    }
-                },
-                "gauge": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
-                    "integrity": "sha512-6STz6KdQgxO4S/ko+AbjlFGGdGcknluoqU+79GOFCDqqyYj5OanQf9AjxwN0jCidtT+ziPMmPSt9E4hfQ0CwIQ==",
-                    "requires": {
-                        "aproba": "^1.0.3 || ^2.0.0",
-                        "color-support": "^1.1.2",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.1",
-                        "object-assign": "^4.1.1",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1 || ^2.0.0",
-                        "strip-ansi": "^3.0.1 || ^4.0.0",
-                        "wide-align": "^1.1.2"
-                    }
-                },
-                "npmlog": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-                    "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-                    "requires": {
-                        "are-we-there-yet": "^2.0.0",
-                        "console-control-strings": "^1.1.0",
-                        "gauge": "^3.0.0",
-                        "set-blocking": "^2.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
-            }
-        },
         "@msgpack/msgpack": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
@@ -6842,11 +6491,6 @@
             "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
             "dev": true
         },
-        "abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
         "accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -6879,11 +6523,6 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/alawmulaw/-/alawmulaw-5.0.2.tgz",
             "integrity": "sha512-W3bWBB7MwTNGALlAKbOxe+tMNW9DpqGsv1V1idGPzctnBH++eS+Dx3UuucHNe5nk38WvAuy0sgMAbS5idHCArw=="
-        },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "4.3.0",
@@ -6983,11 +6622,6 @@
                     }
                 }
             }
-        },
-        "aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "arg": {
             "version": "4.1.3",
@@ -7096,21 +6730,10 @@
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
         },
-        "bcrypt": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.1.tgz",
-            "integrity": "sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==",
-            "requires": {
-                "@mapbox/node-pre-gyp": "^1.0.0",
-                "node-addon-api": "^3.1.0"
-            },
-            "dependencies": {
-                "node-addon-api": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-                    "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-                }
-            }
+        "bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -7521,11 +7144,6 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
         "colorspace": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
@@ -7619,11 +7237,6 @@
                     "dev": true
                 }
             }
-        },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "content-disposition": {
             "version": "0.5.4",
@@ -7727,11 +7340,6 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
         "depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7741,11 +7349,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-        },
-        "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "detect-node": {
             "version": "2.1.0",
@@ -8399,6 +8002,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
             "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
             "requires": {
                 "minipass": "^3.0.0"
             }
@@ -8520,11 +8124,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "hosted-git-info": {
             "version": "4.1.0",
@@ -8676,11 +8275,6 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
-        },
-        "is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-glob": {
             "version": "4.0.3",
@@ -8886,14 +8480,6 @@
                 "yallist": "^4.0.0"
             }
         },
-        "make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "requires": {
-                "semver": "^6.0.0"
-            }
-        },
         "make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -8968,6 +8554,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
             "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -8976,6 +8563,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
             "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
             "requires": {
                 "minipass": "^3.0.0",
                 "yallist": "^4.0.0"
@@ -9017,27 +8605,11 @@
             "dev": true,
             "optional": true
         },
-        "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "requires": {
-                "whatwg-url": "^5.0.0"
-            }
-        },
         "node-gyp-build": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
             "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
             "optional": true
-        },
-        "nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "requires": {
-                "abbrev": "1"
-            }
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -9496,7 +9068,8 @@
         "semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -9595,11 +9168,6 @@
                 "send": "0.18.0"
             }
         },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
         "setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -9638,11 +9206,6 @@
                 "get-intrinsic": "^1.0.2",
                 "object-inspect": "^1.9.0"
             }
-        },
-        "signal-exit": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-            "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
         },
         "simple-swizzle": {
             "version": "0.2.2",
@@ -9801,38 +9364,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-                    "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
         "strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -9867,6 +9398,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
             "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+            "dev": true,
             "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
@@ -9879,17 +9411,20 @@
                 "chownr": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+                    "dev": true
                 },
                 "minipass": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-                    "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+                    "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+                    "dev": true
                 },
                 "mkdirp": {
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
                 }
             }
         },
@@ -9962,11 +9497,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-        },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "tree-kill": {
             "version": "1.2.2",
@@ -10205,20 +9735,6 @@
                 "imaadpcm": "^4.1.2"
             }
         },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10226,14 +9742,6 @@
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
-            }
-        },
-        "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "requires": {
-                "string-width": "^1.0.2 || 2"
             }
         },
         "winston": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "ajv": "^8.11.0",
         "atem-connection": "3.4.0",
         "axios": "^1.6.0",
-        "bcrypt": "^5.0.1",
+        "bcryptjs": "^2.4.0",
         "bonjour-service": "^1.0.12",
         "compression": "^1.7.4",
         "dotenv": "^16.0.0",

--- a/src/_helpers/auth.ts
+++ b/src/_helpers/auth.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken';
-import bcrypt from 'bcrypt';
+import bcrypt from 'bcryptjs';
 import { logger } from "../index";
 import { currentConfig, SaveConfig } from './config';
 import { clone } from "./clone";


### PR DESCRIPTION
This change was done in:
`src/_helpers/auth.ts`
`package.json`

Replace was also made in
`Dockerfile`
but I'm not certain that we need it here. Can it be removed in this part? This can perhaps be sorted out later.

It was removed in
`.gitpod.yml`
since we should not need to rebuild this package.

The purpose is to fix https://github.com/josephdadams/TallyArbiter/issues/603.

bcrypt.js: https://github.com/dcodeIO/bcrypt.js#readme
bcrypt: https://github.com/kelektiv/node.bcrypt.js#readme