### PR TITLE
Update VMix.ts

### DIFF
--- a/src/_modules/VMix.ts
+++ b/src/_modules/VMix.ts
@@ -53,6 +53,13 @@ export class VMixEmulator extends ListenerProvider {
 		} else if (parts[0] === 'UNSUBSCRIBE TALLY') {
 			socket.write('UNSUBSCRIBE OK TALLY\r\n')
 			this.removeVmixListener(this.getHost(socket))
+		} else if (parts[0].startsWith('ACTS')) {
+			// reacts to ACTS commands, e.g. "ACTS Overlay1" so vMix Listener Devices work correctly (e.g. Hollyland Wireless Tally System)
+			const commandParts = parts[0].split(' ')
+			const activator = commandParts.length >= 2 ? commandParts[1] : 'Unknown'
+			const activator_status = '0'; // static response because tally state is already handled by TALLY OK ##
+			const acts_response = 'ACTS OK ${activator} ${activator_status}\r\n'
+			socket.write(acts_response)
 		} else if (parts[0] === 'QUIT') {
 			socket.destroy()
 		}


### PR DESCRIPTION
reacts to ACTS commands, e.g. "ACTS Overlay1" so vMix Listener Devices work correctly (e.g. Hollyland Wireless Tally System)


response 0 ist static, because the tally status is already handled by tallyArbiter so no need to check for overlay status again.

be aware if you´re running vMix and TallyArbiter on the same machine, there will be a conflict where hollyland will connect to, so make sure to run tallyarbiter on a different computer. But since Hollyland directly works with vMix and does this great, if you only use vMix there is no need for tallyArbiter for hollyland tally system.