### PR TITLE
Fix device state for devices with multiple sources from the same physical source

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1389,37 +1389,22 @@ function UpdateDeviceState(deviceId: string) {
 				}
 			}
 		} else {
-			// bus is unlinked
-			for (let i = 0; i < deviceSources.length; i++) {
-				let deviceSource = deviceSources[i]
+			// bus is unlinked – active if ANY device source is on this bus (OR logic)
+			const anySourceInBus = deviceSources.some((deviceSource) => {
+				const data = SourceClients[deviceSource.sourceId]?.tally?.value || []
+				return !!data?.[deviceSource.address]?.includes(bus.id)
+			})
 
-				let data = SourceClients[deviceSource.sourceId]?.tally?.value || []
-
-				if (data?.[deviceSource.address]?.includes(bus.id)) {
-					//if the current source tally data includes this bus
-					//if the current source tally data includes this bus
-					//console.log('pushing', bus.label);
-					currentDeviceTallyData[device.id].push(bus.id)
-					if (!previousBusses.includes(bus.id)) {
-						RunAction(deviceId, bus.id, true)
-					}
-				} else {
-					if (previousBusses.includes(bus.id)) {
-						RunAction(deviceId, bus.id, false)
-					}
-				}
-			}
-			/*if (deviceSources.findIndex((s) => currentSourceTallyData?.[s.sourceId]?.includes(bus.id)) !== -1) { //if the current source tally data includes this bus
-				console.log('pushing', bus.label);
-				currentDeviceTallyData[device.id].push(bus.id);
+			if (anySourceInBus) {
+				currentDeviceTallyData[device.id].push(bus.id)
 				if (!previousBusses.includes(bus.id)) {
-					RunAction(deviceId, bus.id, true);
+					RunAction(deviceId, bus.id, true)
 				}
 			} else {
 				if (previousBusses.includes(bus.id)) {
-					RunAction(deviceId, bus.id, false);
+					RunAction(deviceId, bus.id, false)
 				}
-			}*/
+			}
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1168,7 +1168,7 @@ function getDeviceStates(deviceId?: string): DeviceState[] {
 					// TODO: Check if this can be replaced with deviceSources.findIndex((s) and refactored to reduce duplicated code.
 					let num = 0
 					for (let i = 0; i < deviceSources.length; i++) {
-						if (currentSourceTallyData?.[deviceSources[i].sourceId]?.includes(b.id)) {
+						if (currentSourceTallyData?.[deviceSources[i].id]?.includes(b.id)) {
 							num++
 						}
 					}
@@ -1371,7 +1371,7 @@ function UpdateDeviceState(deviceId: string) {
 			// TODO: This should be replaced with deviceSources.findIndex((s).
 			let num = 0
 			for (let i = 0; i < deviceSources.length; i++) {
-				if (currentSourceTallyData?.[deviceSources[i].sourceId]?.includes(bus.id)) {
+				if (currentSourceTallyData?.[deviceSources[i].id]?.includes(bus.id)) {
 					//if the current tally data includes this bus
 					num++
 				}
@@ -1551,7 +1551,7 @@ function initializeSource(source: Source): TallyInput {
 			//console.log('device_source', device_source);
 			//console.log('busses', busses);
 			if (device_source) {
-				tallyData[device_source.sourceId] = busses
+				tallyData[device_source.id] = busses
 			}
 		}
 		//console.log('tallyData', tallyData);


### PR DESCRIPTION
Fixes #930, #890

### Summary

- **Fix key collision in `currentSourceTallyData`:** When a device has multiple sources from the same physical source (e.g. two ATEM inputs), `device_source.sourceId` is identical for all of them. Using it as the key in `tallyData` caused later entries to overwrite earlier ones — only the last-processed address was reflected in the device state. Now uses `device_source.id` (the unique mapping ID) as key, and updates the corresponding lookups in `UpdateDeviceState` and `getDeviceStates` to match.
- **Fix unlinked bus OR logic:** The per-source loop in the unlinked bus path called `RunAction(false)` for each source not on a bus, even when another source of the same device was already active on it. This incorrectly deactivated a bus that should remain active. Replaced with a single `.some()` check so an unlinked bus stays active as long as at least one device source is on it. Also removes a dead commented-out code block.

### Side effects

- The `tally_data` socket event now correctly emits `device_source.id` as the address parameter, which the settings UI already expects (`deviceSources.find((ds) => ds.id === address)`). This fixes a silent bug where device names were never correctly shown in the tally log view.

### Regression safety

| Scenario | Risk |
|---|---|
| Single-source device (OBS, vMix, TSL, etc.) | **None** — semantically identical, one entry per device source |
| Multi-source device, different physical sources, unlinked bus | **None** — unlinked path reads `SourceClients` directly |
| Multi-source device, different physical sources, linked bus | **None** — one entry per source, lookup equivalent |
| Multi-source device, same physical source (the bug case) | **Intended** — this is the fix |
| Cloud path | **None** — `device_source.id` is synced via `cloud_device_sources` event |

### Test plan

- [X] Device with 2 sources from same ATEM: both sources reflect correct tally state independently
- [X] Device with 2 unlinked sources: Source A on bus, Source B not → bus stays active
- [X] Device with 2 unlinked sources: neither on bus → bus inactive
- [X] Device with 2 linked sources: both on bus → bus active (AND preserved)
- [X] Device with 2 linked sources: one not on bus → bus inactive (AND preserved)
- [X] Single-source device: behavior unchanged
- [X] Settings UI tally log: device name displays correctly
