### PR TITLE
fix: guard FreePort against splicing the wrong entry when not found

### DIFF
--- a/src/_decorators/UsesPort.decorator.ts
+++ b/src/_decorators/UsesPort.decorator.ts
@@ -25,9 +25,9 @@ export function UsePort(port: number, sourceId: 'reserved' | string) {
 }
 
 export function FreePort(port: number, sourceId: string) {
-	PortsInUse.value.splice(
-		PortsInUse.value.findIndex((p) => p.port == port && p.sourceId == sourceId),
-		1,
-	)
-	PortsInUse.next(PortsInUse.value)
+	const idx = PortsInUse.value.findIndex((p) => p.port == port && p.sourceId == sourceId)
+	if (idx !== -1) {
+		PortsInUse.value.splice(idx, 1)
+		PortsInUse.next(PortsInUse.value)
+	}
 }


### PR DESCRIPTION
## Summary
- `FreePort(port, sourceId)` used `PortsInUse.value.splice(PortsInUse.value.findIndex(...), 1)` without checking the result of `findIndex`.
- `Array.prototype.findIndex` returns `-1` when no entry matches, and `splice(-1, 1)` does **not** no-op — it removes the *last* element of the array. So calling `FreePort` with a port/sourceId pair that isn't actually registered (e.g. a mismatched fallback port, or a double-free) silently deleted an unrelated port/source's bookkeeping entry from `PortsInUse`.
- Fix: compute the index first and only splice (and emit via `.next()`) when a match was actually found, so a miss is a true no-op instead of corrupting the registry.

Addresses item #22 from `CODE_REVIEW.md`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [x] Read through all `FreePort` call sites (`IncomingWebhook.ts`, `TSL.ts`, `ContributionTally.ts`, `RossCarbonite.ts`, `OSC.ts`, `SimplyLive.ts`) to confirm behavior is unaffected when the entry is present, and the fix only changes behavior for the not-found case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)