### PR TITLE
feat(ui): Add config validation warnings with auto-fix

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -458,6 +458,41 @@
 						<i class="fas fa-exclamation-triangle"></i> Please note that updating your config manually shouldn't be
 						necesary and it's not recommended. Continue at your own risk.
 					</div>
+					<div class="row" *ngIf="configWarnings.length > 0">
+						<h3>Config Warnings</h3>
+						<div class="alert alert-warning" role="alert">
+							<div class="d-flex justify-content-between align-items-center mb-3">
+								<p class="mb-0"><i class="fas fa-exclamation-triangle"></i> Some configuration properties are missing and will use default values.</p>
+								<button 
+									class="btn btn-warning" 
+									(click)="fixAllConfigWarnings()"
+									[title]="'Apply all default values (' + configWarnings.length + ' fixes)'"
+								>
+									<i class="fas fa-wrench"></i> Fix All ({{ configWarnings.length }})
+								</button>
+							</div>
+							<div *ngFor="let warning of configWarnings" class="mb-2">
+								<div class="d-flex align-items-center">
+									<i 
+										class="fas fa-exclamation-circle text-warning me-2" 
+										style="cursor: pointer; font-size: 1.2em;"
+										[title]="warning.message + ' Double-click to apply fix.'"
+										(dblclick)="fixConfigWarning(warning)"
+									></i>
+									<span class="flex-grow-1">
+										<strong>{{ warning.path }}:</strong> {{ warning.message }}
+									</span>
+									<button 
+										class="btn btn-sm btn-warning ms-2" 
+										(click)="fixConfigWarning(warning)"
+										[title]="'Apply default value for ' + warning.path"
+									>
+										<i class="fas fa-wrench"></i> Fix
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
 					<div class="row">
 						<h3>Config editor</h3>
 						<json-editor

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -156,6 +156,29 @@ export class SettingsComponent {
 				this.updatedConfig = config
 				this.updatedRawConfig = JSON.stringify(config, null, 2)
 				this.configLoaded = true
+				// Check for warnings on initial load - validation will happen when editor is ready
+				// Use setTimeout to ensure editor is initialized
+				setTimeout(() => {
+					let errors: any[] = []
+					try {
+						if (this.configEditor) {
+							const editorJson = this.configEditor.getEditor()
+							if (editorJson) {
+								editorJson.validate()
+								if (editorJson.validateSchema && editorJson.validateSchema.errors) {
+									errors = editorJson.validateSchema.errors || []
+								} else if (editorJson.validator && editorJson.validator.errors) {
+									errors = editorJson.validator.errors || []
+								} else if ((editorJson as any).ajv && (editorJson as any).ajv.errors) {
+									errors = (editorJson as any).ajv.errors || []
+								}
+							}
+						}
+					} catch (e) {
+						console.error('Error validating config on load:', e)
+					}
+					this.checkConfigWarnings(config, errors)
+				}, 100)
 			})
 			this.socketService.socket.emit('get_unread_error_reports')
 			this.socketService.socket.emit('get_config')
@@ -799,20 +822,449 @@ export class SettingsComponent {
 		})
 	}
 
