### PR TITLE
Fix global handling of current tally data

### DIFF
--- a/src/_models/TallyData.ts
+++ b/src/_models/TallyData.ts
@@ -3,7 +3,7 @@ export type AddressTallyData = {
 }
 
 export type SourceTallyData = {
-    [sourceId: string]: string[];
+    [deviceSourceId: string]: string[];
 }
 
 export type DeviceTallyData = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -983,51 +983,32 @@ function TSLClients_UpdateAll() {
 
 function getDeviceStates(deviceId?: string): DeviceState[] {
 	let deviceStateObj = devices.filter((d) => deviceId ? d.id == deviceId : true).flatMap((d) => currentConfig.bus_options.map((b) => {
-		const deviceSources = device_sources.filter((s) => s.deviceId == d.id);
+		const device = GetDeviceByDeviceId(d.id);
+		const deviceSourcesForDevice = device_sources.filter((s) => s.deviceId == d.id);
 
 		// Check if buss is linked, if linked all sources must be in this bus
-		const device = GetDeviceByDeviceId(d.id);
 		if ((device.linkedBusses || []).includes(b.id)) {
-
-			// Check if all sources are in the buss, if not return [] for sources. 
-			// Count number of sources in bus
-			// TODO: Check if this can be replaced with deviceSources.findIndex((s) and refactored to reduce duplicated code.
-			let num = 0;
-			for (let i = 0; i < deviceSources.length; i++) {
-				if (currentSourceTallyData?.[deviceSources[i].sourceId]?.includes(b.type)) {
-					num++
-				}
-			}
-			if (num === deviceSources.length) {
+			if (currentDeviceTallyData?.[device.id]?.includes(b.type)) {
 				return {
 					busId: b.id,
 					deviceId: d.id,
-					sources: deviceSources.filter(
-						(s) => Object.entries(SourceClients[s.sourceId]?.tally?.value || [])
-						.filter(([address, busses]) => address == s.address)
-							.findIndex(([address, busses]: [string, string[]]) => busses.includes(b.type)) !== -1).map((s) => s.id),
-				}	
+					sources: deviceSourcesForDevice.filter(deviceSource => currentSourceTallyData?.[deviceSource.id]?.includes(b.type)).map((s) => s.id),
+				}
 			} else {
 				return {
 					busId: b.id,
 					deviceId: d.id,
 					sources: [],
-				}		
+				}
 			}
 		} else {
 			return {
 				busId: b.id,
 				deviceId: d.id,
-				sources: deviceSources.filter(
-					(s) => Object.entries(SourceClients[s.sourceId]?.tally?.value || [])
-					.filter(([address, busses]) => address == s.address)
-						.findIndex(([address, busses]: [string, string[]]) => busses.includes(b.type)) !== -1).map((s) => s.id),
+				sources: deviceSourcesForDevice.filter(deviceSource => currentSourceTallyData?.[deviceSource.id]?.includes(b.type)).map((s) => s.id),
 			}
-		}	
+		}
 	}));
-
-	//console.log('*** device state obj ***')
-	//console.log(deviceStateObj)
 
 	return deviceStateObj;
 }
@@ -1166,39 +1147,27 @@ function UpdateDeviceState(deviceId: string) {
 
 	const deviceSources = device_sources.filter((d) => d.deviceId == deviceId);
 	for (const bus of currentConfig.bus_options) {
+		let isDeviceActiveOnCurrentBus: boolean = false
 		if ((device.linkedBusses || []).includes(bus.id)) {
-			// bus is linked, which means all sources must be in this bus			
+			// bus is linked, which means all configured sources for the current device must have this bus active
 
-			// Count number of sources in bus
-			// TODO: This should be replaced with deviceSources.findIndex((s).
-			let num = 0;
-			for (let i = 0; i < deviceSources.length; i++) {
-				if (currentSourceTallyData?.[deviceSources[i].sourceId]?.includes(bus.type)) {
-					num++
-				}
-			}
+			let deviceSourcesForCurrentDevice = deviceSources.filter(devSrc => devSrc.deviceId = device.id)
+			let deviceSourcesForCurrentDeviceActiveOnCurrentBus = deviceSourcesForCurrentDevice.filter(devSrc => currentSourceTallyData?.[devSrc.id]?.includes(bus.type))
 
-			if (num === deviceSources.length) {
-				currentDeviceTallyData[device.id].push(bus.id);
-				if (!previousBusses.includes(bus.id)) {
-					RunAction(deviceId, bus.id, true);
-				}	
-			} else {
-				if (previousBusses.includes(bus.id)) {
-					RunAction(deviceId, bus.id, false);
-				}
-			}
+			isDeviceActiveOnCurrentBus = deviceSourcesForCurrentDevice.length === deviceSourcesForCurrentDeviceActiveOnCurrentBus.length
 		} else {
 			// bus is unlinked
-			if (deviceSources.findIndex((s) => currentSourceTallyData?.[s.sourceId]?.includes(bus.type)) !== -1) {
-				currentDeviceTallyData[device.id].push(bus.id);
-				if (!previousBusses.includes(bus.id)) {
-					RunAction(deviceId, bus.id, true);
-				}
-			} else {
-				if (previousBusses.includes(bus.id)) {
-					RunAction(deviceId, bus.id, false);
-				}
+			isDeviceActiveOnCurrentBus = deviceSources.findIndex((s) => s.deviceId == device.id && currentSourceTallyData?.[s.id]?.includes(bus.type)) !== -1
+		}
+
+		if (isDeviceActiveOnCurrentBus) {
+			currentDeviceTallyData[device.id].push(bus.id);
+			if (!previousBusses.includes(bus.id)) {
+				RunAction(deviceId, bus.id, true);
+			}
+		} else {
+			if (previousBusses.includes(bus.id)) {
+				RunAction(deviceId, bus.id, false);
 			}
 		}
 	}
@@ -1325,8 +1294,8 @@ function initializeSource(source: Source): TallyInput {
 		const tallyData: SourceTallyData = {};
 		for (const [sourceAddress, busses] of Object.entries(tallyDataWithAddresses)) {
 			let device_source = device_sources.find((s) => s.sourceId == source.id && s.address == sourceAddress);
-			if(device_source) {
-				tallyData[device_source.sourceId] = busses;
+			if (device_source) {
+				tallyData[device_source.id] = busses;
 			}
 		}
 		SendCloudSourceTallyData(source.id, tallyData);


### PR DESCRIPTION
During implementation of SimplyLive source (https://github.com/josephdadams/TallyArbiter/pull/717), i noticed some strange behaviour.

E.g. the tally state in the UI was not matching the state in the VMix emulator.
I traced it to some inconsistencies in the tally state update and linked bus logic.

This PR should fix any updateDevice logic and get rid of duplicated code for linked bus logic. This relies on the internal state which is computed by "UpdateDevice" to be accurate and can be used as SSOT for all other places where the current tally state of a device is used.