### PR TITLE
cleanup: remove dead code and fix retain default in MQTT module

### DIFF
--- a/src/_modules/MQTT.ts
+++ b/src/_modules/MQTT.ts
@@ -26,7 +26,6 @@ export class MQTTService extends EventEmitter {
 	private client: MqttClient | null = null
 	private config: ConfigMQTT | null = null
 	private isConnected: boolean = false
-	private reconnectTimer: NodeJS.Timeout | null = null
 
 	public start(config: ConfigMQTT): void {
 		if (!config.enabled) {
@@ -39,11 +38,6 @@ export class MQTTService extends EventEmitter {
 	}
 
 	public stop(): void {
-		if (this.reconnectTimer) {
-			clearTimeout(this.reconnectTimer)
-			this.reconnectTimer = null
-		}
-
 		if (this.client) {
 			this.client.end()
 			this.client = null
@@ -106,8 +100,6 @@ export class MQTTService extends EventEmitter {
 				this.isConnected = true
 				logger('MQTT broker connected successfully.', 'info')
 				this.publishStatus('online')
-				// Publish initial state for all devices
-				this.publishAllDeviceStates()
 			})
 
 			this.client.on('error', (error) => {
@@ -186,11 +178,6 @@ export class MQTTService extends EventEmitter {
 		this.publish(availabilityTopic, 'online')
 	}
 
-	private publishAllDeviceStates(): void {
-		// This will be called by the main index.ts after device states are available
-		// For now, we'll rely on updateDeviceState being called for each device
-	}
-
 	private publishStatus(status: 'online' | 'offline'): void {
 		if (!this.config) return
 
@@ -209,7 +196,7 @@ export class MQTTService extends EventEmitter {
 				payloadString,
 				{
 					qos: this.config.qos || 0,
-					retain: this.config.retain !== undefined ? this.config.retain : false,
+					retain: this.config.retain !== undefined ? this.config.retain : true,
 				},
 				(error) => {
 					if (error) {


### PR DESCRIPTION
## Summary

Addresses the MQTT.ts improvements noted in `CODE_REVIEW.md` section 3 (not edited here):

- Removed the unused `reconnectTimer` field. It was declared and cleared in `stop()` but never assigned anywhere — the `mqtt` library's own `reconnectPeriod` option already handles reconnection.
- Removed the empty `publishAllDeviceStates()` stub and its call site in the `connect` event handler. Implementing it properly would require computing per-device tally state, which currently lives in a non-exported `getDeviceStates()` function in `index.ts` that depends on several internals (`device_sources`, `currentSourceTallyData`, `SourceClients`, `GetDeviceByDeviceId`) that `MQTT.ts` doesn't otherwise depend on. Exposing/plumbing that through was judged out of scope for this cleanup, so the dead stub was removed instead. Note `updateDeviceState()` already publishes per-device state whenever tally data changes (including right after a device state update following connect), so no functional behavior is lost.
- Fixed the `retain` option's fallback default (used when `config.retain` is `undefined`) from `false` to `true`, matching `ConfigDefaults.mqtt.retain` in `src/_helpers/config.ts` and the schema in `src/_helpers/configSchema.ts`. Low impact since `retain` is normally always populated by config defaults, but fixes the inconsistency.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manual review of the full diff — only `src/_modules/MQTT.ts` touched, no other `_modules/` files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)