### PR TITLE
fix: harden auth helper against crashes, password leaks, and enumeration

### DIFF
--- a/src/_helpers/auth.ts
+++ b/src/_helpers/auth.ts
@@ -12,6 +12,7 @@ export function hashPassword(password: string): Promise<string> {
 		bcrypt.hash(password, 10, (err, hash) => {
 			if (err) {
 				reject(err)
+				return
 			}
 			resolve(hash)
 		})
@@ -29,26 +30,29 @@ export function authenticate(username: string, password: string): Promise<Authen
 			let user = clone(user_original)
 			if (username === user.username) {
 				userFound = true
-				checkPassword(password, user.password).then((password_valid) => {
-					if (!password_valid) {
-						reject(new Error('Password is incorrect'))
-					} else {
-						delete user['password']
-						jwt.sign({ user }, currentConfig.security.jwt_private_key, { expiresIn: '2 days' }, (err, token) => {
-							if (err) {
-								reject(err)
-							}
-							resolve({
-								access_token: token,
-								user: user,
+				checkPassword(password, user.password)
+					.then((password_valid) => {
+						if (!password_valid) {
+							reject(new Error('Invalid username or password'))
+						} else {
+							delete user['password']
+							jwt.sign({ user }, currentConfig.security.jwt_private_key, { expiresIn: '2 days' }, (err, token) => {
+								if (err) {
+									reject(err)
+									return
+								}
+								resolve({
+									access_token: token,
+									user: user,
+								})
 							})
-						})
-						return true
-					}
-				})
+							return true
+						}
+					})
+					.catch(reject)
 			}
 		})
-		if (!userFound) reject(new Error('User not found'))
+		if (!userFound) reject(new Error('Invalid username or password'))
 	})
 }
 
@@ -57,13 +61,14 @@ export function validateAccessToken(access_token: string): Promise<User> {
 		jwt.verify(access_token, currentConfig.security.jwt_private_key, (err, decoded) => {
 			if (err) {
 				reject(err)
+				return
 			}
 			resolve(decoded.user)
 		})
 	})
 }
 
-export function getUsersList(removePassword = false): User[] {
+export function getUsersList(removePassword = true): User[] {
 	let users = clone(currentConfig.users)
 	if (removePassword) {
 		users.forEach((user) => {
@@ -95,11 +100,16 @@ export function addUser(user: User): Promise<boolean> {
 	})
 }
 
+const BCRYPT_HASH_PATTERN = /^\$2[aby]?\$\d{2}\$/
+
 export function editUser(user: User) {
 	let userFound = false
 	currentConfig.users.forEach((user_original, index) => {
 		if (user.username === user_original.username) {
 			userFound = true
+			if (user.password && !BCRYPT_HASH_PATTERN.test(user.password)) {
+				user.password = bcrypt.hashSync(user.password, 10)
+			}
 			currentConfig.users[index] = user
 		}
 	})


### PR DESCRIPTION
This addresses items #7, #8, #9, #10 from CODE_REVIEW.md.

- **`validateAccessToken` no longer falls through after `reject(err)`**: added `return` after `reject(err)` in the `jwt.verify` callback so an invalid/expired JWT no longer causes a `TypeError` (from accessing `.user` on `undefined`) that could crash the whole process.
- **`editUser` now hashes the password like `addUser` does**: previously it wrote `user.password` to `config.json` in plaintext, breaking future bcrypt-based logins. It now hashes the incoming password (skipping re-hashing if the value already looks like a bcrypt hash, to avoid double-hashing on a get-then-resubmit round trip).
- **`getUsersList()` now defaults `removePassword` to `true`**: callers must opt in to receiving raw password hashes instead of opting out of leaking them. Checked all call sites (`src/index.ts`); the only caller (`socket.emit('users', getUsersList())`) needs the redacted list, so no call sites required updating.
- **`authenticate()` no longer leaks whether a username exists**: "user not found" and "password incorrect" now both return the same generic `Invalid username or password` error. Also added a `.catch(reject)` to the `checkPassword(...).then(...)` chain so a bcrypt rejection propagates instead of leaving the promise unsettled forever.
- **`hashPassword` no longer falls through after `reject(err)`**: added `return` for correctness, matching the same fix pattern as `validateAccessToken`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors introduced
- [ ] Manual verification of login, add user, and edit user flows (no existing test suite covers `src/_helpers/auth.ts`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>