### PR TITLE
fix: guard against a missing security section in config.json

### DIFF
--- a/src/_helpers/config.ts
+++ b/src/_helpers/config.ts
@@ -118,6 +118,15 @@ export function readConfig(): void {
 		currentConfig.uuid = uuidv4()
 		SaveConfig() //uuid added if missing on config save
 	}
+	if (!loadedConfig.security || typeof loadedConfig.security !== 'object') {
+		// the top-level security section is missing/corrupted; fall back to the
+		// default (empty) section so the jwt_private_key check below can safely
+		// dereference it and will regenerate a fresh key, rather than throwing
+		// and leaving currentConfig.security.jwt_private_key as the empty default.
+		logger('Security configuration section missing or invalid; recreating it.', 'info-quiet')
+		loadedConfig.security = clone(ConfigDefaults.security)
+		currentConfig.security = clone(ConfigDefaults.security)
+	}
 	if (!loadedConfig.security.jwt_private_key || typeof loadedConfig.security.jwt_private_key !== 'string') {
 		logger('Adding a private key for JWT authentication.', 'info-quiet')
 		currentConfig.security.jwt_private_key = randomBytes(256).toString('base64')
@@ -145,10 +154,7 @@ export function readConfig(): void {
 }
 
 export function getConfigRedacted(): Config {
-	let config: Config = {} as Config
-	try {
-		config = JSON.parse(fs.readFileSync(config_file).toString())
-	} catch (e) {}
+	const config: Config = clone(currentConfig)
 	config['security'] = {
 		jwt_private_key: '',
 	}


### PR DESCRIPTION
## Summary
- `readConfig()` in `src/_helpers/config.ts` dereferenced `loadedConfig.security.jwt_private_key` without first checking that `loadedConfig.security` itself exists. If `config.json` is hand-edited or corrupted such that the top-level `security` key is missing entirely, this throws a `TypeError`. The caller (`loadConfig()` in `src/index.ts`) wraps `readConfig()` in a try/catch that swallows the exception, so the process kept running with `currentConfig.security.jwt_private_key` left at the empty-string default from `ConfigDefaults` — a silent downgrade to signing/verifying JWTs with an empty secret.
- Fixed by adding a check that falls back to a fresh default `security` section (cloned from `ConfigDefaults.security`) whenever it's missing or not an object, on both `loadedConfig` and `currentConfig`. This lets the existing `jwt_private_key` check run safely afterward and naturally regenerate a real random secret (since the defaulted section's key is falsy), reusing the existing generation logic rather than duplicating it.
- Also updated `getConfigRedacted()` to build its result from the in-memory `currentConfig` (deep-cloned via the existing `clone()` helper) instead of doing a blocking `fs.readFileSync` of `config.json` on every call, applying the exact same redaction (`security`, `users`, `cloud_destinations`, `cloud_keys`, `uuid`) as before.

This addresses item #20 from `CODE_REVIEW.md`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Read through `readConfig()` end-to-end to confirm the missing-`security` fallback flows correctly into the existing `jwt_private_key` and user-migration logic (which also reads `loadedConfig.security.*`)
- [x] Confirmed `getConfigRedacted()` still redacts the same fields as before, now from the in-memory config

🤖 Generated with [Claude Code](https://claude.com/claude-code)