### PR TITLE
Change from Common JS to ES Modules

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 // This is the electron startup script
-const { app, BrowserWindow, Tray, Menu, dialog, ipcMain, powerMonitor } = require('electron');
-const { autoUpdater } = require("electron-updater");
-const { nativeImage } = require('electron/common');
-const path = require("path");
+import { app, BrowserWindow, Tray, Menu, dialog, ipcMain, powerMonitor } from 'electron';
+import { autoUpdater } from "electron-updater";
+import { nativeImage } from 'electron/common';
+import path from "path";
 
 let server;
 let mainWindow;
@@ -166,7 +166,7 @@ function checkForUpdates() {
     </style>
   </head>
   <body>
-    <script>const { ipcRenderer } = require('electron');</script>
+    <script>import { ipcRenderer } from 'electron';</script>
     <h1><b>There's an update available for TallyArbiter.</b> Do you want to download and install it?</h1>
     <button class="btn btn-success" onclick="ipcRenderer.send('updateButtonPressed')">Update</button> <button class="btn btn-danger" onclick="window.close();">Cancel</button>
     <h1>Release notes for version <b>${info.releaseName}</b>:</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@types/express": "^4.17.13",
                 "ajv": "^8.11.0",
                 "atem-connection": "3.4.0",
-                "axios": "^0.28.0",
+                "axios": "^1.7.5",
                 "bcryptjs": "^2.4.0",
                 "bonjour-service": "^1.0.12",
                 "compression": "^1.7.4",
@@ -1545,11 +1545,12 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/axios": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-            "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+            "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -7533,11 +7534,11 @@
             }
         },
         "axios": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-            "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+            "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
             "requires": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "@types/express": "^4.17.13",
         "ajv": "^8.11.0",
         "atem-connection": "3.4.0",
-        "axios": "^0.28.0",
+        "axios": "^1.7.5",
         "bcryptjs": "^2.4.0",
         "bonjour-service": "^1.0.12",
         "compression": "^1.7.4",
@@ -89,7 +89,8 @@
         "winston": "^3.7.2",
         "xml2js": "^0.5.0"
     },
-    "main": "main.js",
+    "exports": "./start.js",
+    "type": "module",
     "scripts": {
         "start": "ts-node-dev src/index.ts --dev",
         "prepare": "cd UI && npm i && npm run build",


### PR DESCRIPTION
To be able to upgrade to a later axios package must the code be changed from CommonJS to ES Modules.
Axios changed from 0.28.0 to 1.7.5.