### PR TITLE
Allow shutdown on mac while app is running

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // This is the electron startup script
-const { app, BrowserWindow, Tray, Menu, dialog, ipcMain } = require('electron');
+const { app, BrowserWindow, Tray, Menu, dialog, ipcMain, powerMonitor } = require('electron');
 const { autoUpdater } = require("electron-updater");
 const { nativeImage } = require('electron/common');
 const path = require("path");
@@ -208,6 +208,11 @@ function checkForUpdates() {
         });
     });
 }
+
+powerMonitor.on('shutdown', () => {
+    app.isQuiting = true;
+    app.quit();
+});
 
 
 if (!gotTheLock) {


### PR DESCRIPTION
Currently, if app is still running and the mac os is shutdown, the app prevents shutdown. This allows the shutdown to close the app.