### PR TITLE
Clean-up in m5atom and m5stick listeners

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/README.md
+++ b/listener_clients/M5AtomMatrix-listener/README.md
@@ -42,13 +42,14 @@ Done! Now your board is running the latest listener client firmware version. Go 
 # Setup your device
 1. Plug the device in a power source
 2. Wait for the boot animation to finish, if there is no saved AP it will start an Access Point where you can configure one.
-3. Connect to the 'm5Atom-1xxxxxxx' access point via phone and go to 192.168.4.1 (or wait a bit, and captive portal page should open).
+3. Connect to the 'm5Atom-XXXXXX' Access Point via phone and go to 192.168.4.1 (or wait a bit, a captive portal page should open). NB: The portal times out after 120 sec of inactivity.
 4. Set your Tally Arbiter server ip by going to *"Setup"* page.
 5. Go back, then go to the "Configure WiFi" page and set your WiFi credentials. The board should reboot.
 6. If the connection is successful a WiFi animation and a green tick mark will show. If not a red cross will be shown and you can reboot the device to try again.
 
-* If you need to reset WI-FI credentials. Press Atom button for 5 seconds.
-
+Button (behind screen):
+Single click - Toggle between camera number 1 to 16.
+Long press 5 seconds - reset WiFi credentials.
 
 # Troubleshooting
 ### macOS build error

--- a/listener_clients/m5stickc-listener/README.md
+++ b/listener_clients/m5stickc-listener/README.md
@@ -39,6 +39,8 @@ Make sure you have selected the **right serial port** and the **right board type
 
 Done! Now your board is running the latest listener client firmware version. Go to the *"Setup your device"* sections to connect the board to the Tally Arbiter server.
 
+NB: The code base is either compiled for m5stickC or m5stickC-Plus based on the define C_PLUS, default is for m5stickC.
+
 # Setup your device
 1. Plug the device in a power source
 2. Wait for the boot up to finish, if there is no saved AP it will startup an Access Point where you can configure one.
@@ -47,7 +49,12 @@ Done! Now your board is running the latest listener client firmware version. Go 
 5. Go back, then go to the "Configure WiFi" page and set your WiFi credentials. The board should reboot.
 6. If the connection is successful a settings page will shown. If not, reconnect to 'm5StickC-XXXXXX' Access Point.
 
-If you need to reset WI-FI credentials. Press M5 button for 5 seconds.
+Button A (M5):
+Single click - Switch between settings screen and device name (the device name is from Tally Arbiter server).
+Long press 5 seconds - reset WiFi credentials.
+
+Button B:
+Single click - Increase screen brightness
 
 NB: The captive portal page is accessible on the device when the settings screen is shown.
 


### PR DESCRIPTION
**m5stickc**
Adjusted screen brigthness on m5stickcplus.
Updated showdevice page on m5stickcplus.
Updated m5stickc ReadMe

**m5atom**
Updated WiFI AP to use 3 bytes of mac address on m5atom.
Updated to use 3 bytes of  mac address in device name for m5atom
Added define to build with or without camber number during pvw and pgm for m5atom
Updated m5atom ReadMe