### PR TITLE
fix: add missing null guards in TSL module

### DIFF
--- a/src/_modules/TSL.ts
+++ b/src/_modules/TSL.ts
@@ -97,6 +97,9 @@ export class TSLListenerProvider extends ListenerProvider {
 
 	public stopTSLClientConnection(tslClientId) {
 		const tslClient = this.tsl_clients.find((t) => t.id == tslClientId)
+		if (!tslClient) {
+			return
+		}
 		switch (tslClient.transport) {
 			case 'udp':
 				logger(
@@ -210,10 +213,11 @@ export class TSLListenerProvider extends ListenerProvider {
 		bufUMD[0] = 0x80 + tslAddress
 		bufUMD.write(device.name, 2)
 
-		for (const busId of currentTallyData[device.id]) {
-			if (GetBusByBusId(busId).type === 'preview') {
+		for (const busId of currentTallyData[device.id] ?? []) {
+			const bus = GetBusByBusId(busId)
+			if (bus?.type === 'preview') {
 				mode_preview = true
-			} else if (GetBusByBusId(busId).type === 'program') {
+			} else if (bus?.type === 'program') {
 				mode_program = true
 			}
 			//could add support for other states here like tally3, tally4, whatever the TSL protocol supports


### PR DESCRIPTION
## Summary
- `createTSL31Packet` was missing the null guards its sibling methods (`getPvwPgmState`, `createTSL5Packet`) already have: it iterated `currentTallyData[device.id]` directly (throws for a device with no tally state yet) and called `.type` on the result of `GetBusByBusId(busId)` without checking for `undefined` (throws for an unresolvable bus id). Fixed by using `currentTallyData[device.id] ?? []` and `bus?.type`, matching the pattern already used in `getPvwPgmState` and `createTSL5Packet`.
- `stopTSLClientConnection` dereferenced `this.tsl_clients.find(...)` without checking for `undefined`. This throws when a TSL client is edited twice within its 5-second re-add window (`setTimeout(..., 5000)`), since `this.tsl_clients` can legitimately lack an entry that exists in `currentConfig.tsl_clients`. Fixed by returning early if no matching client is found.

This addresses items #23 and #24 from `CODE_REVIEW.md`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manual review of both fixes against sibling method patterns in the same file

🤖 Generated with [Claude Code](https://claude.com/claude-code)