+	public configWarnings: Array<{ path: string; message: string; fix: () => void }> = []
+
 	public configUpdated(event: any) {
-		console.log(event, this.configEditor)
 		this.updatedConfig = event
 		this.updatedRawConfig = JSON.stringify(event, null, 2)
 
-		const editorJson = this.configEditor.getEditor()
-		console.log(editorJson)
-		editorJson.validate()
-		const errors = editorJson.validateSchema.errors
+		// Get validation errors from the JSON editor (it uses Ajv internally)
+		let errors: any[] = []
+		try {
+			if (this.configEditor) {
+				const editorJson = this.configEditor.getEditor()
+				if (editorJson) {
+					// Trigger validation
+					editorJson.validate()
+					
+					// Try to access validation errors from the editor
+					// jsoneditor uses Ajv internally and stores errors in validateSchema.errors
+					if (editorJson.validateSchema && editorJson.validateSchema.errors) {
+						errors = editorJson.validateSchema.errors || []
+					} else if (editorJson.validator && editorJson.validator.errors) {
+						errors = editorJson.validator.errors || []
+					} else if ((editorJson as any).ajv && (editorJson as any).ajv.errors) {
+						// Direct access to Ajv instance
+						errors = (editorJson as any).ajv.errors || []
+					}
+				}
+			}
+		} catch (e) {
+			console.error('Error accessing validation errors:', e)
+		}
+		
+		
 		if (errors && errors.length > 0) {
 			this.updatedConfigValid = false
 		} else {
 			this.updatedConfigValid = true
 		}
+
+		// Check for missing optional properties that should have defaults
+		// Also check for missing required properties from schema validation
+		this.checkConfigWarnings(event, errors)
+	}
+
+	private checkConfigWarnings(config: any, schemaErrors: any[] = []) {
+		const warnings: Array<{ path: string; message: string; fix: () => void }> = []
+		
+		// Check for missing top-level properties
+		const defaults = this.getConfigDefaults()
+		this.findMissingProperties(config, defaults, '', warnings)
+		
+		// Check for missing required properties from schema validation errors
+		if (schemaErrors && schemaErrors.length > 0) {
+			this.parseSchemaValidationErrors(schemaErrors, config, warnings)
+		}
+		
+		this.configWarnings = warnings
+	}
+
+	private getConfigDefaults(): any {
+		// These should match ConfigDefaults from src/_helpers/config.ts
+		return {
+			security: {
+				jwt_private_key: '',
+			},
+			users: [],
+			cloud_destinations: [],
+			cloud_keys: [],
+			device_actions: [],
+			device_sources: [],
+			devices: [],
+			sources: [],
+			tsl_clients: [],
+			tsl_clients_1secupdate: false,
+			bus_options: [
+				{ id: 'e393251c', label: 'Preview', type: 'preview', color: '#3fe481', priority: 50, visible: true },
+				{ id: '334e4eda', label: 'Program', type: 'program', color: '#e43f5a', priority: 200, visible: true },
+				{ id: '12c8d699', label: 'Aux 1', type: 'aux', color: '#0000FF', priority: 100, visible: true },
+				{ id: '0449b0c7', label: 'Aux 2', type: 'aux', color: '#0000FF', priority: 100, visible: true },
+				{ id: '5d94f273', label: 'Aux 3', type: 'aux', color: '#0000FF', priority: 100, visible: false },
+				{ id: '77ffb605', label: 'Aux 4', type: 'aux', color: '#0000FF', priority: 100, visible: false },
+				{ id: '09d4975d', label: 'Aux 5', type: 'aux', color: '#0000FF', priority: 100, visible: false },
+				{ id: 'e2c2e192', label: 'Aux 6', type: 'aux', color: '#0000FF', priority: 100, visible: false },
+				{ id: '734f7395', label: 'Aux 7', type: 'aux', color: '#0000FF', priority: 100, visible: false },
+				{ id: '3011d34a', label: 'Aux 8', type: 'aux', color: '#0000FF', priority: 100, visible: false },
+			],
+			externalAddress: 'http://0.0.0.0:4455/#/tally',
+			remoteErrorReporting: false,
+			uuid: '',
+			mqtt: {
+				enabled: false,
+				broker: 'localhost',
+				port: 1883,
+				username: '',
+				password: '',
+				topicPrefix: 'tallyarbiter',
+				retain: true,
+				qos: 0,
+			},
+		}
+	}
+
+	private findMissingProperties(config: any, defaults: any, path: string, warnings: Array<{ path: string; message: string; fix: () => void }>) {
+		for (const [key, defaultValue] of Object.entries(defaults)) {
+			const currentPath = path ? `${path}.${key}` : key
+			
+			// Check if property exists in config
+			if (config[key] === undefined) {
+				// Property is missing
+				if (Array.isArray(defaultValue)) {
+					warnings.push({
+						path: currentPath,
+						message: `Property "${currentPath}" is missing. Default value: empty array []`,
+						fix: () => {
+							this.applyPropertyDefault(currentPath, defaultValue)
+						},
+					})
+				} else if (defaultValue !== null && typeof defaultValue === 'object' && !Array.isArray(defaultValue)) {
+					// It's an object - warn about missing object
+					warnings.push({
+						path: currentPath,
+						message: `Property "${currentPath}" is missing. This will be added with default values.`,
+						fix: () => {
+							this.applyPropertyDefault(currentPath, defaultValue)
+						},
+					})
+				} else {
+					// Primitive value
+					const displayValue = typeof defaultValue === 'string' && defaultValue.length > 50 
+						? defaultValue.substring(0, 50) + '...' 
+						: JSON.stringify(defaultValue)
+					warnings.push({
+						path: currentPath,
+						message: `Property "${currentPath}" is missing. Default value: ${displayValue}`,
+						fix: () => {
+							this.applyPropertyDefault(currentPath, defaultValue)
+						},
+					})
+				}
+			} else if (defaultValue !== null && typeof defaultValue === 'object' && !Array.isArray(defaultValue) && typeof config[key] === 'object' && !Array.isArray(config[key])) {
+				// Both are objects - recurse to check nested properties
+				this.findMissingProperties(config[key], defaultValue, currentPath, warnings)
+			}
+			// If config[key] exists and is not an object, or if it's an array, we don't need to check further
+		}
+	}
+
+	private parseSchemaValidationErrors(errors: any[], config: any, warnings: Array<{ path: string; message: string; fix: () => void }>) {
+		if (!errors || errors.length === 0) {
+			return
+		}
+		
+		const arrayItemDefaults = this.getArrayItemDefaults()
+		
+		for (const error of errors) {
+			
+			// Only handle "required" errors (missing required properties)
+			if (error.keyword === 'required' && error.params && error.params.missingProperty) {
+				const missingProperty = error.params.missingProperty
+				// Try different path properties (AJV v6 vs v7+)
+				const dataPath = error.dataPath || error.instancePath || error.path || ''
+				
+				// Parse the dataPath - format is ".device_sources[0]"
+				// Remove leading dot and extract property name and index
+				const cleanPath = dataPath.replace(/^\.+/, '')
+				const match = cleanPath.match(/^([^[\]]+)\[(\d+)\]$/)
+				
+				if (!match) {
+					console.warn(`Unexpected path format: ${dataPath}`)
+					continue
+				}
+				
+				const pathParts = [match[1], match[2]] // ["device_sources", "0"]
+				const displayPath = `${match[1]}[${match[2]}].${missingProperty}`
+				const defaultValue = this.getDefaultValueForProperty(pathParts, missingProperty, arrayItemDefaults)
+				
+				// Create fix function
+				const fix = () => {
+					this.applyPropertyDefaultFromPath(pathParts, missingProperty, defaultValue)
+				}
+				
+				// Check if we already have a warning for this path
+				const existingWarning = warnings.find(w => w.path === displayPath)
+				if (!existingWarning) {
+					const displayValue = typeof defaultValue === 'string' && defaultValue.length > 50 
+						? defaultValue.substring(0, 50) + '...' 
+						: JSON.stringify(defaultValue)
+					
+					warnings.push({
+						path: displayPath,
+						message: `Missing required property "${missingProperty}". Default value: ${displayValue}`,
+						fix: fix,
+					})
+				}
+			}
+		}
+	}
+	
+	private getArrayItemDefaults(): any {
+		// Default values for properties within array items
+		return {
+			device_sources: {
+				reconnect_interval: 5000,
+				max_reconnects: 5,
+				rename: false,
+				bus: '',
+				address: '',
+				deviceId: '',
+				id: '',
+				sourceId: '',
+			},
+			device_actions: {
+				active: false,
+			},
+			devices: {},
+			sources: {
+				reconnect_interval: 5000,
+				max_reconnects: 5,
+			},
+		}
+	}
+	
+	private getDefaultValueForProperty(pathParts: string[], propertyName: string, arrayItemDefaults: any): any {
+		// If this is an array item (pathParts has a numeric last part)
+		if (pathParts.length >= 2) {
+			const arrayName = pathParts[pathParts.length - 2]
+			const itemDefaults = arrayItemDefaults[arrayName]
+			if (itemDefaults && itemDefaults[propertyName] !== undefined) {
+				return itemDefaults[propertyName]
+			}
+		}
+		
+		// Default based on property name patterns
+		if (propertyName.includes('interval') || propertyName.includes('Interval')) {
+			return 5000
+		}
+		if (propertyName.includes('reconnect') || propertyName.includes('Reconnect')) {
+			return 5
+		}
+		if (propertyName.includes('enabled') || propertyName.includes('Enabled') || propertyName.includes('active') || propertyName.includes('Active')) {
+			return false
+		}
+		if (propertyName.includes('rename') || propertyName.includes('Rename')) {
+			return false
+		}
+		if (propertyName.includes('id') || propertyName.includes('Id')) {
+			return ''
+		}
+		// For string properties like "bus", "address", etc., return empty string
+		if (propertyName === 'bus' || propertyName === 'address' || propertyName === 'name' || propertyName === 'label') {
+			return ''
+		}
+		
+		// Generic defaults - return empty string for unknown properties (safer than null)
+		// This prevents type errors when the schema expects a string but gets null
+		return ''
+	}
+	
+	private applyPropertyDefaultFromPath(pathParts: string[], propertyName: string, defaultValue: any) {
+		// Create a working copy to avoid mutating the original during navigation
+		let target: any = this.updatedConfig
+		
+		console.log(`Applying fix: path=${pathParts.join('.')}, property=${propertyName}, value=${defaultValue}`)
+		
+		// Navigate to the target object
+		for (let i = 0; i < pathParts.length; i++) {
+			const part = pathParts[i]
+			// Check if part is a numeric index (array)
+			const index = parseInt(part, 10)
+			const isNumericIndex = !isNaN(index) && part === index.toString()
+			
+			if (isNumericIndex) {
+				// It's a numeric index - target should be an array
+				if (!Array.isArray(target)) {
+					console.warn(`Expected array at ${pathParts.slice(0, i).join('.')}, got ${typeof target}`)
+					return
+				}
+				if (target[index] === undefined) {
+					console.warn(`Array index ${index} does not exist in ${pathParts.slice(0, i).join('.')}`)
+					return
+				}
+				target = target[index]
+			} else {
+				// It's a property name
+				if (target[part] === undefined) {
+					// Check if next part is a numeric index - if so, this should be an array
+					if (i < pathParts.length - 1) {
+						const nextPart = pathParts[i + 1]
+						const nextIndex = parseInt(nextPart, 10)
+						if (!isNaN(nextIndex) && nextPart === nextIndex.toString()) {
+							// Next part is an array index, so this should be an array
+							target[part] = []
+						} else {
+							target[part] = {}
+						}
+					} else {
+						// This is the final part, but we're setting a property on it, so it should be an object
+						// This shouldn't happen for array item fixes, but handle it anyway
+						target[part] = {}
+					}
+				} else if (!Array.isArray(target[part]) && typeof target[part] !== 'object') {
+					// If it's not an object or array, we can't navigate further
+					console.warn(`Cannot navigate to property ${part} in path ${pathParts.join('.')} - not an object`)
+					return
+				}
+				target = target[part]
+			}
+		}
+		
+		// Set the property value on the array item object
+		target[propertyName] = defaultValue
+		
+		// Create a deep copy to ensure Angular detects the change
+		const newConfig = JSON.parse(JSON.stringify(this.updatedConfig))
+		this.updatedConfig = newConfig
+		this.config = newConfig
+		this.updatedRawConfig = JSON.stringify(newConfig, null, 2)
+		
+		// Revalidate after editor updates
+		setTimeout(() => {
+			this.configUpdated(newConfig)
+		}, 200)
+	}
+
+	private applyPropertyDefault(path: string, defaultValue: any) {
+		const pathParts = path.split('.')
+		let target: any = this.updatedConfig
+		
+		// Navigate to the parent object
+		for (let i = 0; i < pathParts.length - 1; i++) {
+			const part = pathParts[i]
+			if (!target[part] || typeof target[part] !== 'object') {
+				target[part] = {}
+			}
+			target = target[part]
+		}
+		
+		// Set the value
+		const finalKey = pathParts[pathParts.length - 1]
+		
+		// If it's an object, merge with existing values
+		if (defaultValue !== null && typeof defaultValue === 'object' && !Array.isArray(defaultValue)) {
+			target[finalKey] = {
+				...defaultValue,
+				...(target[finalKey] || {}),
+			}
+		} else {
+			target[finalKey] = defaultValue
+		}
+		
+		// Create a deep copy to ensure we have a fresh object reference
+		const newConfig = JSON.parse(JSON.stringify(this.updatedConfig))
+		
+		// Update all config references with the new deep copy
+		this.updatedConfig = newConfig
+		this.config = newConfig  // This is bound to [data] in the template, so updating it will update the editor
+		this.updatedRawConfig = JSON.stringify(newConfig, null, 2)
+		
+		// Trigger validation and recheck warnings after Angular updates the editor
+		setTimeout(() => {
+			this.configUpdated(newConfig)
+		}, 200)
+	}
+
+	public fixConfigWarning(warning: { path: string; message: string; fix: () => void }) {
+		warning.fix()
+		Swal.fire({
+			title: 'Fixed!',
+			text: `Applied default value for ${warning.path}`,
+			icon: 'success',
+			timer: 2000,
+			showConfirmButton: false,
+			...globalSwalOptions,
+		})
+	}
+
+	public fixAllConfigWarnings() {
+		if (this.configWarnings.length === 0) {
+			return
+		}
+
+		// Collect all changes that will be applied
+		const changes: Array<{ path: string; value: string }> = []
+		for (const warning of this.configWarnings) {
+			// Extract the value from the warning message
+			const valueMatch = warning.message.match(/Default value: (.+)$/)
+			const displayValue = valueMatch ? valueMatch[1] : 'default'
+			changes.push({
+				path: warning.path,
+				value: displayValue,
+			})
+		}
+
+		// Apply all fixes by directly modifying the config
+		// This is more efficient than calling each fix() individually
+		const config: any = this.updatedConfig
+		for (const warning of this.configWarnings) {
+			// Extract path parts from warning path (e.g., "device_sources[0].bus" -> ["device_sources", "0", "bus"])
+			const pathMatch = warning.path.match(/^([^[\]]+)\[(\d+)\]\.(.+)$/)
+			if (pathMatch) {
+				const arrayName = pathMatch[1]
+				const index = parseInt(pathMatch[2], 10)
+				const propertyName = pathMatch[3]
+				
+				// Get the default value
+				const arrayItemDefaults = this.getArrayItemDefaults()
+				const defaultValue = this.getDefaultValueForProperty([arrayName, index.toString()], propertyName, arrayItemDefaults)
+				
+				// Apply the fix directly
+				if (config[arrayName] && Array.isArray(config[arrayName]) && config[arrayName][index]) {
+					config[arrayName][index][propertyName] = defaultValue
+				}
+			} else {
+				// For non-array paths, use the existing fix function
+				warning.fix()
+			}
+		}
+
+		// Create a deep copy and update all references
+		const newConfig = JSON.parse(JSON.stringify(this.updatedConfig))
+		this.updatedConfig = newConfig
+		this.config = newConfig
+		this.updatedRawConfig = JSON.stringify(newConfig, null, 2)
+
+		// Revalidate after all fixes are applied
+		setTimeout(() => {
+			this.configUpdated(newConfig)
+			
+			// Show summary of changes
+			let summaryHtml = `<div style="text-align: left;"><p><strong>Applied ${changes.length} fixes:</strong></p><ul style="margin-top: 10px; max-height: 400px; overflow-y: auto;">`
+			for (const change of changes) {
+				summaryHtml += `<li style="margin-bottom: 5px;"><strong>${change.path}</strong>: <code>${change.value}</code></li>`
+			}
+			summaryHtml += '</ul></div>'
+
+			Swal.fire({
+				title: 'All Fixed!',
+				html: summaryHtml,
+				icon: 'success',
+				confirmButtonText: 'OK',
+				width: '600px',
+				...globalSwalOptions,
+			})
+		}, 300)
 	}
 
 	@Confirmable('Are you sure you want to update your config? Be careful and continue only if you are absolutely sure.')
