### PR TITLE
Remove TFT_eSPI specific dependency

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup TFT_eSPI and select User Setup
       run: |
-        git clone https://github.com/Bodmer/TFT_eSPI/
+        git clone --branch v2.5.33 https://github.com/Bodmer/TFT_eSPI/
         cd TFT_eSPI
         sed -i 's/#include <User_Setup.h>/\/\/#include <User_Setup.h>/g' User_Setup_Select.h
         sed -i 's/\/\/#include <User_Setups\/Setup22_TTGO_T4.h>/#include <User_Setups\/Setup22_TTGO_T4.h>/g' User_Setup_Select.h

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup TFT_eSPI and select User Setup
       run: |
-        git clone --branch v2.5.33 https://github.com/Bodmer/TFT_eSPI/
+        git clone https://github.com/Bodmer/TFT_eSPI/
         cd TFT_eSPI
         sed -i 's/#include <User_Setup.h>/\/\/#include <User_Setup.h>/g' User_Setup_Select.h
         sed -i 's/\/\/#include <User_Setups\/Setup22_TTGO_T4.h>/#include <User_Setups\/Setup22_TTGO_T4.h>/g' User_Setup_Select.h

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -129,10 +129,10 @@ jobs:
         fqbn: ${{ matrix.board.fqbn }}
         libraries: |
           - name: WebSockets
-          - source-path: TFT_eSPI
+          - name: WiFiManager
           - name: MultiButton
           - name: Arduino_JSON
-          - name: WiFiManager
+          - source-path: TFT_eSPI
         cli-compile-flags: |
           - --export-binaries
         sketch-paths: |

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -131,8 +131,8 @@ jobs:
           - name: WebSockets
           - name: WiFiManager
           - name: MultiButton
-          - name: Arduino_JSON
           - source-path: TFT_eSPI
+          - name: Arduino_JSON
         cli-compile-flags: |
           - --export-binaries
         sketch-paths: |

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup TFT_eSPI and select User Setup
       run: |
-        git clone --branch v2.5.33 https://github.com/Bodmer/TFT_eSPI/
+        git clone https://github.com/Bodmer/TFT_eSPI/
         cd TFT_eSPI
         sed -i 's/#include <User_Setup.h>/\/\/#include <User_Setup.h>/g' User_Setup_Select.h
         sed -i 's/\/\/#include <User_Setups\/Setup22_TTGO_T4.h>/#include <User_Setups\/Setup22_TTGO_T4.h>/g' User_Setup_Select.h
@@ -129,10 +129,10 @@ jobs:
         fqbn: ${{ matrix.board.fqbn }}
         libraries: |
           - name: WebSockets
-          - name: WiFiManager
-          - name: MultiButton
           - source-path: TFT_eSPI
+          - name: MultiButton
           - name: Arduino_JSON
+          - name: WiFiManager
         cli-compile-flags: |
           - --export-binaries
         sketch-paths: |

--- a/listener_clients/TTGO_T-listener/TTGO_T-listener.ino
+++ b/listener_clients/TTGO_T-listener/TTGO_T-listener.ino
@@ -14,9 +14,9 @@ Modify User_Setup_Select.h in libraryY TFT_eSPI
 #include <WiFi.h>
 #include <WebSocketsClient.h>
 #include <SocketIOclient.h>
+#include <TFT_eSPI.h>
 #include <Arduino_JSON.h>
 #include <PinButton.h>
-#include <TFT_eSPI.h>
 #include <SPI.h>
 #include <Arduino.h>
 #include <WiFiManager.h>


### PR DESCRIPTION
Removed the TFT_eSPI specific dependency to v2.5.33. Now latest version of TFT_eSPI can be used. It was verified with v2.5.43. This is a solution to https://github.com/josephdadams/TallyArbiter/issues/618.

The solution was to change the include order of TFT_eSPI in `TTGO_T-listener.ino` so that latest version of TFT_eSPI can be referenced in the build file.

NB: The failure in `Run arduino/compile-sketches@v1` is due to a memory usage size check with the previous sketch which will fail with this PR. I was lazy and didn't want to split this PR into two PRs where the include line is changed in the first PR and then the build file is changed in the second PR.