### PR TITLE
TSL packages without name

### DIFF
--- a/src/sources/SimplyLive.ts
+++ b/src/sources/SimplyLive.ts
@@ -21,9 +21,12 @@ export class SimplyLivePSource extends TallyInput {
         this.server.bind(port);
 
         this.server.on('message', (message) => {
-            if (message.length > 12) {
+            if (message.length >= 12) {
                 let tallyobj: any = TSL5DataParser.parseTSL5Data(message)
-                this.renameAddress(tallyobj.INDEX[0].toString(), tallyobj.INDEX[0].toString(), tallyobj.TEXT.toString().trim());
+
+                if (tallyobj.TEXT !== "") {
+                    this.renameAddress(tallyobj.INDEX[0].toString(), tallyobj.INDEX[0].toString(), tallyobj.TEXT.toString().trim());
+                }
 
                 let inPreview: number = 0;
                 let inProgram: number = 0;

--- a/src/sources/TSL.ts
+++ b/src/sources/TSL.ts
@@ -178,17 +178,19 @@ export class TSL5DataParser {
         var LENGTH = jspack.Unpack("<H", data, cursor)
         cursor += _LENGTH;
 
-        tallyobj.TEXT = jspack.Unpack("s".repeat(LENGTH), data, cursor)
+        tallyobj.TEXT = jspack.Unpack("s".repeat(LENGTH), data, cursor).join("")
         return tallyobj;
     }
 }
 
 class TSL5Base extends TallyInput {
     protected processTSL5Tally(data) {
-        if (data.length > 12) {
+        if (data.length >= 12) {
             let tallyobj: any = TSL5DataParser.parseTSL5Data(data)
 
-			this.renameAddress(tallyobj.INDEX[0].toString(), tallyobj.INDEX[0].toString(), tallyobj.TEXT.toString().trim()); 
+            if (tallyobj.TEXT !== "") {
+                this.renameAddress(tallyobj.INDEX[0].toString(), tallyobj.INDEX[0].toString(), tallyobj.TEXT.toString().trim());
+            }
 
             let inPreview = 0;
             let inProgram = 0;


### PR DESCRIPTION
Allow TSL packages without a source name.
In case there is no name provided, dont update the address label.

Note: I will check how i can unify the code in TSL & SimplyLive in the next step, when building the generic TSL options.
Just wanted to separate this change to not mix up things.