### PR TITLE
Fix the camera number sometimes not getting updated | M5Atom

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -959,6 +959,12 @@ void loop(){
         delay(100);                                         // Introduce a short delay before closing
         preferences.end();                                  // Close the Preferences after saving
     }
+    
+    float accX, accY, accZ;
+
+    M5.IMU.getAccelData(&accX, &accY, &accZ);
+
+    updateDisplayBasedOnOrientation(accX, accY, accZ);
     drawNumber(rotatedNumber, offcolor);
 
     // Lets get some info sent out the serial connection for debugging


### PR DESCRIPTION
Sometimes, when you press the button on the M5Atom, it doesn't get updated, but the server still recieves it.