### PR TITLE
Draw camera number after flashing | M5Atom

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -541,6 +541,8 @@ void socket_Flash() {
   //Matrix Off
   drawNumber(icons[1], alloffcolor);
   delay(100);
+  // Draw camera number after flashing
+  drawNumber(rotatedNumber, offcolor);
   //then resume normal operation
   evaluateMode();
 }

--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -541,10 +541,10 @@ void socket_Flash() {
   //Matrix Off
   drawNumber(icons[1], alloffcolor);
   delay(100);
-  // Draw camera number after flashing
-  drawNumber(rotatedNumber, offcolor);
   //then resume normal operation
   evaluateMode();
+  // Draw camera number after flashing
+  drawNumber(rotatedNumber, offcolor);
 }
 
 void socket_Connected(const char * payload, size_t length) {


### PR DESCRIPTION
When the M5Atom is flashed, it stops showing the camera number.