@@ -857,12 +1309,52 @@ export class SettingsComponent {
 						this.config = JSON.parse(result)
 						this.updatedConfig = this.config
 						this.updatedRawConfig = JSON.stringify(this.config, null, 2)
+						
+						// Update the JSON editor with the new config
+						if (this.configEditor) {
+							this.configEditor.set(this.config as any)
+						}
+						
+						// Trigger validation and check for warnings after import
+						setTimeout(() => {
+							let errors: any[] = []
+							try {
+								if (this.configEditor) {
+									const editorJson = this.configEditor.getEditor()
+									if (editorJson) {
+										editorJson.validate()
+										if (editorJson.validateSchema && editorJson.validateSchema.errors) {
+											errors = editorJson.validateSchema.errors || []
+										} else if (editorJson.validator && editorJson.validator.errors) {
+											errors = editorJson.validator.errors || []
+										} else if ((editorJson as any).ajv && (editorJson as any).ajv.errors) {
+											errors = (editorJson as any).ajv.errors || []
+										}
+									}
+								}
+							} catch (err) {
+								console.error('Error validating imported config:', err)
+							}
+							
+							// Update validation status
+							if (errors && errors.length > 0) {
+								this.updatedConfigValid = false
+							} else {
+								this.updatedConfigValid = true
+							}
+							
+							// Check for warnings with validation errors
+							this.checkConfigWarnings(this.config, errors)
+						}, 100)
+						
 						this.socketService.socket.emit('set_config', this.config)
 					}
 				}
 				reader.readAsText((input.files as FileList)[0])
 			}
 			input.click()
