### PR TITLE
fix: close authentication and authorization bypasses in socket handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,7 @@ function initialSetup() {
 				let access_token = tmpSocketAccessTokens[socket.id]
 				validateAccessToken(access_token)
 					.then((user) => {
-						if (user.roles.includes(role) || user.roles.includes('admin')) {
+						if (user.roles.split(';').includes(role) || user.roles.split(';').includes('admin')) {
 							resolve(user)
 						} else {
 							let error_msg = 'Access denied. You are not authorized to do this.'
@@ -320,8 +320,8 @@ function initialSetup() {
 					logger(`User ${username} (ip addr ${ipAddr}) has attempted a login (${error})`)
 					//wrong credentials
 					Promise.all([
-						limiterConsecutiveFailsByUsernameAndIP.consume(ipAddr),
-						limiterSlowBruteByIP.consume(`${username}_${ipAddr}`),
+						limiterConsecutiveFailsByUsernameAndIP.consume(`${username}_${ipAddr}`),
+						limiterSlowBruteByIP.consume(ipAddr),
 					])
 						.then((values) => {
 							//rate limits not exceeded
@@ -524,19 +524,31 @@ function initialSetup() {
 		})
 
 		socket.on('companion', () => {
-			socket.join('companion')
-			socket.emit('sources', getSources())
-			socket.emit('devices', devices)
-			socket.emit('bus_options', currentConfig.bus_options)
-			socket.emit('device_sources', device_sources)
-			socket.emit('device_states', getDeviceStates())
-			socket.emit('listener_clients', listener_clients)
-			socket.emit('tsl_clients', tslListenerProvider.tsl_clients)
-			socket.emit('cloud_destinations', cloud_destinations)
+			requireRole('producer')
+				.then((user) => {
+					socket.join('companion')
+					socket.emit('sources', getSources())
+					socket.emit('devices', devices)
+					socket.emit('bus_options', currentConfig.bus_options)
+					socket.emit('device_sources', device_sources)
+					socket.emit('device_states', getDeviceStates())
+					socket.emit('listener_clients', listener_clients)
+					socket.emit('tsl_clients', tslListenerProvider.tsl_clients)
+					socket.emit('cloud_destinations', cloud_destinations)
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on('flash', (clientId) => {
-			FlashListenerClient(clientId)
+			requireRole('producer')
+				.then((user) => {
+					FlashListenerClient(clientId)
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on(
@@ -550,125 +562,161 @@ function initialSetup() {
 				socketid: string,
 				message: string,
 			) => {
-				MessageListenerClient(clientId, type, socketid, message)
+				requireRole('producer')
+					.then((user) => {
+						MessageListenerClient(clientId, type, socketid, message)
+					})
+					.catch((e) => {
+						console.error(e)
+					})
 			},
 		)
 
 		socket.on('reassign', (clientId: string, oldDeviceId: string, deviceId: string) => {
-			ReassignListenerClient(clientId, oldDeviceId, deviceId)
+			requireRole('producer')
+				.then((user) => {
+					ReassignListenerClient(clientId, oldDeviceId, deviceId)
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on('listener_reassign', (oldDeviceId: string, deviceId: string) => {
-			socket.leave('device-' + oldDeviceId)
-			socket.join('device-' + deviceId)
+			requireRole('producer')
+				.then((user) => {
+					socket.leave('device-' + oldDeviceId)
+					socket.join('device-' + deviceId)
 
-			for (let i = 0; i < listener_clients.length; i++) {
-				if (listener_clients[i].socketId === socket.id) {
-					listener_clients[i].deviceId = deviceId
-					listener_clients[i].inactive = false
-					break
-				}
-			}
+					for (let i = 0; i < listener_clients.length; i++) {
+						if (listener_clients[i].socketId === socket.id) {
+							listener_clients[i].deviceId = deviceId
+							listener_clients[i].inactive = false
+							break
+						}
+					}
 
-			let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
-			let deviceName = GetDeviceByDeviceId(deviceId).name
+					let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
+					let deviceName = GetDeviceByDeviceId(deviceId).name
 
-			logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
-			UpdateSockets('listener_clients')
-			UpdateCloud('listener_clients')
-			socket.emit('device_states', getDeviceStates())
+					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
+					UpdateSockets('listener_clients')
+					UpdateCloud('listener_clients')
+					socket.emit('device_states', getDeviceStates())
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on('listener_reassign_relay', (relayGroupId, oldDeviceId, deviceId) => {
-			let canRemove = true
-			for (let i = 0; i < listener_clients.length; i++) {
-				if (listener_clients[i].socketId === socket.id) {
-					if (listener_clients[i].deviceId === oldDeviceId) {
-						if (listener_clients[i].internalId !== relayGroupId) {
-							canRemove = false
-							break
+			requireRole('producer')
+				.then((user) => {
+					let canRemove = true
+					for (let i = 0; i < listener_clients.length; i++) {
+						if (listener_clients[i].socketId === socket.id) {
+							if (listener_clients[i].deviceId === oldDeviceId) {
+								if (listener_clients[i].internalId !== relayGroupId) {
+									canRemove = false
+									break
+								}
+							}
 						}
 					}
-				}
-			}
-			if (canRemove) {
-				//no other relay groups on this socket are using the old device ID, so we can safely leave that room
-				socket.leave('device-' + oldDeviceId)
-			}
-
-			socket.join('device-' + deviceId)
-
-			for (let i = 0; i < listener_clients.length; i++) {
-				if (listener_clients[i].socketId === socket.id) {
-					if (listener_clients[i].internalId === relayGroupId) {
-						listener_clients[i].deviceId = deviceId
+					if (canRemove) {
+						//no other relay groups on this socket are using the old device ID, so we can safely leave that room
+						socket.leave('device-' + oldDeviceId)
 					}
-				}
-			}
 
-			let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
-			let deviceName = GetDeviceByDeviceId(deviceId).name
+					socket.join('device-' + deviceId)
 
-			logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
-			UpdateSockets('listener_clients')
-			UpdateCloud('listener_clients')
-			socket.emit('device_states', getDeviceStates())
+					for (let i = 0; i < listener_clients.length; i++) {
+						if (listener_clients[i].socketId === socket.id) {
+							if (listener_clients[i].internalId === relayGroupId) {
+								listener_clients[i].deviceId = deviceId
+							}
+						}
+					}
+
+					let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
+					let deviceName = GetDeviceByDeviceId(deviceId).name
+
+					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
+					UpdateSockets('listener_clients')
+					UpdateCloud('listener_clients')
+					socket.emit('device_states', getDeviceStates())
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on('listener_reassign_gpo', (gpoGroupId, oldDeviceId, deviceId) => {
-			let canRemove = true
-			for (let i = 0; i < listener_clients.length; i++) {
-				if (listener_clients[i].socketId === socket.id) {
-					if (listener_clients[i].deviceId === oldDeviceId) {
-						if (listener_clients[i].internalId !== gpoGroupId) {
-							canRemove = false
-							break
+			requireRole('producer')
+				.then((user) => {
+					let canRemove = true
+					for (let i = 0; i < listener_clients.length; i++) {
+						if (listener_clients[i].socketId === socket.id) {
+							if (listener_clients[i].deviceId === oldDeviceId) {
+								if (listener_clients[i].internalId !== gpoGroupId) {
+									canRemove = false
+									break
+								}
+							}
 						}
 					}
-				}
-			}
-			if (canRemove) {
-				//no other gpo groups on this socket are using the old device ID, so we can safely leave that room
-				socket.leave('device-' + oldDeviceId)
-			}
-
-			socket.join('device-' + deviceId)
-
-			for (let i = 0; i < listener_clients.length; i++) {
-				if (listener_clients[i].socketId === socket.id) {
-					if (listener_clients[i].internalId === gpoGroupId) {
-						listener_clients[i].deviceId = deviceId
+					if (canRemove) {
+						//no other gpo groups on this socket are using the old device ID, so we can safely leave that room
+						socket.leave('device-' + oldDeviceId)
 					}
-				}
-			}
 
-			let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
-			let deviceName = GetDeviceByDeviceId(deviceId).name
+					socket.join('device-' + deviceId)
 
-			logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
-			UpdateSockets('listener_clients')
-			UpdateCloud('listener_clients')
+					for (let i = 0; i < listener_clients.length; i++) {
+						if (listener_clients[i].socketId === socket.id) {
+							if (listener_clients[i].internalId === gpoGroupId) {
+								listener_clients[i].deviceId = deviceId
+							}
+						}
+					}
+
+					let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
+					let deviceName = GetDeviceByDeviceId(deviceId).name
+
+					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
+					UpdateSockets('listener_clients')
+					UpdateCloud('listener_clients')
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on('listener_reassign_object', (reassignObj) => {
-			socket.leave('device-' + reassignObj.oldDeviceId)
-			socket.join('device-' + reassignObj.newDeviceId)
+			requireRole('producer')
+				.then((user) => {
+					socket.leave('device-' + reassignObj.oldDeviceId)
+					socket.join('device-' + reassignObj.newDeviceId)
 
-			for (let i = 0; i < listener_clients.length; i++) {
-				if (listener_clients[i].socketId === socket.id) {
-					listener_clients[i].deviceId = reassignObj.newDeviceId
-					listener_clients[i].inactive = false
-					break
-				}
-			}
+					for (let i = 0; i < listener_clients.length; i++) {
+						if (listener_clients[i].socketId === socket.id) {
+							listener_clients[i].deviceId = reassignObj.newDeviceId
+							listener_clients[i].inactive = false
+							break
+						}
+					}
 
-			let oldDeviceName = GetDeviceByDeviceId(reassignObj.oldDeviceId).name
-			let deviceName = GetDeviceByDeviceId(reassignObj.newDeviceId).name
+					let oldDeviceName = GetDeviceByDeviceId(reassignObj.oldDeviceId).name
+					let deviceName = GetDeviceByDeviceId(reassignObj.newDeviceId).name
 
-			logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
-			UpdateSockets('listener_clients')
-			UpdateCloud('listener_clients')
-			socket.emit('device_states', getDeviceStates())
+					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
+					UpdateSockets('listener_clients')
+					UpdateCloud('listener_clients')
+					socket.emit('device_states', getDeviceStates())
+				})
+				.catch((e) => {
+					console.error(e)
+				})
 		})
 
 		socket.on('listener_delete', (clientId) => {
@@ -920,7 +968,17 @@ function initialSetup() {
 
 		socket.on('cloud_data', (key: string, sourceId: string, tallyObj: SourceTallyData) => {
 			if (cloud_keys.includes(key)) {
-				processSourceTallyData(sourceId, tallyObj)
+				let cloudClientId = GetCloudClientBySocketId(socket.id)?.id
+				let source = GetSourceBySourceId(sourceId)
+
+				if (cloudClientId && source && source.cloudClientId === cloudClientId) {
+					processSourceTallyData(sourceId, tallyObj)
+				} else {
+					logger(
+						`Cloud Client (key: ${key}) attempted to send tally data for a source it does not own: ${sourceId}`,
+						'info',
+					)
+				}
 			} else {
 				socket.emit('invalidkey')
 				socket.disconnect()
@@ -1623,7 +1681,7 @@ function TallyArbiter_Manage(obj: Manage, access_token: string = ''): Promise<Ma
 	return new Promise((resolve, reject) => {
 		validateAccessToken(access_token).then((user) => {
 			const validate_user_role = (role) => {
-				if (!user.roles.includes(role) && !user.roles.includes('admin')) {
+				if (!user.roles.split(';').includes(role) && !user.roles.split(';').includes('admin')) {
 					resolve({ result: 'error', error: 'Access denied. You are not authorized to do this.' })
 					return false
 				} else {
@@ -2481,8 +2539,9 @@ function TallyArbiter_Remove_Cloud_Client(obj: Manage): ManageResponse {
 			//disconnect the cloud client
 			ipAddress = cloud_clients[i].ipAddress
 			key = cloud_clients[i].key
-			if ((io.sockets as any).connected && (io.sockets as any).connected.includes(cloud_clients[i].socketId)) {
-				;(io.sockets as any).connected[cloud_clients[i].socketId].disconnect(true)
+			const clientSocket = io.sockets.sockets.get(cloud_clients[i].socketId)
+			if (clientSocket) {
+				clientSocket.disconnect(true)
 				clientRemoved = true
 			}
 			cloud_clients.splice(i, 1)
@@ -2704,8 +2763,9 @@ function FlashListenerClient(listenerClientId): FlashListenerClientResponse | vo
 	if (listenerClientObj) {
 		if (listenerClientObj.cloudConnection) {
 			let cloudClientSocketId = GetCloudClientById(listenerClientObj.cloudClientId).socketId
-			if ((io.sockets as any).connected && (io.sockets as any).connected.includes(cloudClientSocketId)) {
-				;(io.sockets as any).connected[cloudClientSocketId].emit('flash', listenerClientId)
+			const cloudClientSocket = io.sockets.sockets.get(cloudClientSocketId)
+			if (cloudClientSocket) {
+				cloudClientSocket.emit('flash', listenerClientId)
 			}
 		} else {
 			if (listenerClientObj.canBeFlashed) {
@@ -2731,14 +2791,9 @@ function MessageListenerClient(
 	if (listenerClientObj) {
 		if (listenerClientObj.cloudConnection) {
 			let cloudClientSocketId = GetCloudClientById(listenerClientObj.cloudClientId).socketId
-			if ((io.sockets as any).connected && (io.sockets as any).connected.includes(cloudClientSocketId)) {
-				;(io.sockets as any).connected[cloudClientSocketId].emit(
-					'messaging_client',
-					listenerClientId,
-					type,
-					socketid,
-					message,
-				)
+			const cloudClientSocket = io.sockets.sockets.get(cloudClientSocketId)
+			if (cloudClientSocket) {
+				cloudClientSocket.emit('messaging_client', listenerClientId, type, socketid, message)
 			}
 		} else {
 			if (listenerClientObj.canBeFlashed) {
@@ -2825,10 +2880,11 @@ function AddCloudClient(socketId, key, ipAddress, datetimeConnected) {
 function DeleteCloudClients(key) {
 	for (let i = cloud_clients.length - 1; i >= 0; i--) {
 		if (cloud_clients[i].key === key) {
-			if ((io.sockets as any).connected && (io.sockets as any).connected.includes(cloud_clients[i].socketId)) {
-				;(io.sockets as any).connected[cloud_clients[i].socketId].disconnect(true)
-				cloud_clients.splice(i, 1)
+			const clientSocket = io.sockets.sockets.get(cloud_clients[i].socketId)
+			if (clientSocket) {
+				clientSocket.disconnect(true)
 			}
+			cloud_clients.splice(i, 1)
 		}
 	}
 


### PR DESCRIPTION
## Summary

This addresses items #1-#6 from `CODE_REVIEW.md` — a set of security bugs in `src/index.ts`'s Socket.IO connection handler and cloud-client management code.

- **Login rate limiters were keyed backwards.** `limiterConsecutiveFailsByUsernameAndIP` was consumed with only the IP address, and `limiterSlowBruteByIP` was consumed with `username_ip` — exactly swapped from what each limiter's `keyPrefix` (`login_fail_consecutive_username_and_ip` vs `login_fail_ip_per_day`) intends. Swapped the keys back to match, restoring the intended brute-force protection.
- **Substring-match role check allowed privilege escalation.** Both the socket `requireRole` helper and the `TallyArbiter_Manage` `validate_user_role` helper used `user.roles.includes(role)` against the semicolon-delimited roles string, so a user with role `settings:testing` satisfied a `requireRole('settings')` check via substring match. Changed both to `user.roles.split(';').includes(role)` for exact membership.
- **`companion` socket handler had no authorization check** while every other data-bearing handler (`settings`, `producer`) does. Added a `requireRole('producer')` guard, matching the existing pattern (`.then()`/`.catch()`).
- **Several control-plane socket events had no role/auth guard**: `flash`, `messaging_client`, `reassign`, `listener_reassign`, `listener_reassign_relay`, `listener_reassign_gpo`, `listener_reassign_object`. Added `requireRole('producer')` guards to each, following the same pattern used by already-guarded handlers like `listener_delete` and `testmode`.
- **`cloud_data` allowed any cloud-key holder to spoof tally state for sources they don't own.** Added an ownership check (comparing the submitting cloud client's id against the source's `cloudClientId`, the same pattern used in `cloud_sources`) before calling `processSourceTallyData`; unauthorized submissions are logged and ignored rather than applied.
- **Dead Socket.IO v2 API usage (`(io.sockets as any).connected`)** meant revoked/removed cloud clients were never actually disconnected, in `DeleteCloudClients`, `TallyArbiter_Remove_Cloud_Client`, `FlashListenerClient`, and `MessageListenerClient`. Replaced with the v4-correct `io.sockets.sockets.get(socketId)` lookup and removed the `as any` casts. Also fixed `DeleteCloudClients` so it always splices the `cloud_clients` array entry, not only when a live socket happens to be found.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [ ] Manual: log in with wrong credentials repeatedly from one IP/username and confirm rate limiting still triggers as expected.
- [ ] Manual: connect as a non-producer/non-admin user and confirm `companion`, `flash`, `reassign`, and the `listener_reassign*` events are rejected with an `error` emit.
- [ ] Manual: connect two cloud clients with different keys/sources and confirm one cannot push `cloud_data` for a source owned by the other.
- [ ] Manual: delete a cloud key / remove a cloud client from the Settings UI and confirm the corresponding socket is actually disconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)