### PR TITLE
Client Updates

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -79,6 +79,7 @@ String prevType = ""; // reduce display flicker by storing previous state
 String actualType = "";
 String actualColor = "";
 int actualPriority = 0;
+long colorNumber = 0;
 
 // default color values
 int GRB_COLOR_WHITE = 0xffffff;


### PR DESCRIPTION
adding variable up the top

Changes:

- Autorotation! Display will now display the numbers in the correct orientation during tally changes - added as some of my cameras I mount using a stiff USB cable into a v-mount battery
- Colours from TallyArbiter now are correct
	- Changed GRB_COLOR to RGB_COLOR as someone else changed the values to read RGB instead of GRB
	- Swapped R&G Channels in the HEX converter
	- Added the following colors "WarmWhite" "DIMWarmWhite"
	- Reduced the RGB_COLOR_GREEN as green was significantly brighter than RED or BLUE
- Continued to add more inconsistant comments
	- fixed several spelling mistakes
	- added several spelling mistakes


To Do:

- Add persistant Show numbers during tally must be set durning wifi setup
- Allow setting to allow persistant access to WifiManager during normal operation