### PR TITLE
Improving linked busses support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tallyarbiter",
-    "version": "3.0.8",
+    "version": "3.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "tallyarbiter",
-            "version": "3.0.8",
+            "version": "3.0.10",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^6.19.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1135,12 +1135,36 @@ function UpdateDeviceState(deviceId: string) {
 	const deviceSources = device_sources.filter((d) => d.deviceId == deviceId);
 	for (const bus of currentConfig.bus_options) {
 		if ((device.linkedBusses || []).includes(bus.id)) {
-			// bus is linked, which means all sources must be in this bus
-			if (deviceSources.findIndex((s) => !currentSourceTallyData?.[s.id]?.includes(bus.type)) === -1) {
+			// bus is linked, which means all sources must be in this bus			
+			//logger(`findIndex: ${deviceSources.findIndex((s) => !currentSourceTallyData?.[s.id]?.includes(bus.type))}`, 'info-quiet');
+			//if (deviceSources.findIndex((s) => !currentSourceTallyData?.[s.sourceId]?.includes(bus.type)) === -1) {
+			// if (deviceSources.findIndex((s) => !currentSourceTallyData?.[s.sourceId]?.includes(bus.type)) === -1) {
+			// 	logger(`Match!!!!`, 'info-quiet');
+			// 	currentDeviceTallyData[device.id].push(bus.id);
+			// 	if (!previousBusses.includes(bus.id)) {
+			// 		RunAction(deviceId, bus.id, true);
+			// 	}
+			// } else {
+			// 	logger(`No Match!!!!`, 'info-quiet');
+			// 	if (previousBusses.includes(bus.id)) {
+			// 		RunAction(deviceId, bus.id, false);
+			// 	}
+			// }
+
+			// Count number of sources in bus
+			// TODO: This should be replaced with deviceSources.findIndex((s).
+			let num = 0;
+			for (let i = 0; i < deviceSources.length; i++) {
+				if (currentSourceTallyData?.[deviceSources[i].sourceId]?.includes(bus.type)) {
+					num++
+				}
+			}
+
+			if (num === deviceSources.length) {
 				currentDeviceTallyData[device.id].push(bus.id);
 				if (!previousBusses.includes(bus.id)) {
 					RunAction(deviceId, bus.id, true);
-				}
+				}	
 			} else {
 				if (previousBusses.includes(bus.id)) {
 					RunAction(deviceId, bus.id, false);
@@ -1148,7 +1172,7 @@ function UpdateDeviceState(deviceId: string) {
 			}
 		} else {
 			// bus is unlinked
-			if (deviceSources.findIndex((s) => currentSourceTallyData?.[s.id]?.includes(bus.type)) !== -1) {
+			if (deviceSources.findIndex((s) => currentSourceTallyData?.[s.sourceId]?.includes(bus.type)) !== -1) {
 				currentDeviceTallyData[device.id].push(bus.id);
 				if (!previousBusses.includes(bus.id)) {
 					RunAction(deviceId, bus.id, true);
@@ -1284,7 +1308,7 @@ function initializeSource(source: Source): TallyInput {
 		for (const [sourceAddress, busses] of Object.entries(tallyDataWithAddresses)) {
 			let device_source = device_sources.find((s) => s.sourceId == source.id && s.address == sourceAddress);
 			if(device_source) {
-				tallyData[device_source.id] = busses;
+				tallyData[device_source.sourceId] = busses;
 			}
 		}
 		SendCloudSourceTallyData(source.id, tallyData);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1136,20 +1136,6 @@ function UpdateDeviceState(deviceId: string) {
 	for (const bus of currentConfig.bus_options) {
 		if ((device.linkedBusses || []).includes(bus.id)) {
 			// bus is linked, which means all sources must be in this bus			
-			//logger(`findIndex: ${deviceSources.findIndex((s) => !currentSourceTallyData?.[s.id]?.includes(bus.type))}`, 'info-quiet');
-			//if (deviceSources.findIndex((s) => !currentSourceTallyData?.[s.sourceId]?.includes(bus.type)) === -1) {
-			// if (deviceSources.findIndex((s) => !currentSourceTallyData?.[s.sourceId]?.includes(bus.type)) === -1) {
-			// 	logger(`Match!!!!`, 'info-quiet');
-			// 	currentDeviceTallyData[device.id].push(bus.id);
-			// 	if (!previousBusses.includes(bus.id)) {
-			// 		RunAction(deviceId, bus.id, true);
-			// 	}
-			// } else {
-			// 	logger(`No Match!!!!`, 'info-quiet');
-			// 	if (previousBusses.includes(bus.id)) {
-			// 		RunAction(deviceId, bus.id, false);
-			// 	}
-			// }
 
 			// Count number of sources in bus
 			// TODO: This should be replaced with deviceSources.findIndex((s).


### PR DESCRIPTION
Improved the support for linked busses by updating:

- `function getDeviceStates` - added linked busses logic
- `function UpdateDeviceState` - changed id to sourceId and added linked busses logic
- `function initializeSource` - changed id to sourceId

This PR solves https://github.com/josephdadams/TallyArbiter/issues/704.

As a consequence this PR improves RunAction when defining multiple devices for the same source.

As a consequence the code to check the status for linked busses is now duplicated. This can later be improved.