### PR TITLE
cleanup: replace homegrown deep clone with structuredClone

### DIFF
--- a/src/_helpers/clone.ts
+++ b/src/_helpers/clone.ts
@@ -1,16 +1,3 @@
-// based on https://stackoverflow.com/a/122190
-export function clone(obj) {
-	if (obj === null || typeof obj !== 'object' || 'isActiveClone' in obj) return obj
-
-	if (obj instanceof Date) var temp = new Date(obj) as any
-	else var temp = obj.constructor() as any
-
-	for (var key in obj) {
-		if (Object.prototype.hasOwnProperty.call(obj, key)) {
-			obj['isActiveClone'] = null
-			temp[key] = clone(obj[key])
-			delete obj['isActiveClone']
-		}
-	}
-	return temp
+export function clone<T>(obj: T): T {
+	return structuredClone(obj)
 }


### PR DESCRIPTION
## Summary
- Replaces the homegrown deep-clone in `src/_helpers/clone.ts` (constructor-based clone with a mutate-then-restore `isActiveClone` marker to dodge circular refs) with Node's built-in `structuredClone()`.
- Adds proper generic typing (`clone<T>(obj: T): T`) instead of implicit `any` in/out.
- Addresses the `clone.ts` improvement noted in `CODE_REVIEW.md` section 3.

The old implementation broke on non-plain objects (e.g. `RegExp`, class instances requiring constructor args), didn't correctly preserve circular references, and would throw on frozen input. All CI workflows run Node 20, well above the Node 17+ requirement for `structuredClone`.

## Call sites checked
- `src/_helpers/config.ts:70` — `clone(ConfigDefaults)` (plain `Config` object: strings, booleans, arrays of plain objects)
- `src/_helpers/config.ts:113` — `clone(ConfigDefaults)` spread into config write
- `src/_helpers/auth.ts:29` — `clone(user_original)` (plain `User` object: `username`, `password`, `roles` strings)
- `src/_helpers/auth.ts:67` — `clone(currentConfig.users)` (array of plain `User` objects)

No other files in `src/` or `UI/src` import or call this `clone` function. All usages are plain, JSON-serializable-ish config/user objects with no functions, `RegExp`, or DOM nodes — fully compatible with `structuredClone`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Confirmed Node 20 in all CI workflows (`.github/workflows/npm.yml`, `build-desktop.yml`, `codeql-analysis.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)