### PR TITLE
fix: use exact role matching instead of substring matching

### DIFF
--- a/UI/src/app/_guards/authorize.guard.ts
+++ b/UI/src/app/_guards/authorize.guard.ts
@@ -42,7 +42,16 @@ export class AuthorizeGuard {
 			this.router.navigate(destination)
 			return false
 		} else {
-			let checkRole = this.authService.requireRole(requiredRole)
+			// The /settings route hosts every settings tab, so anyone holding any
+			// 'settings:*' sub-role (or admin) should reach the page shell; individual
+			// tabs/sections gate more granularly on their specific sub-role.
+			let checkRole: boolean
+			if (requiredRole === 'settings') {
+				const profileRoles: string[] = this.authService.profile.roles.split(';')
+				checkRole = profileRoles.includes('admin') || profileRoles.some((r) => r.startsWith('settings:'))
+			} else {
+				checkRole = this.authService.requireRole(requiredRole)
+			}
 			if (checkRole) {
 				return true
 			} else {

--- a/UI/src/app/_services/auth.service.ts
+++ b/UI/src/app/_services/auth.service.ts
@@ -44,7 +44,14 @@ export class AuthService {
 
 	public loadProfile() {
 		let now = Date.now().valueOf() / 1000
-		let decoded: any = jwtDecode(this.access_token)
+		let decoded: any
+		try {
+			decoded = jwtDecode(this.access_token)
+		} catch (e) {
+			this.removeToken()
+			this.profile = undefined
+			return false
+		}
 		if (typeof decoded.exp !== 'undefined' && decoded.exp < now) {
 			return false
 		}
@@ -78,8 +85,8 @@ export class AuthService {
 
 	public requireRole(role: string) {
 		if (this.profile === undefined) return false
-		if (this.profile.roles.includes('admin')) return true
-		if (!this.profile.roles.includes(role)) return false
-		return true
+		const roles: string[] = this.profile.roles.split(';')
+		if (roles.includes('admin')) return true
+		return roles.includes(role)
 	}
 }


### PR DESCRIPTION
## Summary

- `AuthService.requireRole()` (`UI/src/app/_services/auth.service.ts`) was calling `String.includes()` on the raw semicolon-delimited `profile.roles` string, which is fragile substring matching rather than membership testing on the delimited role list. Any role whose name contains another role name as a substring (e.g. a `settings:*` sub-role satisfying a check for `settings`) would incorrectly pass. Fixed by splitting on `;` first and checking exact membership, matching the pattern already used correctly in `settings.component.ts`'s `isUserRoleSelected`.
- `AuthorizeGuard.canActivate()` (`UI/src/app/_guards/authorize.guard.ts`) guards the `/settings` route with `requiredRole = 'settings'`, which isn't a real role token — the canonical roles (`src/_helpers/authRoles.ts`) are `admin`, `settings:sources_devices`, `settings:listeners`, `settings:cloud`, `settings:testing`, `settings:config`, `settings:users`, `producer`, `tally_viewer`. It relied on the old substring behavior of `requireRole` to let any `settings:*` sub-role holder through. Since `requireRole` is now exact-match, the guard now special-cases the `/settings` route to check for `admin` or any role with a `settings:` prefix, preserving existing access (any settings sub-role holder, or admin, can reach the settings page shell; individual tabs still gate more granularly on their specific sub-role).
- Hardened `AuthService.loadProfile()` to wrap `jwtDecode()` in a try/catch. A corrupted/malformed token in localStorage previously threw synchronously from the service constructor (which is injected nearly everywhere), which could break app bootstrap. On decode failure it now clears the stored token and treats the user as logged out.

This addresses item #68 (and the client-side half of #2) from `CODE_REVIEW.md`.

## Test plan

- [x] `cd UI && npx tsc --noEmit -p tsconfig.app.json` passes with zero errors after regenerating the shared model/environment files (`node ../scripts/sync-ui-shared.js`, `node git.version.js`) that are normally produced by the `prestart` script and are gitignored.
- [x] Manually reviewed that `admin` and every `settings:*` sub-role still reach `/settings`, and that other routes (`/errors` → `admin`, `/producer` → `producer`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)