### PR TITLE
feat: Add MQTT integration

### DIFF
--- a/src/_modules/MQTT.ts
+++ b/src/_modules/MQTT.ts
@@ -169,6 +169,7 @@ export class MQTTService extends EventEmitter {
 				busId: deviceState.busId,
 				busLabel: bus.label,
 				busType: bus.type,
+				busColor: bus.color,
 				sources: deviceState.sources,
 				timestamp: new Date().toISOString(),
 			})


### PR DESCRIPTION
Add MQTT support to publish TallyArbiter device and bus states to MQTT brokers for integration with Home Assistant and other various platforms.

- Publish device states as JSON with full source information
- Publish individual bus states (Preview/Program/Aux) for each device
- Simple ON/OFF state topics for Home Assistant binary sensors
- Configurable broker, credentials, topic prefix, QoS, and retention
- Automatic reconnection and error handling
- Service and device availability status topics

Configuration added to config.json:
- enabled (default: false), broker (default: "localhost"), port (default: 1883), username (optional), password (optional)
- topicPrefix (default: "tallyarbiter"), retain (default: true), qos (default: 0), reconnectPeriod (default: 5000), connectTimeout (default: 10000), keepalive (default: 60), clientId (default: '', auto-generates an id of `tallyarbiter_${Date.now()}` if not set)

An example of how this could be integrated into HomeAssistant, allows you to use the data coming from TallyArbiter to link various states up to a massive number of devices (Hue lights, Zigbee, Z-Wave lights, ESPHome, etc) although not without additional delay when states change compared to directly listening to the TallyArbiter server: 
![firefox_AnHeE79qGz](https://github.com/user-attachments/assets/a549a400-07a8-4ecb-851f-0e92ea0f6e1f)

Another example of this being useful would be to directly integrate the MQTT data into any ESPHome compatible devices as customized listeners without require people to build custom arduino code.

Untested example of configuring an M5StickC Plus2 as an MQTT-based tally: https://gist.github.com/JonBons/2e87ef6778ad32ef6cc107903c38237c