### PR TITLE
Added in on_flash support for output_invert for lastState.

### DIFF
--- a/listener_clients/gpo-listener/gpo-listener.py
+++ b/listener_clients/gpo-listener/gpo-listener.py
@@ -243,7 +243,7 @@ def on_flash(gpoGroupId):
                 time.sleep(0.5)
                 GPIO.output(gpo["pinNumber"], getOutputValue(False))
                 time.sleep(0.5)
-                GPIO.output(gpo["pinNumber"], gpo["lastState"])
+                GPIO.output(gpo["pinNumber"], getOutputValue(gpo["lastState"]))
 
 @sio.on("reassign")
 def on_reassign(oldDeviceId, newDeviceId, gpoGroupId):


### PR DESCRIPTION
This could be a fix for https://github.com/josephdadams/TallyArbiter/issues/661. Based on code inspection is looks plausible but I don't have any board to test with at the moment.