### PR TITLE
Fix empty Mac-Adress | M5Atom

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -761,6 +761,9 @@ void setup() {
   //Save battery by turning off BlueTooth
   btStop();
 
+  //Initialize WiFi
+  WiFi.begin();
+
     // Initialize IMU (MPU6886) The rotation sensor
   if (M5.IMU.Init() != 0) {
     Serial.println("MPU6886 initialization failed!");


### PR DESCRIPTION
The Mac-Adress would be 00:00:00:00:00:00, because the WiFi wasn't initialized.