### PR TITLE
Fix camera number display on boot

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -833,11 +833,19 @@ void setup() {
 
   preferences.end();
 
+  // Initialize rotatedNumber with current orientation
+  float accX, accY, accZ;
+  M5.IMU.getAccelData(&accX, &accY, &accZ);
+  updateDisplayBasedOnOrientation(accX, accY, accZ);  // Initialize rotatedNumber
+
   delay(100); //wait 100ms before moving on
   connectToNetwork(); //starts Wifi connection
   while (!networkConnected) {
     delay(200);
   }  
+
+  // Show camera number after WiFi connection
+  drawNumber(rotatedNumber, offcolor);  
 
   //debug
   //char message[200]; // Adjust the size as needed


### PR DESCRIPTION
Boot Display Fix:
The camera number wasn't appearing on initial boot until the button was pressed
Added initialization of rotatedNumber during setup
Now displays camera number immediately after WiFi connection