### PR TITLE
fix: cap unbounded growth of the tally data log file

### DIFF
--- a/src/_helpers/logger.ts
+++ b/src/_helpers/logger.ts
@@ -48,7 +48,6 @@ export const logFilePath = getLogFilePath()
 export const Logs = [] //Used for loading logs in settings page
 
 var tallyDataFilePath = getTallyDataPath()
-export const tallyDataFile = fs.openSync(tallyDataFilePath, 'w') // Setup TallyData File
 
 const serverLoggerLevels = {
 	levels: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import { Actions } from './_globals/Actions'
 
 // Helpers
 import { uuidv4 } from './_helpers/uuid'
-import { logFilePath, Logs, serverLogger, tallyDataFile } from './_helpers/logger'
+import { logFilePath, Logs, serverLogger, tallyLogger } from './_helpers/logger'
 import { getNetworkInterfaces } from './_helpers/networkInterfaces'
 import { loadClassesFromFolder } from './_helpers/fileLoader'
 import { UsePort } from './_decorators/UsesPort.decorator'
@@ -1445,7 +1445,10 @@ export function logger(log, type: 'info-quiet' | 'info' | 'error' | 'console_act
 function writeTallyDataFile(log) {
 	try {
 		const logLine = JSON.stringify(log) + ','
-		fs.appendFileSync(tallyDataFile, logLine + '\n')
+		// Routed through the rotating winston tallyLogger (maxsize/maxFiles) instead of
+		// appending to a raw, uncapped file descriptor, so the tally data file can no
+		// longer grow unbounded for the life of the process.
+		tallyLogger.info(logLine)
 	} catch (error) {
 		logger(`Error saving logs to file: ${error}`, 'error')
 	}


### PR DESCRIPTION
## Summary

Addresses item #26 from `CODE_REVIEW.md`: the rotating winston `tallyLogger` (configured with `maxsize`/`maxFiles` in `src/_helpers/logger.ts`) was dead code — never imported or used anywhere. The tally data file that is *actually* written to each run was instead a raw `fs.openSync(tallyDataFilePath, 'w')` file descriptor, appended to via `fs.appendFileSync` in `src/index.ts`, with **no size cap or rotation**. It grows unbounded for the life of the process. The `findRemoveSync` call only prunes old *files* once at startup — it does not limit the size of the *current* file.

## Approach taken

Went with the preferred, lower-risk option: **reuse the existing, already-correctly-configured rotating `tallyLogger`** instead of writing new rotation logic.

Before choosing this, I verified there is no external consumer of the raw tally data file format:
- Grepped the whole repo (`src/`, listener clients, docs) for any code that reads `.tadata` files or `tallyDataFilePath` back — found none. The file is write-only/diagnostic.
- `tallyLogger` was already exported from `logger.ts` (line `export const tallyLogger = winston.loggers.get('tally')`), so no export change was needed there.

Changes:
- `src/_helpers/logger.ts`: removed the now-unused `export const tallyDataFile = fs.openSync(tallyDataFilePath, 'w')` raw file descriptor setup (the `tallyDataFilePath` variable is still used to configure the winston `tally` transport's `filename`, so it stays).
- `src/index.ts`: `writeTallyDataFile()` now calls `tallyLogger.info(logLine)` instead of `fs.appendFileSync(tallyDataFile, ...)`. Import updated from `tallyDataFile` to `tallyLogger`.

This means tally data writes now go through the winston transport that already has `maxsize: 3e6` (3MB) / `maxFiles: 3` configured, eliminating the unbounded growth risk with no new rotation code required. The per-line format changes slightly (winston prepends a `[timestamp]` to each line, same as the other loggers in this file), since there's no confirmed external reader relying on the previous byte-for-byte format.

## Test plan
- [x] Read `src/_helpers/logger.ts` fully and confirmed `tallyLogger` was unused outside its own definition (`grep -rn "tallyLogger" src/`).
- [x] Searched `src/index.ts` and the rest of the repo for all usages of `tallyDataFile` / `tallyDataFilePath` / `.tadata` to confirm no external/consumer format dependency before switching write paths.
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>