### PR TITLE
fix: prevent Ember action from crashing the server on reconnect failure

### DIFF
--- a/src/actions/Ember.ts
+++ b/src/actions/Ember.ts
@@ -3,6 +3,8 @@ import { logger } from '..'
 import { RegisterAction } from '../_decorators/RegisterAction'
 import { Action } from './_Action'
 import { EmberClientEvent } from 'node-emberplus'
+import type { Parameter } from 'node-emberplus/lib/common/parameter'
+import type { QualifiedParameter } from 'node-emberplus/lib/common/qualified-parameter'
 
 @RegisterAction('48c73ee4', 'Ember+', [
 	{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
@@ -25,8 +27,8 @@ export class Ember extends Action {
 	// code.  MCX 6.4.x uses an int64 value for virtul GPI/O.  MCX 10.x uses an actual boolean type.
 	// this code is compatible with both.  However, if you intend to set a string value, the results could be
 	// unpredictable.  This code might need to be refactored if string support is required in the future.
-	private static emberConnections = {}
-	private static emberConnectionStatus = {}
+	private static emberConnections: Record<string, EmberClient> = {}
+	private static emberConnectionStatus: Record<string, boolean> = {}
 
 	private getConnection() {
 		const connection = `${this.action.data.ip}:${this.action.data.port}`
@@ -51,7 +53,11 @@ export class Ember extends Action {
 			.on(EmberClientEvent.DISCONNECTED, async (e) => {
 				Ember.emberConnectionStatus[connection] = false
 				logger(`Ember+ client disconnected - reconnecting: erorr: ${e}`)
-				await this.getConnection().connectAsync()
+				try {
+					await this.getConnection().connectAsync()
+				} catch (error) {
+					logger(`Ember+ reconnection error: ${error}`, 'error')
+				}
 			})
 			.on(EmberClientEvent.CONNECTED, () => {
 				logger(`Ember+ Connected.`)
@@ -78,7 +84,7 @@ export class Ember extends Action {
 	}
 
 	private async setGPI() {
-		if (!this.isConnected) {
+		if (!this.isConnected()) {
 			logger(`Ember+ error: not connected.  Ignoring request.`, 'error')
 			return
 		}
@@ -98,7 +104,7 @@ export class Ember extends Action {
 				emberValue = this.action.data.value
 			}
 
-			await this.getConnection().setValueAsync(node, emberValue)
+			await this.getConnection().setValueAsync(node as Parameter | QualifiedParameter, emberValue)
 		} catch (error) {
 			logger(`Ember+ error, giving up sending: ${error}`, 'error')
 		}
@@ -110,17 +116,17 @@ export class Ember extends Action {
 			logger(`Ember+ Creating new connection.`)
 			try {
 				this.newConnection()
-				this.connect()
 			} catch (error) {
 				logger(`Ember+ Caught error trying to create new connection: ${error}`, 'error')
 			}
+			this.connect().catch((error) => {
+				logger(`Ember+ Caught error trying to connect: ${error}`, 'error')
+			})
 		}
 
 		// send message
-		try {
-			this.setGPI()
-		} catch (error) {
+		this.setGPI().catch((error) => {
 			logger(`Ember+ An error occured sending Ember+: ${error}`, 'error')
-		}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- `isConnected` was referenced without calling it (`if (!this.isConnected)`), so the "not connected, ignoring request" guard in `setGPI()` never actually fired regardless of real connection state. Fixed to call it: `if (!this.isConnected())`.
- The `DISCONNECTED` event handler's reconnect attempt (`await this.getConnection().connectAsync()`) had no error handling. Since there is no process-wide `unhandledRejection` handler in this codebase (only `uncaughtException` is registered, in `src/index.ts`), a failed reconnect could crash the whole server whenever an Ember+ device dropped and immediately failed to reconnect. Wrapped it in try/catch, mirroring the existing `connect()` method in the same file.
- Replaced synchronous `try/catch` around un-awaited async calls (`this.connect()`, `this.setGPI()`) in `run()` with `.catch()` on the returned promise, since a sync try/catch around a fire-and-forget async call can never actually catch a rejection.
- Added proper types to the connection-tracking dictionaries: `Record<string, EmberClient>` for `emberConnections` and `Record<string, boolean>` for `emberConnectionStatus`.
- As a consequence of properly typing `emberConnections`, `getConnection()` is no longer implicitly `any`, which surfaced a pre-existing type mismatch between `getElementByPathAsync` (returns `TreeNode`) and `setValueAsync` (expects `Parameter | QualifiedParameter`). Fixed with a type-only import and cast, consistent with how `node-emberplus` subpath types are already imported in this file.

Addresses items #51 and #52 from `CODE_REVIEW.md`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manual review of the full file for consistency with existing patterns (error logging, fire-and-forget `run(): void` design of the base `Action` class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)