### PR TITLE
fix: stop truncating generated IDs to 32 bits

### DIFF
--- a/src/_helpers/uuid.ts
+++ b/src/_helpers/uuid.ts
@@ -2,5 +2,5 @@ import { v4 as uuid } from 'uuid'
 
 export function uuidv4(): string {
 	//unique UUID generator for IDs
-	return uuid().split('-')[0]
+	return uuid()
 }


### PR DESCRIPTION
## Summary
- `uuidv4()` in `src/_helpers/uuid.ts` discarded ~90 bits of entropy by keeping only the first 8 hex characters (32 bits, ~4.3B space) of a v4 UUID.
- This ID generator is used for sources, devices, listener clients, error reports, and cloud clients (and others) via `uuidv4()` calls throughout `src/index.ts`, `src/_helpers/config.ts`, `src/_helpers/errorReports.ts`, and `src/_modules/VMix.ts`.
- Birthday-paradox collisions become plausible after tens of thousands of IDs are generated over a server's lifetime, and since IDs are used as object/array keys or `.find(id === ...)` matches, a collision silently aliases/overwrites an unrelated existing record.
- Fix: return the full v4 UUID from `uuid()` instead of truncating it to the first dash-delimited segment.

This addresses item #25 from `CODE_REVIEW.md`.

## Compatibility
- IDs are stored and compared as opaque strings everywhere (no fixed-length assumptions found elsewhere in `src/` or `UI/src/` — grepped for 8-character length checks and hex regexes, no matches related to ID format). Existing short IDs already persisted in `config.json` files remain valid; new IDs generated going forward will simply be full-length UUIDs.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Grepped `src/` and `UI/src/` for fixed-length (8-char) ID assumptions — none found