-		} catch (e) {}
+		} catch (e) {
+			console.error('Error importing config:', e)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds a system to detect missing required config properties and provide one-click fixes with default values. Includes individual fix buttons and a "Fix All" option with change summary. 

I have instances of TallyArbiter that work fine but have warnings from configs of older version that I've upgraded but they prevent me from applying any further changes and I've not bothered to try and fix them across all of those instances, this helps with that.

- Parse JSON schema validation errors to find missing properties
- Display warnings with suggested defaults
- Apply fixes directly to config without creating duplicates
- Support nested array items (e.g., device_sources[0].bus)
- Revalidate after config import

## Problem

When editing the configuration JSON manually, users often encounter validation errors for missing required properties (e.g., `bus`, `reconnect_interval`, `max_reconnects` in `device_sources`). These errors were visible in the JSON editor but required manual fixes, which could be tedious and error-prone.

### Auto-Validation
- Re-validates configuration after applying fixes
- Re-checks warnings after importing a config file
- Updates warnings in real-time as the config is edited

## Testing

### Manual Testing Steps

1. **Test Missing Properties**:
   - Export and save a working config to a file
   - Edit config file to remove a few required properties (e.g., `bus`, `reconnect_interval`. `max_reconnects` from a `device_sources` entry)
   - Import edited bad config file
   - Verify warning appears with correct path and default value
   - Click "Fix" button
   - Verify property is added with correct default value
   - Verify warning disappears

2. **Test Fix All**:
   - Create a config with multiple missing properties
   - Verify all warnings appear
   - Click "Fix All" button
   - Verify summary dialog shows all changes
   - Verify all properties are fixed
   - Verify all warnings disappear
