### PR TITLE
Fix freetype dependency in docker build for all platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update nodejs npm \
     && npm i --ignore-script --omit=dev \
     && npm uninstall bcryptjs \
     && npm install bcryptjs \
+    && node-gyp -C node_modules/@julusian/freetype2 rebuild \
     && npm uninstall node-gyp -g \
     && apk del .build-deps
 


### PR DESCRIPTION
The freetype2 npm package has prebuilt bindings, but not for all platforms supported by the TallyArbiter docker image. This fixes the issue by rebuilding the freetype2 dependency during the docker image build.

Closes issue #683