### PR TITLE
Fix issue #877 blink 1 precedence

### DIFF
--- a/listener_clients/blink1-listener/blink1-listener.py
+++ b/listener_clients/blink1-listener/blink1-listener.py
@@ -283,7 +283,7 @@ def processTallyData():
         doBlink(0, 0, 0)
     else:
         try:
-            busses_list.sort(key=lambda x: x["priority"])
+            busses_list.sort(key=lambda x: x["priority"], reverse=True)
         except:
             return
         current_color = hex_to_rgb(busses_list[0]["color"])


### PR DESCRIPTION
Fixes an issue whereby the blink1 shows in preview rather than program when both preview and program are selected for an input. Fix as proposed by joesephadams is to reverse the sort by priority to ensure these are ordered correctly.