### PR TITLE
Fix 579 dependencies dgram@1.0.1 and @types/socket.io-client@3.0.0

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -20,7 +20,6 @@
         "@fortawesome/fontawesome-free": "^6.5.1",
         "@ng-bootstrap/ng-bootstrap": "^16.0.0",
         "@popperjs/core": "^2.11.8",
-        "@types/socket.io-client": "^3.0.0",
         "ang-jsoneditor": "^3.1.1",
         "bootstrap": "^5.3.2",
         "bootstrap-icons": "^1.11.2",
@@ -4116,14 +4115,6 @@
         "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/socket.io-client": {
-      "version": "3.0.0",
-      "deprecated": "This is a stub types definition. socket.io-client provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "socket.io-client": "*"
       }
     },
     "node_modules/@types/sockjs": {
@@ -15906,12 +15897,6 @@
         "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
-      }
-    },
-    "@types/socket.io-client": {
-      "version": "3.0.0",
-      "requires": {
-        "socket.io-client": "*"
       }
     },
     "@types/sockjs": {

--- a/UI/package.json
+++ b/UI/package.json
@@ -24,7 +24,6 @@
     "@fortawesome/fontawesome-free": "^6.5.1",
     "@ng-bootstrap/ng-bootstrap": "^16.0.0",
     "@popperjs/core": "^2.11.8",
-    "@types/socket.io-client": "^3.0.0",
     "ang-jsoneditor": "^3.1.1",
     "bootstrap": "^5.3.2",
     "bootstrap-icons": "^1.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,12 +2208,6 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/dgram": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dgram/-/dgram-1.0.1.tgz",
-            "integrity": "sha1-N/OyAPgDOl/3WTAwicgc42G2UcM=",
-            "deprecated": "npm is holding this package for security reasons. As it's a core Node module, we will not transfer it over to other users. You may safely remove the package from your dependencies."
-        },
         "node_modules/diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -7354,11 +7348,6 @@
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true,
             "optional": true
-        },
-        "dgram": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dgram/-/dgram-1.0.1.tgz",
-            "integrity": "sha1-N/OyAPgDOl/3WTAwicgc42G2UcM="
         },
         "diff": {
             "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5155,7 +5155,6 @@
             "integrity": "sha512-qB6izbsJjL7bL/EsZ1pHhp8fI/N6kMIcEh6tduwIZRdBdsTMHL2ULb9XOeeUoynPWHoM9beYudiENiyaJ7dBvQ==",
             "dependencies": {
                 "debug": "^4.1.1",
-                "dgram": "^1.0.1",
                 "events": "^3.0.0",
                 "packet": "0.0.6",
                 "util": "^0.11.1"
@@ -5167,7 +5166,6 @@
             "integrity": "sha512-3SfKpMCS0jx1Tn/KBqIG1SsnnPHuqFbn8DkuloA7YqiOYyr8TwoWMosMOYG2QHRz05dZ2Bx48Sx/dl6VeSOd5Q==",
             "dependencies": {
                 "debug": "^4.3.2",
-                "dgram": "^1.0.1",
                 "net": "^1.0.2"
             }
         },
@@ -9585,7 +9583,6 @@
             "integrity": "sha512-qB6izbsJjL7bL/EsZ1pHhp8fI/N6kMIcEh6tduwIZRdBdsTMHL2ULb9XOeeUoynPWHoM9beYudiENiyaJ7dBvQ==",
             "requires": {
                 "debug": "^4.1.1",
-                "dgram": "^1.0.1",
                 "events": "^3.0.0",
                 "packet": "0.0.6",
                 "util": "^0.11.1"
@@ -9597,7 +9594,6 @@
             "integrity": "sha512-3SfKpMCS0jx1Tn/KBqIG1SsnnPHuqFbn8DkuloA7YqiOYyr8TwoWMosMOYG2QHRz05dZ2Bx48Sx/dl6VeSOd5Q==",
             "requires": {
                 "debug": "^4.3.2",
-                "dgram": "^1.0.1",
                 "net": "^1.0.2"
             }
         },


### PR DESCRIPTION
This PR clean up the dependencies
```
npm WARN deprecated dgram@1.0.1: npm is holding this package for security reasons. As it's a core Node module, we will not transfer it over to other users. You may safely remove the package from your dependencies.
npm WARN deprecated @types/socket.io-client@3.0.0: This is a stub types definition. socket.io-client provides its own type definitions, so you do not need this installed.
```
These things were reported in https://github.com/josephdadams/TallyArbiter/issues/579.

There are a number of npm audit things to fix in the UI part connected to _axio_ and _vite_ but that requires more testing then I today have time for. Note that there is today no solution for the issue with _sweetalert2_.

**axios**
Specific dependency to 0.21.4 in node_modules/localtunnel, should be 1.6.0 to pass npm audit.

**vite**
Currently specified as 4.51, should be 4.5.2 to pass npm audit.