### PR TITLE
Added support for nested OBS scenes for websocket5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "jspack": "^0.0.4",
                 "node-emberplus": "^3.0.5",
                 "obs-websocket-js": "npm:obs-websocket-js@^4.0.3",
-                "obs-websocket-js-5": "npm:obs-websocket-js@^5.0.2",
+                "obs-websocket-js-5": "npm:obs-websocket-js@^5.0.6",
                 "osc": "^2.4.3",
                 "rate-limiter-flexible": "^2.3.7",
                 "reflect-metadata": "^0.1.13",
@@ -4456,43 +4456,61 @@
         },
         "node_modules/obs-websocket-js-5": {
             "name": "obs-websocket-js",
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/obs-websocket-js/-/obs-websocket-js-5.0.2.tgz",
-            "integrity": "sha512-4XxWd5abIFOk0HjIHk+X/NwSXuOTPGsNnn7845g0UQZV0T3AtNk+dfp21zSjJVzuN/5oZR3UKjzEqg8pxMndCA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/obs-websocket-js/-/obs-websocket-js-5.0.6.tgz",
+            "integrity": "sha512-tHRq8py1XrdlMhSV+N/KTGHqoRIcsBBXbjcA9ex21k128iQ7YXjxzNWs3s9gidP1tEcIyVuJu8FnPgrSBWGm0Q==",
+            "license": "MIT",
             "dependencies": {
                 "@msgpack/msgpack": "^2.7.1",
                 "crypto-js": "^4.1.1",
                 "debug": "^4.3.2",
-                "eventemitter3": "^4.0.7",
-                "isomorphic-ws": "^4.0.1",
-                "type-fest": "^2.3.2",
-                "ws": "^8.2.2"
+                "eventemitter3": "^5.0.1",
+                "isomorphic-ws": "^5.0.0",
+                "type-fest": "^3.11.0",
+                "ws": "^8.13.0"
             },
             "engines": {
-                "node": ">12.0"
+                "node": ">16.0"
+            }
+        },
+        "node_modules/obs-websocket-js-5/node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "license": "MIT"
+        },
+        "node_modules/obs-websocket-js-5/node_modules/isomorphic-ws": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+            "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "ws": "*"
             }
         },
         "node_modules/obs-websocket-js-5/node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+            "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
-                "node": ">=12.20"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/obs-websocket-js-5/node_modules/ws": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-            "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -9743,28 +9761,39 @@
             }
         },
         "obs-websocket-js-5": {
-            "version": "npm:obs-websocket-js@5.0.2",
-            "resolved": "https://registry.npmjs.org/obs-websocket-js/-/obs-websocket-js-5.0.2.tgz",
-            "integrity": "sha512-4XxWd5abIFOk0HjIHk+X/NwSXuOTPGsNnn7845g0UQZV0T3AtNk+dfp21zSjJVzuN/5oZR3UKjzEqg8pxMndCA==",
+            "version": "npm:obs-websocket-js@5.0.6",
+            "resolved": "https://registry.npmjs.org/obs-websocket-js/-/obs-websocket-js-5.0.6.tgz",
+            "integrity": "sha512-tHRq8py1XrdlMhSV+N/KTGHqoRIcsBBXbjcA9ex21k128iQ7YXjxzNWs3s9gidP1tEcIyVuJu8FnPgrSBWGm0Q==",
             "requires": {
                 "@msgpack/msgpack": "^2.7.1",
                 "crypto-js": "^4.1.1",
                 "debug": "^4.3.2",
-                "eventemitter3": "^4.0.7",
-                "isomorphic-ws": "^4.0.1",
-                "type-fest": "^2.3.2",
-                "ws": "^8.2.2"
+                "eventemitter3": "^5.0.1",
+                "isomorphic-ws": "^5.0.0",
+                "type-fest": "^3.11.0",
+                "ws": "^8.13.0"
             },
             "dependencies": {
+                "eventemitter3": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+                    "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+                },
+                "isomorphic-ws": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+                    "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+                    "requires": {}
+                },
                 "type-fest": {
-                    "version": "2.19.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-                    "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+                    "version": "3.13.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+                    "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
                 },
                 "ws": {
-                    "version": "8.9.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-                    "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+                    "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
                     "requires": {}
                 }
             }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "jspack": "^0.0.4",
         "node-emberplus": "^3.0.5",
         "obs-websocket-js": "npm:obs-websocket-js@^4.0.3",
-        "obs-websocket-js-5": "npm:obs-websocket-js@^5.0.2",
+        "obs-websocket-js-5": "npm:obs-websocket-js@^5.0.6",
         "osc": "^2.4.3",
         "rate-limiter-flexible": "^2.3.7",
         "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
Support for nested OBS scenes added in source type OBS for websocket5. The support and behaviour with nested scenes is now the same for both websocket4 and websocket5 in TA.

This is a fix for https://github.com/josephdadams/TallyArbiter/issues/527 including its duplicate https://github.com/josephdadams/TallyArbiter/issues/665.

NB: Support for group is not added.