### PR TITLE
camera support at device level

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -849,6 +849,22 @@
 				[(ngModel)]="currentDevice.tslAddress"
 			/>
 		</div>
+		<hr class="my-3">
+		<div class="mb-3">
+			<label for="deviceCameraIP" class="form-label">
+				Camera IP
+				<span class="ta-tooltip" data-tip="If your camera supports tally natively, use this feature to send tally commands directly to it.">ⓘ</span>
+			</label>
+			<input type="text" class="form-control" id="deviceCameraIP" [(ngModel)]="currentDevice.cameraIP" />
+			<label for="deviceCameraModel" class="form-label mt-2">Camera Model</label>
+			<select class="form-select" id="deviceCameraModel" [(ngModel)]="currentDevice.cameraModel">
+				<option value="">-- Select Model --</option>
+				<option *ngFor="let cameraModel of socketService.cameraModels" [value]="cameraModel.id">
+					{{ cameraModel.label }}
+				</option>
+			</select>
+		</div>
+		<hr class="my-3">
 		<div class="mb-3">
 			<b>Linked Busses:</b><br />
 			<small>

--- a/UI/src/app/_services/socket.service.ts
+++ b/UI/src/app/_services/socket.service.ts
@@ -7,6 +7,7 @@ import { CloudClient } from '../_models/CloudClient'
 import { CloudDestination } from '../_models/CloudDestination'
 import { Message } from '../_models/Message'
 import { Device } from '../_models/Device'
+import { CameraModel } from '../_models/CameraModels'
 import { DeviceAction } from '../_models/DeviceAction'
 import { DeviceSource } from '../_models/DeviceSource'
 import { ListenerClient } from '../_models/ListenerClient'
@@ -34,6 +35,7 @@ import { User } from '../_models/User'
 export class SocketService {
 	public socket: Socket
 	public devices: Device[] = []
+	public cameraModels: CameraModel[] = []
 	public device_states: DeviceState[] = []
 	public currentDeviceIdx?: number
 	public mode_preview?: boolean
@@ -238,6 +240,7 @@ export class SocketService {
 				busOptions: BusOption[],
 				sourcesData: Source[],
 				devicesData: Device[],
+				cameraModels: CameraModel[],
 				deviceSources: DeviceSource[],
 				deviceActions: DeviceAction[],
 				device_states: DeviceState[],
@@ -256,6 +259,7 @@ export class SocketService {
 				this.busOptionsVisible = busOptions.filter((b) => b.visible == true || b.visible == undefined)
 				this.sources = this.prepareSources(sourcesData)
 				this.devices = devicesData
+				this.cameraModels = cameraModels.filter((cm) => cm.visible == true || cm.visible == undefined)
 				this.deviceSources = deviceSources
 				this.deviceActions = deviceActions
 				this.device_states = device_states

--- a/src/_models/CameraModels.ts
+++ b/src/_models/CameraModels.ts
@@ -1,0 +1,10 @@
+export interface CameraModel {
+    id: string
+    label: string
+    visible: boolean
+}
+
+export const CameraModels: CameraModel[] = [
+    { id: 'canon_xc', label: 'Canon PTZ Camera (XC Protocol)', visible: true },
+    // Add more camera models as needed and support for them in 
+]

--- a/src/_models/Device.ts
+++ b/src/_models/Device.ts
@@ -11,4 +11,6 @@ export interface Device {
 	listenerCount?: number
 	modePreview?: boolean
 	modeProgram?: boolean
+	cameraIP?: string
+	cameraModel?: string
 }


### PR DESCRIPTION
this PR adds support for controlling tally states for cameras at a device level. So if for example your device is actually a Canon PTZ camera, you can add its IP and camera model to the device and then any time the tally state changes, the correct command will be sent to the camera automatically rather than the user having to deal with multiple device actions.