### PR TITLE
Revert axios (1.6.0 to 0.27.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@types/express": "^4.17.13",
                 "ajv": "^8.11.0",
                 "atem-connection": "3.4.0",
-                "axios": "^1.6.0",
+                "axios": "^0.27.2",
                 "bcryptjs": "^2.4.0",
                 "bonjour-service": "^1.0.12",
                 "compression": "^1.7.4",
@@ -1355,13 +1355,12 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/axios": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
             "dependencies": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
             }
         },
         "node_modules/balanced-match": {
@@ -4212,11 +4211,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -6692,13 +6686,12 @@
             }
         },
         "axios": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
             "requires": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
             }
         },
         "balanced-match": {
@@ -8846,11 +8839,6 @@
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
             }
-        },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "pump": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "@types/express": "^4.17.13",
         "ajv": "^8.11.0",
         "atem-connection": "3.4.0",
-        "axios": "^1.6.0",
+        "axios": "^0.27.2",
         "bcryptjs": "^2.4.0",
         "bonjour-service": "^1.0.12",
         "compression": "^1.7.4",


### PR DESCRIPTION
Reverting axios (update previously made in https://github.com/josephdadams/TallyArbiter/pull/607).

In order to step to axios 1.6.0 the change in axios from Common JS to ES Module needs to be handled, this it not quickly done. This revert is only to make a release more sucessfull. A new issue will be created to track this technical debt.

When this PR has been merged to main is the suggestion that we go ahead with a new release since there are several queued up fixes that would be good to have in a formal release package.

Fixes https://github.com/josephdadams/TallyArbiter/issues/640