### PR TITLE
Added support for m5stickC-Plus2

### DIFF
--- a/listener_clients/m5stickc-listener/README.md
+++ b/listener_clients/m5stickc-listener/README.md
@@ -39,9 +39,9 @@ Make sure you have selected the **right serial port** and the **right board type
 
 Done! Now your board is running the latest listener client firmware version. Go to the *"Setup your device"* sections to connect the board to the Tally Arbiter server.
 
-NB: The code base is either compiled for m5stickC, m5stickC-Plus or m5stickC-Plus2 based on the defines M5STICKC, M5STICKC_PLUS and M5STICKC_PLUS_2. Default is build for m5stickC. Only one can be enabled at at time.
+NB: The code base is either compiled for **M5StickC**, **M5StickC-Plus** or **M5StickC-Plus2** based on the configured **board** in **Arduino IDE**. Only one can be enabled at at time.
 
-TALLY_EXTRA_OUTPUT can be used for extra tally info. The internal led is used for program. Preview and aux is available on external ports.
+TALLY_EXTRA_OUTPUT can be used for extra tally info. The internal led is used for program. Preview and aux is available on external ports by default.
 
 # Setup your device
 1. Plug the device in a power source

--- a/listener_clients/m5stickc-listener/README.md
+++ b/listener_clients/m5stickc-listener/README.md
@@ -39,7 +39,9 @@ Make sure you have selected the **right serial port** and the **right board type
 
 Done! Now your board is running the latest listener client firmware version. Go to the *"Setup your device"* sections to connect the board to the Tally Arbiter server.
 
-NB: The code base is either compiled for m5stickC or m5stickC-Plus based on the define C_PLUS, default is for m5stickC.
+NB: The code base is either compiled for m5stickC, m5stickC-Plus or m5stickC-Plus2 based on the defines M5STICKC, M5STICKC_PLUS and M5STICKC_PLUS_2. Default is build for m5stickC. Only one can be enabled at at time.
+
+TALLY_EXTRA_OUTPUT can be used for extra tally info. The internal led is used for program. Preview and aux is available on external ports.
 
 # Setup your device
 1. Plug the device in a power source

--- a/listener_clients/m5stickc-listener/m5stickc-listener.ino
+++ b/listener_clients/m5stickc-listener/m5stickc-listener.ino
@@ -1,11 +1,13 @@
-#define M5STICKC true        // CHANGE TO true IF YOU USE THE M5STICK
-#define M5STICKC_PLUS false   // CHANGE TO true IF YOU USE THE M5STICK-C PLUS
-#define M5STICKC_PLUS_2 false  // CHANGE TO true IF YOU USE THE M5STICK-C PLUS2
-
-#if M5STICKC_PLUS_2
+//
+// Board defines used by Arduino IDE as preprocessor flags
+// M5StickC        ARDUINO_m5stack_stickc
+// M5StickC-Plus   ARDUINO_m5stack_stickc_plus
+// M5StickC-Plus2  ARDUINO_m5stack_stickc_plus2
+//
+#if defined(ARDUINO_m5stack_stickc_plus2)
 #include <M5StickCPlus2.h>
 #else
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
 #include <M5StickCPlus.h>
 #else
 #include <M5StickC.h>
@@ -66,7 +68,7 @@ uint8_t wasPressed();
 // Program (Internal led): 10: Low is on, HIGH is off
 // Preview: 26
 // Aux: Not supported
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
 const int led_program = 19;  //OPTIONAL Led for program on pin G19
 #else
 const int led_program = 10;  //OPTIONAL Led for program on pin G10
