### PR TITLE
Corrected m5atom camera number handling after flash and first received tally data

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -542,6 +542,7 @@ void socket_Flash() {
   drawNumber(icons[1], alloffcolor);
   delay(100);
   //then resume normal operation
+  prevType = "socket_Flash"; // Force repaint after socket flash
   evaluateMode();
 }
 
@@ -900,7 +901,6 @@ void rotate270(int source[25], int dest[25]) {
 
 // Screen Update Routine
 void updateDisplayBasedOnOrientation(float accX, float accY, float accZ) {
-
   //Serial.print("Screen Orientation: ");
   //Serial.print("Accel X: ");
   //Serial.print(accX);
@@ -959,6 +959,16 @@ void loop(){
         delay(100);                                         // Introduce a short delay before closing
         preferences.end();                                  // Close the Preferences after saving
     }
+    
+    // Orientation Sensor Data variables
+    float accX, accY, accZ;
+
+    // Read acceleration data
+    M5.IMU.getAccelData(&accX, &accY, &accZ);
+
+    // Run the rotation change to the variabne rotatedNumber
+    updateDisplayBasedOnOrientation(accX, accY, accZ);
+    
     drawNumber(rotatedNumber, offcolor);
 
     // Lets get some info sent out the serial connection for debugging
@@ -995,13 +1005,13 @@ void loop(){
   // Check orientation and autorotate the screen
 
     // Orientation Sensor Data variables
-  float accX, accY, accZ;
+  //float accX, accY, accZ;
 
   // Read acceleration data
-  M5.IMU.getAccelData(&accX, &accY, &accZ);
+  //M5.IMU.getAccelData(&accX, &accY, &accZ);
 
   // Run the rotation change to the variabne rotatedNumber
-  updateDisplayBasedOnOrientation(accX, accY, accZ);
+  //updateDisplayBasedOnOrientation(accX, accY, accZ);
     
 //  #else
 //  #endif


### PR DESCRIPTION
Two error corrections and one performance improvement for m5atom.

- Corrected so that number is displayed after flash. Solved: https://github.com/josephdadams/TallyArbiter/issues/394
- Corrected so that number is not incremented when tally is triggered. Solved: https://github.com/josephdadams/TallyArbiter/issues/410
- Removed unnecessary call to updateDisplayBasedOnOrientation().
