### PR TITLE
Fix listener automatic builds

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -22,7 +22,7 @@ jobs:
           platforms: |
             - name: esp32:esp32
               source-url: https://dl.espressif.com/dl/package_esp32_index.json
-          fqbn: 'esp32:esp32:m5stick_stickc'
+          fqbn: 'esp32:esp32:m5stack_stickc'
           libraries: |
             - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
             - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-M5StickC'
-          path: 'listener_clients/m5stickc-listener/build/esp32.esp32.m5stick_stickc'
+          path: 'listener_clients/m5stickc-listener/build/esp32.esp32.m5stack_stickc'
 
   build_m5atom-listener:
     name: Build M5Atom Listener

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -51,9 +51,9 @@ jobs:
           platforms: |
             - name: esp32:esp32
               source-url: https://dl.espressif.com/dl/package_esp32_index.json
-          fqbn: 'esp32:esp32:m5stack-atom'
+          fqbn: 'esp32:esp32:m5stack_atom'
           libraries: |
-            - source-url: https://github.com/m5stack/M5Atom/archive/refs/tags/0.1.2.zip
+            - source-url: https://github.com/m5stack/M5Atom/archive/refs/tags/0.1.3.zip
             - name: WebSockets
             - name: WiFiManager
             - name: MultiButton
@@ -68,7 +68,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-M5Atom'
-          path: 'listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/build/esp32.esp32.m5stack-atom'
+          path: 'listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/build/esp32.esp32.m5stack_atom'
 
   build_esp32-neopixel-listener:
     name: Build ESP32 NeoPixel Listener

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -36,7 +36,7 @@ jobs:
             - listener_clients/m5stickc-listener
           enable-deltas-report: true
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-M5StickC'
           path: 'listener_clients/m5stickc-listener/build/esp32.esp32.m5stick-c'
@@ -65,7 +65,7 @@ jobs:
             - listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom
           enable-deltas-report: true
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-M5Atom'
           path: 'listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/build/esp32.esp32.m5stack-atom'
@@ -93,7 +93,7 @@ jobs:
             - listener_clients/esp32-neopixel-listener
           enable-deltas-report: true
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-ESP32-NeoPixel'
           path: 'listener_clients/esp32-neopixel-listener/build/esp32.esp32.esp32'
@@ -144,7 +144,7 @@ jobs:
           FQBN_REPLACED=$(echo $RAW_FQBN | sed 's/:/./g')
           echo "FQBN_REPLACED=$FQBN_REPLACED" >> $GITHUB_ENV
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-${{ matrix.board.name }}'
           path: 'listener_clients/TTGO_T-listener/build/${{ env.FQBN_REPLACED }}'

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -24,7 +24,7 @@ jobs:
               source-url: https://dl.espressif.com/dl/package_esp32_index.json
           fqbn: 'esp32:esp32:m5stick_stickc'
           libraries: |
-            - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.2.9.zip
+            - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
             - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
             - name: WebSockets
             - name: WiFiManager

--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -22,7 +22,7 @@ jobs:
           platforms: |
             - name: esp32:esp32
               source-url: https://dl.espressif.com/dl/package_esp32_index.json
-          fqbn: 'esp32:esp32:m5stick-c'
+          fqbn: 'esp32:esp32:m5stick_stickc'
           libraries: |
             - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.2.9.zip
             - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'TallyArbiter-Listener-M5StickC'
-          path: 'listener_clients/m5stickc-listener/build/esp32.esp32.m5stick-c'
+          path: 'listener_clients/m5stickc-listener/build/esp32.esp32.m5stick_stickc'
 
   build_m5atom-listener:
     name: Build M5Atom Listener

--- a/listener_clients/TTGO_T-listener/TTGO_T-listener.ino
+++ b/listener_clients/TTGO_T-listener/TTGO_T-listener.ino
@@ -14,12 +14,12 @@ Modify User_Setup_Select.h in libraryY TFT_eSPI
 #include <WiFi.h>
 #include <WebSocketsClient.h>
 #include <SocketIOclient.h>
+#include <WiFiManager.h>
 #include <TFT_eSPI.h>
 #include <Arduino_JSON.h>
 #include <PinButton.h>
 #include <SPI.h>
 #include <Arduino.h>
-#include <WiFiManager.h>
 #include <ArduinoOTA.h>
 #include <ESPmDNS.h>
 #include <Preferences.h>
@@ -277,12 +277,12 @@ void saveParamCallback() {
 
 void WiFiEvent(WiFiEvent_t event) {
   switch (event) {
-    case SYSTEM_EVENT_STA_GOT_IP:
+    case IP_EVENT_STA_GOT_IP:
       logger("Network connected!", "info");
       logger(WiFi.localIP().toString(), "info");
       networkConnected = true;
       break;
-    case SYSTEM_EVENT_STA_DISCONNECTED:
+    case WIFI_EVENT_STA_DISCONNECTED:
       tft.setCursor(0, 0);
       tft.fillScreen(TFT_BLACK);
       tft.setTextSize(2);

--- a/listener_clients/esp32-neopixel-listener/esp32-neopixel-listener.ino
+++ b/listener_clients/esp32-neopixel-listener/esp32-neopixel-listener.ino
@@ -279,12 +279,12 @@ void saveParamCallback() {
 
 void WiFiEvent(WiFiEvent_t event) {
   switch (event) {
-    case SYSTEM_EVENT_STA_GOT_IP:
+    case IP_EVENT_STA_GOT_IP:
       logger("Network connected!", "info");
       logger(WiFi.localIP().toString(), "info");
       networkConnected = true;
       break;
-    case SYSTEM_EVENT_STA_DISCONNECTED:
+    case WIFI_EVENT_STA_DISCONNECTED:
       logger("Network connection lost!", "info");
       networkConnected = false;
       break;


### PR DESCRIPTION
Updated from actions/upload-artifact: v3 to actions/upload-artifact: v4.
Updated fqbn for M5Atom and M5Stickc. Changed - to _.
Uppdated TTGO code to new WiFiEvents.
NB: Testing of the builds have not been done, only updating the builds so that they build sucessfully. The build for TTGO fails due too large image.