### PR TITLE
fix: stop truncating network interface names on the first space

### DIFF
--- a/src/_helpers/networkInterfaces.ts
+++ b/src/_helpers/networkInterfaces.ts
@@ -9,7 +9,12 @@ export function getNetworkInterfaces(): NetworkInterface[] {
 	for (const networkInterface in networkInterfaces) {
 		let numberOfAddresses = networkInterfaces[networkInterface].length
 		let v4Addresses = []
-		let iface = networkInterface.split(' ')[0]
+		// Use the full OS-reported interface name as-is. Splitting on the first
+		// space previously truncated distinct Windows adapters (e.g. "Ethernet",
+		// "Ethernet 2", "Ethernet 3") down to the same string, causing collisions,
+		// since the `${i}` suffix below only disambiguates multiple addresses
+		// within the same OS-level key, not across differently-named adapters.
+		let iface = networkInterface
 
 		for (let i = 0; i < numberOfAddresses; i++) {
 			if (networkInterfaces[networkInterface][i]['family'] === 'IPv4') {


### PR DESCRIPTION
## Summary
- `getNetworkInterfaces()` in `src/_helpers/networkInterfaces.ts` truncated the OS-reported interface name on the first space (`networkInterface.split(' ')[0]`). On Windows, distinct adapters are often reported as `"Ethernet"`, `"Ethernet 2"`, `"Ethernet 3"`, etc., and this truncation collapsed all of them to the same `"Ethernet"` name.
- The existing per-key `${i}` suffix only disambiguates multiple IPv4 addresses within the same OS-level key — it does nothing to prevent collisions across differently-named adapters that got truncated to an identical string, so those adapters ended up indistinguishable in the resulting interface list.
- Fix: use the full, untruncated OS-reported key as the interface name instead of splitting on the first space. Interface names on macOS/Linux (e.g. `en0`, `eth0`, `lo0`) don't contain spaces, so this preserves existing behavior there while fixing the Windows collision.
- Addresses item #27 from `CODE_REVIEW.md` (not modified by this PR).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manual review of `getNetworkInterfaces()` confirms `iface` is only used to build `name`, and no other code path relies on the truncated form