### PR TITLE
Added default disabling of wifi sleep mode on M5StickC Listener

### DIFF
--- a/listener_clients/m5stickc-listener/m5stickc-listener.ino
+++ b/listener_clients/m5stickc-listener/m5stickc-listener.ino
@@ -97,6 +97,11 @@ String listenerDeviceHW = "M5StickC";
     Change the following variables before compiling and sending the code to your device.
 */
 
+// WiFi Power Management
+// Set to true to disable WiFi sleep mode (recommended for real-time tally updates)
+// Set to false to allow WiFi sleep mode (saves battery but may cause message delays)
+#define DISABLE_WIFI_SLEEP true
+
 bool LAST_MSG = false;  // true = show log on tally screen
 
 //Tally Arbiter Server
@@ -403,6 +408,9 @@ WiFiManagerParameter *custom_taServer;
 WiFiManagerParameter *custom_taPort;
 
 void connectToNetwork() {
+#if DISABLE_WIFI_SLEEP
+  WiFi.setSleep(false); // Disable WiFi sleep mode
+#endif
   WiFi.mode(WIFI_STA);  // explicitly set mode, esp defaults to STA+AP
   logger("Connecting to SSID: " + String(WiFi.SSID()), "info");
 


### PR DESCRIPTION
On my network I was encountering weird 10-20s delays between tally updates due to device wifi going to sleep. I'm sure this could increase power consumption but it's a trade-off I'm willing to accept for more reliable tally usage.

I was seeing events show up (with additional debug logging) with timestamps like this in batches of 20-40+ device_states messages all at the same time with 20 seconds in-between the last batch.
```
[00:00:20.014] Got device_states (225 bytes)
[00:00:20.018] Got device_states (225 bytes)
[00:00:20.022] Got device_states (225 bytes)
[00:00:20.025] Got device_states (235 bytes)
[00:00:20.028] Got device_states (235 bytes)
[00:00:20.031] Got device_states (235 bytes)
[00:00:20.034] Got device_states (235 bytes)
[00:00:20.037] Got device_states (225 bytes)
[00:00:20.050] Got device_states (225 bytes)
[00:00:20.053] Got device_states (225 bytes)
[00:00:20.056] Got device_states (225 bytes)
[00:00:20.059] Got device_states (225 bytes)
[00:00:20.062] Got device_states (225 bytes)
[00:00:20.066] Got device_states (225 bytes)
[00:00:20.069] Got device_states (225 bytes)
[00:00:20.072] Got device_states (235 bytes)
[00:00:20.075] Got device_states (235 bytes)
[00:00:20.078] Got device_states (235 bytes)
[00:00:20.091] Got device_states (235 bytes)
[00:00:40.013] Got device_states (225 bytes)
[00:00:40.017] Got device_states (225 bytes)
[00:00:40.021] Got device_states (225 bytes)
[00:00:40.024] Got device_states (225 bytes)
[00:00:40.027] Got device_states (225 bytes)
[00:00:40.030] Got device_states (225 bytes)
[00:00:40.033] Got device_states (225 bytes)
[00:00:40.036] Got device_states (225 bytes)
[00:00:40.039] Got device_states (235 bytes)
[00:00:40.042] Got device_states (235 bytes)
[00:00:40.045] Got device_states (235 bytes)
[00:00:40.058] Got device_states (235 bytes)
```
