### PR TITLE
fix: guard against NaN input in secondsToHms

### DIFF
--- a/src/_helpers/time.ts
+++ b/src/_helpers/time.ts
@@ -2,6 +2,7 @@
 //used in login function for displaying rate limits
 export function secondsToHms(d: number | string): string {
 	d = Number(d)
+	if (isNaN(d)) return 'a moment'
 	var h = Math.floor(d / 3600)
 	var m = Math.floor((d % 3600) / 60)
 	var s = Math.floor((d % 3600) % 60)


### PR DESCRIPTION
## Summary
- `secondsToHms(d)` in `src/_helpers/time.ts` converts its input with `Number(d)` but never checked whether that conversion produced `NaN`.
- A malformed/non-numeric input (e.g. `undefined` or `'abc'`) silently produced a broken string like `"NaN hours, NaN minutes, NaN seconds"`.
- Its only caller (`src/index.ts`, rate-limit message in the login flow) renders the return value directly into a user-facing string without any validation, so a thrown error would surface as an unhandled exception in that flow. Added a safe fallback (`'a moment'`) instead of throwing, so the guard degrades gracefully in the UI message: `"Please try a moment later."`

This addresses the `time.ts` improvement noted in `CODE_REVIEW.md` section 3 (NaN guard for `secondsToHms`).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manually reasoned through call site in `src/index.ts:345` to confirm fallback string renders sensibly in the rate-limit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)