### PR TITLE
fix(ContributionTally): use arrow function in UDP listening handler

### DIFF
--- a/src/sources/ContributionTally.ts
+++ b/src/sources/ContributionTally.ts
@@ -163,8 +163,8 @@ export class CTPSource extends TallyInput {
 				this.processCTPData(data)
 			})
 
-			this.server.on('listening', function () {
-				var address = this.server.address()
+			this.server.on('listening', () => {
+				const address = this.server.address()
 				console.log('listening on :' + address.address + ':' + address.port)
 			})
 


### PR DESCRIPTION
Inside the UDP `'listening'` callback, `function () {}` rebinds `this` to the socket, so `this.server.address()` throws `TypeError: Cannot read properties of undefined (reading 'address')` (#953). PanasonicAVHS410 already uses the arrow form for the same listener.

Fixes #953