@@ -106,13 +108,14 @@ bool portalRunning = false;
 void setup() {
   pinMode(TRIGGER_PIN, INPUT_PULLUP);
   Serial.begin(115200);
-  while (!Serial);
+  while (!Serial)
+    ;
 
     // Initialize the M5StickC object
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   logger("Initializing M5StickCPlus2.", "info-quiet");
 #else
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
   logger("Initializing M5StickCPlus2.", "info-quiet");
 #else
   logger("Initializing M5StickC.", "info-quiet");
@@ -130,7 +133,7 @@ void setup() {
   // Set WiFi hostname
   wm.setHostname((const char *)listenerDeviceName.c_str());
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   auto cfg = M5.config();
   StickCP2.begin(cfg);
   StickCP2.Display.setRotation(3);
@@ -140,11 +143,12 @@ void setup() {
   M5.Lcd.setRotation(3);
   M5.Lcd.fillScreen(TFT_BLACK);
 #endif
-#if M5STICKC_PLUS_2
+
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.setCursor(0, 0);
   StickCP2.Display.setFreeFont(FSS9);
 #else
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
   M5.Lcd.setCursor(0, 20);
   M5.Lcd.setFreeFont(FSS9);
 #else
@@ -152,7 +156,8 @@ void setup() {
   M5.Lcd.setTextSize(1);
 #endif
 #endif
-#if M5STICKC_PLUS_2
+
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.setTextColor(WHITE, BLACK);
   StickCP2.Display.println("booting...");
 #else
@@ -226,7 +231,7 @@ void setup() {
 #if TALLY_EXTRA_OUTPUT
   // Enable internal led for program trigger
   pinMode(led_program, OUTPUT);
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   digitalWrite(led_program, LOW);
 #else
   digitalWrite(led_program, HIGH);
@@ -255,7 +260,7 @@ void loop() {
   M5.update();
 
   // Is WiFi reset triggered?
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   if (StickCP2.BtnA.pressedFor(5000)) {
 #else
   if (M5.BtnA.pressedFor(5000)) {
@@ -292,16 +297,16 @@ void showSettings() {
   portalRunning = true;
 
   //displays the current network connection and Tally Arbiter server data
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.fillScreen(TFT_BLACK);
 #else
   M5.Lcd.fillScreen(TFT_BLACK);
 #endif
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.setCursor(0, 0);
   StickCP2.Display.setFreeFont(FSS9);
 #else
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
   M5.Lcd.setCursor(0, 20);
   M5.Lcd.setFreeFont(FSS9);
 #else
@@ -310,7 +315,7 @@ void showSettings() {
 #endif
 #endif
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.setTextColor(WHITE, BLACK);
   StickCP2.Display.println("SSID: " + String(WiFi.SSID()));
   StickCP2.Display.println(WiFi.localIP());
@@ -330,7 +335,7 @@ void showSettings() {
   M5.Lcd.print("Battery: ");
 #endif
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   // TODO: The battery voltage code is flawed
   int batteryLevel = floor(100.0 * ((1.01 * StickCP2.Power.getBatteryVoltage() / 1000) / 4));
   batteryLevel = batteryLevel > 100 ? 100 : batteryLevel;
@@ -360,16 +365,16 @@ void showDeviceInfo() {
     portalRunning = false;
   }
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.fillScreen(TFT_BLACK);
 #else
   M5.Lcd.fillScreen(TFT_BLACK);
 #endif
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.setCursor(4, 50);
   StickCP2.Display.setFreeFont(FSS24);
 #else
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
   M5.Lcd.setCursor(4, 82);
   M5.Lcd.setFreeFont(FSS24);
 #else
@@ -378,7 +383,7 @@ void showDeviceInfo() {
 #endif
 #endif
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.setTextColor(DARKGREY, BLACK);
   StickCP2.Display.println(DeviceName);
 #else
@@ -397,7 +402,7 @@ void updateBrightness() {
   }
 
   logger("Set brightness: " + String(currentBrightness), "info-quiet");
-#if M5STICKC || M5STICKC_PLUS
+#if !defined(ARDUINO_m5stack_stickc_plus2)
   // TODO: Add call for brightness on Plus2
   M5.Axp.ScreenBreath(currentBrightness);
 #endif
@@ -433,7 +438,7 @@ void connectToNetwork() {
   wm.addParameter(custom_taPort);
 
   // If no saved WiFi we assume that configuration is needed via the captive portal
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   if (wm.getWiFiIsSaved()) {
     StickCP2.Display.println("connecting...");
   } else {
@@ -465,7 +470,7 @@ void connectToNetwork() {
 
   if (!res) {
     logger("Failed to connect", "error");
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
     StickCP2.Display.println("Configuration timeout");
     StickCP2.Display.println("Restart device to configure");
 #else
@@ -633,7 +638,7 @@ void socket_Connected(const char *payload, size_t length) {
 
 void socket_Flash() {
   //flash the screen white 3 times
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.fillScreen(WHITE);
   delay(500);
   StickCP2.Display.fillScreen(TFT_BLACK);
@@ -693,7 +698,7 @@ void socket_Reassign(String payload) {
   ws_emit("listener_reassign_object", charReassignObj);
   ws_emit("devices");
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
   StickCP2.Display.fillScreen(RED);
   delay(200);
   StickCP2.Display.fillScreen(TFT_BLACK);
@@ -797,11 +802,11 @@ void SetDeviceName() {
 
 void evaluateMode() {
   if (actualType != prevType) {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
     StickCP2.Display.setCursor(4, 50);
     StickCP2.Display.setFreeFont(FSS24);
 #else
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
     M5.Lcd.setCursor(4, 82);
     M5.Lcd.setFreeFont(FSS24);
 #else
@@ -818,7 +823,7 @@ void evaluateMode() {
     int b = number & 0xFF;
 
     if (actualType != "") {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       StickCP2.Display.setTextColor(BLACK);
       StickCP2.Display.fillScreen(M5.Lcd.color565(r, g, b));
       StickCP2.Display.println(DeviceName);
@@ -828,7 +833,7 @@ void evaluateMode() {
       M5.Lcd.println(DeviceName);
 #endif
     } else {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       StickCP2.Display.setTextColor(DARKGREY, BLACK);
       StickCP2.Display.fillScreen(TFT_BLACK);
       StickCP2.Display.println(DeviceName);
@@ -841,7 +846,7 @@ void evaluateMode() {
 
 #if TALLY_EXTRA_OUTPUT
     if (actualType == "\"program\"") {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       digitalWrite(led_program, HIGH);
 #else
       digitalWrite(led_program, LOW);
@@ -849,7 +854,7 @@ void evaluateMode() {
       digitalWrite(led_preview, LOW);
       digitalWrite(led_aux, LOW);
     } else if (actualType == "\"preview\"") {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       digitalWrite(led_program, LOW);
 #else
       digitalWrite(led_program, HIGH);
@@ -857,7 +862,7 @@ void evaluateMode() {
       digitalWrite(led_preview, HIGH);
       digitalWrite(led_aux, LOW);
     } else if (actualType == "\"aux\"") {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       digitalWrite(led_program, LOW);
 #else
       digitalWrite(led_program, HIGH);
@@ -865,7 +870,7 @@ void evaluateMode() {
       digitalWrite(led_preview, LOW);
       digitalWrite(led_aux, HIGH);
     } else {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       digitalWrite(led_program, LOW);
 #else
       digitalWrite(led_program, HIGH);
@@ -882,7 +887,7 @@ void evaluateMode() {
   }
 
   if (LAST_MSG == true) {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
     StickCP2.Display.println(LastMessage);
 #else
     M5.Lcd.println(LastMessage);
@@ -897,16 +902,16 @@ void checkReset() {
     // poor mans debounce/press-hold, code not ideal for production
     delay(50);
     if (digitalRead(TRIGGER_PIN) == LOW) {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       StickCP2.Display.fillScreen(TFT_BLACK);
 #else
       M5.Lcd.fillScreen(TFT_BLACK);
 #endif
-#if M5STICKC_PLUS
+#if defined(ARDUINO_m5stack_stickc_plus)
       M5.Lcd.setCursor(0, 40);
       M5.Lcd.setFreeFont(FSS9);
 #else
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       StickCP2.Display.setCursor(0, 40);
       StickCP2.Display.setFreeFont(FSS9);
 #else
@@ -915,7 +920,7 @@ void checkReset() {
 #endif
 #endif
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       StickCP2.Display.setTextColor(WHITE, BLACK);
       StickCP2.Display.println("Reset button pushed....");
 #else
@@ -927,7 +932,7 @@ void checkReset() {
       // still holding button for 3000 ms, reset settings, code not ideal for production
       delay(3000);  // reset delay hold
       if (digitalRead(TRIGGER_PIN) == LOW) {
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
         StickCP2.Display.println("Erasing....");
 #else
         M5.Lcd.println("Erasing....");
@@ -938,7 +943,7 @@ void checkReset() {
         ESP.restart();
       }
 
-#if M5STICKC_PLUS_2
+#if defined(ARDUINO_m5stack_stickc_plus2)
       StickCP2.Display.println("Starting Portal...");
 #else
       M5.Lcd.println("Starting Portal...");

--- a/listener_clients/m5stickc-listener/m5stickc-listener.ino
+++ b/listener_clients/m5stickc-listener/m5stickc-listener.ino
@@ -1,9 +1,15 @@
-#define C_PLUS 0 //CHANGE TO 1 IF YOU USE THE M5STICK-C PLUS
+#define M5STICKC true        // CHANGE TO true IF YOU USE THE M5STICK
+#define M5STICKC_PLUS false   // CHANGE TO true IF YOU USE THE M5STICK-C PLUS
+#define M5STICKC_PLUS_2 false  // CHANGE TO true IF YOU USE THE M5STICK-C PLUS2
 
-#if C_PLUS == 1
+#if M5STICKC_PLUS_2
+#include <M5StickCPlus2.h>
+#else
+#if M5STICKC_PLUS
 #include <M5StickCPlus.h>
 #else
 #include <M5StickC.h>
+#endif
 #endif
 
 #include <WebSocketsClient.h>
@@ -16,11 +22,11 @@
 #include <Preferences.h>
 #include "Free_Fonts.h"
 
-#define TRIGGER_PIN 0 //reset pin 
-#define GREY  0x0020 //   8  8  8
-#define GREEN 0x0200 //   0 64  0
-#define RED   0xF800 // 255  0  0
-#define maxTextSize 5 //larger sourceName text
+#define TRIGGER_PIN 0  //reset pin
+#define GREY 0x0020    //   8  8  8
+#define GREEN 0x0200   //   0 64  0
+#define RED 0xF800     // 255  0  0
+#define maxTextSize 5  //larger sourceName text
 #define startBrightness 11
 #define maxBrightness 100
 // Name of the device - the 3 last bytes of the mac address will be appended to create a unique identifier for the server.
@@ -31,29 +37,45 @@ String listenerDeviceName = "m5StickC-";
     Change the following variables before compiling and sending the code to your device.
 */
 
-bool LAST_MSG = false; // true = show log on tally screen
+bool LAST_MSG = false;  // true = show log on tally screen
 
 //Tally Arbiter Server
-char tallyarbiter_host[40] = "192.168.0.110"; //IP address of the Tally Arbiter Server
+char tallyarbiter_host[40] = "192.168.0.110";  //IP address of the Tally Arbiter Server
 char tallyarbiter_port[6] = "4455";
 
 /* END OF USER CONFIG */
 
 //M5StickC variables
-PinButton btnM5(37); //the "M5" button on the device
-PinButton btnAction(39); //the "Action" button on the device
+PinButton btnM5(37);      //the "M5" button on the device (Button A)
+PinButton btnAction(39);  //the "Action" button on the device (Button B)
 Preferences preferences;
 uint8_t wasPressed();
 
 #define TALLY_EXTRA_OUTPUT false
 
 #if TALLY_EXTRA_OUTPUT
-const int led_program = 10;
-const int led_preview = 26; //OPTIONAL Led for preview on pin G26
-const int led_aux = 36;     //OPTIONAL Led for aux on pin G36
+// M5STICKC_PLUS_2
+// Program (Internal led): 19: LOW is off, HIGH is on
+// Preview: 26
+// Aux: 25
+// M5STICKC_PLUS
+// Program (Internal led): 10: Low is on, HIGH is off
+// Preview: 26
+// Aux: 25
+// M5STICKC
+// Program (Internal led): 10: Low is on, HIGH is off
+// Preview: 26
+// Aux: Not supported
+#if M5STICKC_PLUS_2
+const int led_program = 19;  //OPTIONAL Led for program on pin G19
+#else
+const int led_program = 10;  //OPTIONAL Led for program on pin G10
+#endif
+const int led_preview = 26;  //OPTIONAL Led for preview on pin G26
+const int led_aux = 25;      //OPTIONAL Led for aux on pin G25
 #endif
 
-String prevType = ""; // reduce display flicker by storing previous state
+String prevType = "";  // reduce display flicker by storing previous state
 
 String actualType = "";
 String actualColor = "";
@@ -70,51 +92,73 @@ String LastMessage = "";
 
 //General Variables
 bool networkConnected = false;
-int currentScreen = 0; //0 = Tally Screen, 1 = Settings Screen
-int currentBrightness = startBrightness; //12 is Max level on m5stickC but 100 on m5stickC-Plus
+int currentScreen = 0;                    //0 = Tally Screen, 1 = Settings Screen
+int currentBrightness = startBrightness;  //12 is Max level on m5stickC but 100 on m5stickC-Plus, unknown on m5stickC-Plus2
 
-WiFiManager wm; // global wm instance
+WiFiManager wm;  // global wm instance
 bool portalRunning = false;
 
 // Lcd size
 // m5stickC: 80x160
 // m5StickC Plus: 135x240
+// m5StickC Plus2: 135x240
 
 void setup() {
   pinMode(TRIGGER_PIN, INPUT_PULLUP);
   Serial.begin(115200);
   while (!Serial);
 
-  // Initialize the M5StickC object
-#if C_PLUS == 1
-  logger("Initializing M5StickCPlus.", "info-quiet");
+    // Initialize the M5StickC object
+#if M5STICKC_PLUS_2
+  logger("Initializing M5StickCPlus2.", "info-quiet");
+#else
+#if M5STICKC_PLUS
+  logger("Initializing M5StickCPlus2.", "info-quiet");
 #else
   logger("Initializing M5StickC.", "info-quiet");
 #endif
+#endif
 
-  setCpuFrequencyMhz(80);   //Save battery by turning down the CPU clock
-  btStop();                 //Save battery by turning off BlueTooth
+  setCpuFrequencyMhz(80);  //Save battery by turning down the CPU clock
+  btStop();                //Save battery by turning off BlueTooth
 
   // Append last three pairs of MAC to listenerDeviceName to make it some what unique
-  byte mac[6];              // the MAC address of your Wifi shield
+  byte mac[6];  // the MAC address of your Wifi shield
   WiFi.macAddress(mac);
   listenerDeviceName = listenerDeviceName + String(mac[3], HEX) + String(mac[4], HEX) + String(mac[5], HEX);
 
   // Set WiFi hostname
-  wm.setHostname ((const char *) listenerDeviceName.c_str());
+  wm.setHostname((const char *)listenerDeviceName.c_str());
 
+#if M5STICKC_PLUS_2
+  auto cfg = M5.config();
+  StickCP2.begin(cfg);
+  StickCP2.Display.setRotation(3);
+  StickCP2.Display.fillScreen(TFT_BLACK);
+#else
   M5.begin();
   M5.Lcd.setRotation(3);
   M5.Lcd.fillScreen(TFT_BLACK);
-  #if C_PLUS == 1
+#endif
+#if M5STICKC_PLUS_2
+  StickCP2.Display.setCursor(0, 0);
+  StickCP2.Display.setFreeFont(FSS9);
+#else
+#if M5STICKC_PLUS
   M5.Lcd.setCursor(0, 20);
   M5.Lcd.setFreeFont(FSS9);
-  #else
+#else
   M5.Lcd.setCursor(0, 0);
   M5.Lcd.setTextSize(1);
-  #endif
+#endif
+#endif
+#if M5STICKC_PLUS_2
+  StickCP2.Display.setTextColor(WHITE, BLACK);
+  StickCP2.Display.println("booting...");
+#else
   M5.Lcd.setTextColor(WHITE, BLACK);
   M5.Lcd.println("booting...");
+#endif
   logger("Tally Arbiter M5StickC Listener Client booting.", "info");
   logger("Listener device name: " + listenerDeviceName, "info");
 
@@ -142,8 +186,8 @@ void setup() {
 
   preferences.end();
 
-  delay(100); //wait 100ms before moving on
-  connectToNetwork(); //starts Wifi connection
+  delay(100);          //wait 100ms before moving on
+  connectToNetwork();  //starts Wifi connection
   //  M5.Lcd.println("SSID: " + String(WiFi.SSID()));
   while (!networkConnected) {
     delay(200);
@@ -152,42 +196,46 @@ void setup() {
   ArduinoOTA.setHostname(listenerDeviceName.c_str());
   ArduinoOTA.setPassword("tallyarbiter");
   ArduinoOTA
-  .onStart([]() {
-    String type;
-    if (ArduinoOTA.getCommand() == U_FLASH)
-      type = "sketch";
-    else // U_SPIFFS
-      type = "filesystem";
+    .onStart([]() {
+      String type;
+      if (ArduinoOTA.getCommand() == U_FLASH)
+        type = "sketch";
+      else  // U_SPIFFS
+        type = "filesystem";
 
-    // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
-    Serial.println("Start updating " + type);
-  })
-  .onEnd([]() {
-    Serial.println("\nEnd");
-  })
-  .onProgress([](unsigned int progress, unsigned int total) {
-    Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-  })
-  .onError([](ota_error_t error) {
-    Serial.printf("Error[%u]: ", error);
-    if (error == OTA_AUTH_ERROR) logger("Auth Failed", "error");
-    else if (error == OTA_BEGIN_ERROR) logger("Begin Failed", "error");
-    else if (error == OTA_CONNECT_ERROR) logger("Connect Failed", "error");
-    else if (error == OTA_RECEIVE_ERROR) logger("Receive Failed", "error");
-    else if (error == OTA_END_ERROR) logger("End Failed", "error");
-  });
+      // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
+      Serial.println("Start updating " + type);
+    })
+    .onEnd([]() {
+      Serial.println("\nEnd");
+    })
+    .onProgress([](unsigned int progress, unsigned int total) {
+      Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+    })
+    .onError([](ota_error_t error) {
+      Serial.printf("Error[%u]: ", error);
+      if (error == OTA_AUTH_ERROR) logger("Auth Failed", "error");
+      else if (error == OTA_BEGIN_ERROR) logger("Begin Failed", "error");
+      else if (error == OTA_CONNECT_ERROR) logger("Connect Failed", "error");
+      else if (error == OTA_RECEIVE_ERROR) logger("Receive Failed", "error");
+      else if (error == OTA_END_ERROR) logger("End Failed", "error");
+    });
 
   ArduinoOTA.begin();
 
-  #if TALLY_EXTRA_OUTPUT
-  // Enable interal led for program trigger
+#if TALLY_EXTRA_OUTPUT
+  // Enable internal led for program trigger
   pinMode(led_program, OUTPUT);
+#if M5STICKC_PLUS_2
   digitalWrite(led_program, LOW);
+#else
+  digitalWrite(led_program, HIGH);
+#endif
   pinMode(led_preview, OUTPUT);
   digitalWrite(led_preview, LOW);
   pinMode(led_aux, OUTPUT);
   digitalWrite(led_aux, LOW);
-  #endif
+#endif
   connectToServer();
 
   // Load ShowSettings screen since network has been configured
@@ -199,7 +247,7 @@ void loop() {
     wm.process();
   }
 
-  checkReset(); //check for reset pin
+  checkReset();  //check for reset pin
   ArduinoOTA.handle();
   socket.loop();
   btnM5.update();
@@ -207,7 +255,11 @@ void loop() {
   M5.update();
 
   // Is WiFi reset triggered?
-  if (M5.BtnA.pressedFor(5000)){
+#if M5STICKC_PLUS_2
+  if (StickCP2.BtnA.pressedFor(5000)) {
+#else
+  if (M5.BtnA.pressedFor(5000)) {
+#endif
     logger("resetSettings()", "info");
     wm.resetSettings();
     ESP.restart();
@@ -231,7 +283,7 @@ void loop() {
   }
 }
 
-// 
+//
 void showSettings() {
   currentScreen = 1;
   logger("showSettings()", "info-quiet");
@@ -240,14 +292,34 @@ void showSettings() {
   portalRunning = true;
 
   //displays the current network connection and Tally Arbiter server data
+#if M5STICKC_PLUS_2
+  StickCP2.Display.fillScreen(TFT_BLACK);
+#else
   M5.Lcd.fillScreen(TFT_BLACK);
-  #if C_PLUS == 1
+#endif
+#if M5STICKC_PLUS_2
+  StickCP2.Display.setCursor(0, 0);
+  StickCP2.Display.setFreeFont(FSS9);
+#else
+#if M5STICKC_PLUS
   M5.Lcd.setCursor(0, 20);
   M5.Lcd.setFreeFont(FSS9);
-  #else
+#else
   M5.Lcd.setCursor(0, 0);
   M5.Lcd.setTextSize(1);
-  #endif
+#endif
+#endif
+
+#if M5STICKC_PLUS_2
+  StickCP2.Display.setTextColor(WHITE, BLACK);
+  StickCP2.Display.println("SSID: " + String(WiFi.SSID()));
+  StickCP2.Display.println(WiFi.localIP());
+
+  StickCP2.Display.println("Tally Arbiter Server:");
+  StickCP2.Display.println(String(tallyarbiter_host) + ":" + String(tallyarbiter_port));
+  StickCP2.Display.println();
+  StickCP2.Display.print("Battery: ");
+#else
   M5.Lcd.setTextColor(WHITE, BLACK);
   M5.Lcd.println("SSID: " + String(WiFi.SSID()));
   M5.Lcd.println(WiFi.localIP());
@@ -256,35 +328,63 @@ void showSettings() {
   M5.Lcd.println(String(tallyarbiter_host) + ":" + String(tallyarbiter_port));
   M5.Lcd.println();
   M5.Lcd.print("Battery: ");
+#endif
+
+#if M5STICKC_PLUS_2
+  // TODO: The battery voltage code is flawed
+  int batteryLevel = floor(100.0 * ((1.01 * StickCP2.Power.getBatteryVoltage() / 1000) / 4));
+  batteryLevel = batteryLevel > 100 ? 100 : batteryLevel;
+  if (batteryLevel >= 100) {
+    StickCP2.Display.println("Charging...");  // show when M5 is plugged in
+  } else {
+    StickCP2.Display.println(String(batteryLevel) + "%");
+  }
+#else
+  // TODO: The battery voltage code is flawed
   int batteryLevel = floor(100.0 * (((M5.Axp.GetBatVoltage()) - 3.0) / (4.07 - 3.0)));
   batteryLevel = batteryLevel > 100 ? 100 : batteryLevel;
   if (batteryLevel >= 100) {
-    M5.Lcd.println("Charging...");   // show when M5 is plugged in
+    M5.Lcd.println("Charging...");  // show when M5 is plugged in
   } else {
     M5.Lcd.println(String(batteryLevel) + "%");
   }
+#endif
 }
 
 void showDeviceInfo() {
   currentScreen = 0;
   logger("showDeviceInfo()", "info-quiet");
-  
+
   if (portalRunning) {
     wm.stopWebPortal();
     portalRunning = false;
   }
 
+#if M5STICKC_PLUS_2
+  StickCP2.Display.fillScreen(TFT_BLACK);
+#else
   M5.Lcd.fillScreen(TFT_BLACK);
-  #if C_PLUS == 1
+#endif
+#if M5STICKC_PLUS_2
+  StickCP2.Display.setCursor(4, 50);
+  StickCP2.Display.setFreeFont(FSS24);
+#else
+#if M5STICKC_PLUS
   M5.Lcd.setCursor(4, 82);
   M5.Lcd.setFreeFont(FSS24);
-  #else
+#else
   M5.Lcd.setCursor(4, 30);
   M5.Lcd.setTextSize(2);
-  #endif
+#endif
+#endif
+
+#if M5STICKC_PLUS_2
+  StickCP2.Display.setTextColor(DARKGREY, BLACK);
+  StickCP2.Display.println(DeviceName);
+#else
   M5.Lcd.setTextColor(DARKGREY, BLACK);
   M5.Lcd.println(DeviceName);
-
+#endif
   //displays the currently assigned device and tally data
   evaluateMode();
 }
@@ -297,7 +397,10 @@ void updateBrightness() {
   }
 
   logger("Set brightness: " + String(currentBrightness), "info-quiet");
+#if M5STICKC || M5STICKC_PLUS
+  // TODO: Add call for brightness on Plus2
   M5.Axp.ScreenBreath(currentBrightness);
+#endif
 }
 
 void logger(String strLog, String strType) {
@@ -312,11 +415,11 @@ void logger(String strLog, String strType) {
   */
 }
 
-WiFiManagerParameter* custom_taServer;
-WiFiManagerParameter* custom_taPort;
+WiFiManagerParameter *custom_taServer;
+WiFiManagerParameter *custom_taPort;
 
 void connectToNetwork() {
-  WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
+  WiFi.mode(WIFI_STA);  // explicitly set mode, esp defaults to STA+AP
   logger("Connecting to SSID: " + String(WiFi.SSID()), "info");
 
   //reset settings - wipe credentials for testing
@@ -330,31 +433,45 @@ void connectToNetwork() {
   wm.addParameter(custom_taPort);
 
   // If no saved WiFi we assume that configuration is needed via the captive portal
+#if M5STICKC_PLUS_2
+  if (wm.getWiFiIsSaved()) {
+    StickCP2.Display.println("connecting...");
+  } else {
+    StickCP2.Display.println("Configure on");
+    StickCP2.Display.println("SSID: " + listenerDeviceName);
+  }
+#else
   if (wm.getWiFiIsSaved()) {
     M5.Lcd.println("connecting...");
   } else {
     M5.Lcd.println("Configure on");
     M5.Lcd.println("SSID: " + listenerDeviceName);
   }
+#endif
 
   wm.setSaveParamsCallback(saveParamCallback);
 
   // custom menu via array or vector
-  std::vector<const char *> menu = {"wifi", "param", "info", "sep", "restart", "exit"};
+  std::vector<const char *> menu = { "wifi", "param", "info", "sep", "restart", "exit" };
   wm.setMenu(menu);
 
   // set dark theme
   wm.setClass("invert");
 
-  wm.setConfigPortalTimeout(120); // auto close configportal after n seconds
+  wm.setConfigPortalTimeout(120);  // auto close configportal after n seconds
 
   bool res;
-  res = wm.autoConnect(listenerDeviceName.c_str()); // AP name for setup
+  res = wm.autoConnect(listenerDeviceName.c_str());  // AP name for setup
 
   if (!res) {
     logger("Failed to connect", "error");
+#if M5STICKC_PLUS_2
+    StickCP2.Display.println("Configuration timeout");
+    StickCP2.Display.println("Restart device to configure");
+#else
     M5.Lcd.println("Configuration timeout");
     M5.Lcd.println("Restart device to configure");
+#endif
     // ESP.restart();
   } else {
     //if you get here you have connected to the WiFi
@@ -450,14 +567,14 @@ void connectToServer() {
   socket.begin(tallyarbiter_host, atol(tallyarbiter_port));
 }
 
-void socket_event(socketIOmessageType_t type, uint8_t * payload, size_t length) {
+void socket_event(socketIOmessageType_t type, uint8_t *payload, size_t length) {
   String eventMsg = "";
   String eventType = "";
   String eventContent = "";
 
   switch (type) {
     case sIOtype_CONNECT:
-      socket_Connected((char*)payload, length);
+      socket_Connected((char *)payload, length);
       break;
 
     case sIOtype_DISCONNECT:
@@ -469,7 +586,7 @@ void socket_event(socketIOmessageType_t type, uint8_t * payload, size_t length) 
       break;
 
     case sIOtype_EVENT:
-      eventMsg = (char*)payload;
+      eventMsg = (char *)payload;
       eventType = eventMsg.substring(2, eventMsg.indexOf("\"", 2));
       eventContent = eventMsg.substring(eventType.length() + 4);
       eventContent.remove(eventContent.length() - 1);
@@ -505,7 +622,7 @@ void socket_event(socketIOmessageType_t type, uint8_t * payload, size_t length) 
   }
 }
 
-void socket_Connected(const char * payload, size_t length) {
+void socket_Connected(const char *payload, size_t length) {
   logger("Connected to Tally Arbiter server.", "info");
   logger("DeviceId: " + DeviceId, "info-quiet");
   String deviceObj = "{\"deviceId\": \"" + DeviceId + "\", \"listenerType\": \"" + listenerDeviceName.c_str() + "\", \"canBeReassigned\": true, \"canBeFlashed\": true, \"supportsChat\": true }";
@@ -516,6 +633,19 @@ void socket_Connected(const char * payload, size_t length) {
 
 void socket_Flash() {
   //flash the screen white 3 times
+#if M5STICKC_PLUS_2
+  StickCP2.Display.fillScreen(WHITE);
+  delay(500);
+  StickCP2.Display.fillScreen(TFT_BLACK);
+  delay(500);
+  StickCP2.Display.fillScreen(WHITE);
+  delay(500);
+  StickCP2.Display.fillScreen(TFT_BLACK);
+  delay(500);
+  StickCP2.Display.fillScreen(WHITE);
+  delay(500);
+  StickCP2.Display.fillScreen(TFT_BLACK);
+#else
   M5.Lcd.fillScreen(WHITE);
   delay(500);
   M5.Lcd.fillScreen(TFT_BLACK);
@@ -527,7 +657,7 @@ void socket_Flash() {
   M5.Lcd.fillScreen(WHITE);
   delay(500);
   M5.Lcd.fillScreen(TFT_BLACK);
-
+#endif
   //then resume normal operation
   switch (currentScreen) {
     case 0:
@@ -563,6 +693,15 @@ void socket_Reassign(String payload) {
   ws_emit("listener_reassign_object", charReassignObj);
   ws_emit("devices");
 
+#if M5STICKC_PLUS_2
+  StickCP2.Display.fillScreen(RED);
+  delay(200);
+  StickCP2.Display.fillScreen(TFT_BLACK);
+  delay(200);
+  StickCP2.Display.fillScreen(RED);
+  delay(200);
+  StickCP2.Display.fillScreen(TFT_BLACK);
+#else
   M5.Lcd.fillScreen(RED);
   delay(200);
   M5.Lcd.fillScreen(TFT_BLACK);
@@ -570,6 +709,7 @@ void socket_Reassign(String payload) {
   M5.Lcd.fillScreen(RED);
   delay(200);
   M5.Lcd.fillScreen(TFT_BLACK);
+#endif
 
   logger("newDeviceId: " + newDeviceId, "info-quiet");
   DeviceId = newDeviceId;
@@ -633,7 +773,7 @@ String getBusColorById(String busId) {
 int getBusPriorityById(String busId) {
   for (int i = 0; i < BusOptions.length(); i++) {
     if (JSON.stringify(BusOptions[i]["id"]) == busId) {
-      return (int) JSON.stringify(BusOptions[i]["priority"]).toInt();
+      return (int)JSON.stringify(BusOptions[i]["priority"]).toInt();
     }
   }
 
@@ -657,50 +797,83 @@ void SetDeviceName() {
 
 void evaluateMode() {
   if (actualType != prevType) {
-    #if C_PLUS == 1
+#if M5STICKC_PLUS_2
+    StickCP2.Display.setCursor(4, 50);
+    StickCP2.Display.setFreeFont(FSS24);
+#else
+#if M5STICKC_PLUS
     M5.Lcd.setCursor(4, 82);
     M5.Lcd.setFreeFont(FSS24);
-    #else
+#else
     M5.Lcd.setCursor(4, 30);
     //M5.Lcd.setTextSize(maxTextSize);
     M5.Lcd.setTextSize(2);
-    #endif
+#endif
+#endif
     actualColor.replace("#", "");
     String hexstring = actualColor;
-    long number = (long) strtol( &hexstring[1], NULL, 16);
+    long number = (long)strtol(&hexstring[1], NULL, 16);
     int r = number >> 16;
     int g = number >> 8 & 0xFF;
     int b = number & 0xFF;
 
     if (actualType != "") {
+#if M5STICKC_PLUS_2
+      StickCP2.Display.setTextColor(BLACK);
+      StickCP2.Display.fillScreen(M5.Lcd.color565(r, g, b));
+      StickCP2.Display.println(DeviceName);
+#else
       M5.Lcd.setTextColor(BLACK);
       M5.Lcd.fillScreen(M5.Lcd.color565(r, g, b));
       M5.Lcd.println(DeviceName);
+#endif
     } else {
+#if M5STICKC_PLUS_2
+      StickCP2.Display.setTextColor(DARKGREY, BLACK);
+      StickCP2.Display.fillScreen(TFT_BLACK);
+      StickCP2.Display.println(DeviceName);
+#else
       M5.Lcd.setTextColor(DARKGREY, BLACK);
       M5.Lcd.fillScreen(TFT_BLACK);
       M5.Lcd.println(DeviceName);
+#endif
     }
 
-    #if TALLY_EXTRA_OUTPUT
+#if TALLY_EXTRA_OUTPUT
     if (actualType == "\"program\"") {
-      digitalWrite (led_program, LOW);
-      digitalWrite (led_preview, HIGH);
-      digitalWrite (led_aux, HIGH);
+#if M5STICKC_PLUS_2
+      digitalWrite(led_program, HIGH);
+#else
+      digitalWrite(led_program, LOW);
+#endif
+      digitalWrite(led_preview, LOW);
+      digitalWrite(led_aux, LOW);
     } else if (actualType == "\"preview\"") {
-      digitalWrite (led_program, HIGH);
-      digitalWrite (led_preview, LOW);
-      digitalWrite (led_aux, HIGH);
+#if M5STICKC_PLUS_2
+      digitalWrite(led_program, LOW);
+#else
+      digitalWrite(led_program, HIGH);
+#endif
+      digitalWrite(led_preview, HIGH);
+      digitalWrite(led_aux, LOW);
     } else if (actualType == "\"aux\"") {
-      digitalWrite (led_program, HIGH);
-      digitalWrite (led_preview, HIGH);
-      digitalWrite (led_aux, LOW);
+#if M5STICKC_PLUS_2
+      digitalWrite(led_program, LOW);
+#else
+      digitalWrite(led_program, HIGH);
+#endif
+      digitalWrite(led_preview, LOW);
+      digitalWrite(led_aux, HIGH);
     } else {
-      digitalWrite (led_program, HIGH);
-      digitalWrite (led_preview, HIGH);
-      digitalWrite (led_aux, HIGH);
+#if M5STICKC_PLUS_2
+      digitalWrite(led_program, LOW);
+#else
+      digitalWrite(led_program, HIGH);
+#endif
+      digitalWrite(led_preview, LOW);
+      digitalWrite(led_aux, LOW);
     }
-    #endif
+#endif
 
     logger("Device is in " + actualType + " (color " + actualColor + " priority " + String(actualPriority) + ")", "info");
     Serial.println(" r: " + String(r) + " g: " + String(g) + " b: " + String(b));
@@ -709,40 +882,68 @@ void evaluateMode() {
   }
 
   if (LAST_MSG == true) {
+#if M5STICKC_PLUS_2
+    StickCP2.Display.println(LastMessage);
+#else
     M5.Lcd.println(LastMessage);
+#endif
   }
 }
 
 void checkReset() {
   // check for button press
-  if ( digitalRead(TRIGGER_PIN) == LOW ) {
+  if (digitalRead(TRIGGER_PIN) == LOW) {
 
     // poor mans debounce/press-hold, code not ideal for production
     delay(50);
-    if ( digitalRead(TRIGGER_PIN) == LOW ) {
+    if (digitalRead(TRIGGER_PIN) == LOW) {
+#if M5STICKC_PLUS_2
+      StickCP2.Display.fillScreen(TFT_BLACK);
+#else
       M5.Lcd.fillScreen(TFT_BLACK);
-      #if C_PLUS == 1
+#endif
+#if M5STICKC_PLUS
       M5.Lcd.setCursor(0, 40);
       M5.Lcd.setFreeFont(FSS9);
-      #else
+#else
+#if M5STICKC_PLUS_2
+      StickCP2.Display.setCursor(0, 40);
+      StickCP2.Display.setFreeFont(FSS9);
+#else
       M5.Lcd.setCursor(0, 0);
       M5.Lcd.setTextSize(1);
-      #endif
+#endif
+#endif
+
+#if M5STICKC_PLUS_2
+      StickCP2.Display.setTextColor(WHITE, BLACK);
+      StickCP2.Display.println("Reset button pushed....");
+#else
       M5.Lcd.setTextColor(WHITE, BLACK);
       M5.Lcd.println("Reset button pushed....");
+#endif
       logger("Button Pressed", "info");
 
       // still holding button for 3000 ms, reset settings, code not ideal for production
-      delay(3000); // reset delay hold
-      if ( digitalRead(TRIGGER_PIN) == LOW ) {
+      delay(3000);  // reset delay hold
+      if (digitalRead(TRIGGER_PIN) == LOW) {
+#if M5STICKC_PLUS_2
+        StickCP2.Display.println("Erasing....");
+#else
         M5.Lcd.println("Erasing....");
+#endif
         logger("Button Held", "info");
         logger("Erasing Config, restarting", "info");
         wm.resetSettings();
         ESP.restart();
       }
 
+#if M5STICKC_PLUS_2
+      StickCP2.Display.println("Starting Portal...");
+#else
       M5.Lcd.println("Starting Portal...");
+#endif
+
       // start portal w delay
       logger("Starting config portal", "info");
       wm.setConfigPortalTimeout(120);


### PR DESCRIPTION
Improvements

- Added support for m5stickC-Plus2.
- Changed pin for tally extra preview. (G36 is input only, it was replaced by G25 but it doesn't exist on the plain m5stickC)
- Changed HIGH/LOW for external leds. (On m5stickC and m5stickC-plus is HIGH and LOW not the same for the internal led as on external leds)
- Replaced code internal defines for board types with board defines used by Arduino IDE.

Things to fix in the future:

- Fix battery level for M5stickC-Plus2.
- Add screen brightness for M5stickC-Plus2.