### PR TITLE
fix: correct several data-corruption and dead-code bugs in index.ts

### DIFF
--- a/src/_helpers/auth.ts
+++ b/src/_helpers/auth.ts
@@ -7,15 +7,8 @@ import { clone } from './clone'
 import { AuthenticateSuccessResponse } from '../_models/AuthenticateSuccessResponse'
 import { User } from '../_models/User'
 
-export function hashPassword(password: string): Promise<string> {
-	return new Promise((resolve, reject) => {
-		bcrypt.hash(password, 10, (err, hash) => {
-			if (err) {
-				reject(err)
-			}
-			resolve(hash)
-		})
-	})
+export function hashPassword(password: string): string {
+	return bcrypt.hashSync(password, 10)
 }
 
 export function checkPassword(input_password: string, original_password: string): Promise<boolean> {
@@ -73,26 +66,22 @@ export function getUsersList(removePassword = false): User[] {
 	return users
 }
 
-export function addUser(user: User): Promise<boolean> {
-	return new Promise((resolve, reject) => {
-		let userFound = false
-		currentConfig.users.forEach((user_original) => {
-			if (user.username === user_original.username) {
-				userFound = true
-			}
-		})
-		if (!userFound) {
-			hashPassword(user.password).then((hashed_password) => {
-				user.password = hashed_password
-				currentConfig.users.push(user)
-				SaveConfig()
-				logger(`Added new user ${user.username}.`)
-				resolve(true)
-			})
-		} else {
-			reject()
+export function addUser(user: User): boolean {
+	let userFound = false
+	currentConfig.users.forEach((user_original) => {
+		if (user.username === user_original.username) {
+			userFound = true
 		}
 	})
+	if (!userFound) {
+		user.password = hashPassword(user.password)
+		currentConfig.users.push(user)
+		SaveConfig()
+		logger(`Added new user ${user.username}.`)
+		return true
+	} else {
+		return false
+	}
 }
 
 export function editUser(user: User) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,7 +288,7 @@ function initialSetup() {
 
 		const requireRole = (role: string) => {
 			return new Promise((resolve, reject) => {
-				if (typeof tmpSocketAccessTokens[socket.id] === undefined) {
+				if (typeof tmpSocketAccessTokens[socket.id] === 'undefined') {
 					let error_msg = 'Access token required. Please login to use this feature.'
 					socket.emit('error', error_msg)
 					reject(error_msg)
@@ -409,9 +409,17 @@ function initialSetup() {
 			supportsChat (bool)
 			*/
 
-			if (typeof obj !== 'object' && obj !== null) {
-				logger(`Received JSON object: ${obj}`, 'info-quiet') //Log the raw JSON to console
-				obj = JSON.parse(String(obj)) //Re-parse JSON
+			try {
+				if (typeof obj !== 'object' || obj === null) {
+					logger(`Received JSON object: ${obj}`, 'info-quiet') //Log the raw JSON to console
+					obj = JSON.parse(String(obj)) //Re-parse JSON
+				}
+				if (typeof obj !== 'object' || obj === null) {
+					throw new Error('Invalid listenerclient_connect payload')
+				}
+			} catch (e) {
+				logger(`Invalid listenerclient_connect payload: ${e}`, 'error')
+				return
 			}
 
 			let deviceId = obj.deviceId
@@ -753,6 +761,7 @@ function initialSetup() {
 						if (!found) {
 							//the client was deleted on the local source, so we should delete it here as well
 							sources.splice(i, 1)
+							i--
 						}
 					}
 				}
@@ -775,10 +784,10 @@ function initialSetup() {
 					for (let j = 0; j < devices.length; j++) {
 						if (data[i].id === devices[j].id) {
 							found = true
-							devices[j].name = data[j].name
-							devices[j].description = data[j].description
-							devices[j].tslAddress = data[j].tslAddress
-							devices[j].enabled = data[j].enabled
+							devices[j].name = data[i].name
+							devices[j].description = data[i].description
+							devices[j].tslAddress = data[i].tslAddress
+							devices[j].enabled = data[i].enabled
 							devices[j].cloudConnection = true
 							devices[j].cloudClientId = cloudClientId
 							break
@@ -806,6 +815,7 @@ function initialSetup() {
 						if (!found) {
 							//the client was deleted on the local source, so we should delete it here as well
 							devices.splice(i, 1)
+							i--
 						}
 					}
 				}
@@ -853,6 +863,7 @@ function initialSetup() {
 						if (!found) {
 							//the client was deleted on the local source, so we should delete it here as well
 							device_sources.splice(i, 1)
+							i--
 						}
 					}
 				}
@@ -907,6 +918,7 @@ function initialSetup() {
 						if (!found) {
 							//the client was deleted on the local source, so we should delete it here as well
 							listener_clients.splice(i, 1)
+							i--
 						}
 					}
 				}
@@ -969,7 +981,7 @@ function initialSetup() {
 					ToggleTestMode(value, interval)
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -981,7 +993,7 @@ function initialSetup() {
 					TSLClients_1SecUpdate(value)
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -999,7 +1011,7 @@ function initialSetup() {
 					socket.emit('unread_error_reports', getUnreadErrorReportsList())
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1010,7 +1022,7 @@ function initialSetup() {
 					socket.emit('error_report', getErrorReport(errorReportId))
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1020,7 +1032,7 @@ function initialSetup() {
 					markErrorReportsAsRead()
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1030,7 +1042,7 @@ function initialSetup() {
 					deleteEveryErrorReport()
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1040,7 +1052,7 @@ function initialSetup() {
 					socket.emit('users', getUsersList())
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1050,7 +1062,7 @@ function initialSetup() {
 					socket.emit('config', currentConfig)
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1070,7 +1082,7 @@ function initialSetup() {
 						})
 				})
 				.catch((err) => {
-					console.error(err)
+					logger(err, 'error')
 				})
 		})
 
@@ -1078,6 +1090,7 @@ function initialSetup() {
 			// emitted when any socket.io client disconnects from the server
 			DeactivateListenerClient(socket.id)
 			CheckCloudClients(socket.id)
+			delete tmpSocketAccessTokens[socket.id]
 		})
 
 		socket.on('remote_error_opt', (optStatus: boolean) => {
@@ -1342,13 +1355,7 @@ function removeTestDeviceSource() {
 	for (let i = 0; i < device_sources.length; i++) {
 		if (device_sources[i].sourceId === 'TEST') {
 			device_sources.splice(i, 1)
-			UpdateSockets('device_sources')
-			UpdateCloud('device_sources')
-		}
-	}
-	for (let i = 0; i < device_sources.length; i++) {
-		if (device_sources[i].sourceId === 'TEST') {
-			device_sources.splice(i, 1)
+			i--
 			UpdateSockets('device_sources')
 			UpdateCloud('device_sources')
 		}
@@ -2034,6 +2041,7 @@ function TallyArbiter_Delete_Source(obj: Manage): ManageResponse {
 			sourceName = sources[i].name
 			if (sourceId !== 'TEST') {
 				StopConnection(sourceId)
+				delete SourceClients[sourceId]
 				sources.splice(i, 1)
 			} else {
 				ToggleTestMode(false)
@@ -2695,7 +2703,7 @@ function DeleteInactiveListenerClients() {
 		UpdateCloud('listener_clients')
 	}
 
-	setTimeout(DeleteInactiveListenerClients, 5 * 1000) // runs every 5 minutes
+	setTimeout(DeleteInactiveListenerClients, 5 * 1000) // runs every 5 seconds
 }
 
 function FlashListenerClient(listenerClientId): FlashListenerClientResponse | void {
@@ -2777,8 +2785,11 @@ function UpdateCamera(deviceId: string) {
 
 	const deviceState = getDeviceStates(deviceId)
 
-	const pgmBus = deviceState.find((bus) => bus.busId === '334e4eda')
-	const pvwBus = deviceState.find((bus) => bus.busId === 'e393251c')
+	const pgmBusOption = currentConfig.bus_options.find((b) => b.type === 'program')
+	const pvwBusOption = currentConfig.bus_options.find((b) => b.type === 'preview')
+
+	const pgmBus = pgmBusOption && deviceState.find((bus) => bus.busId === pgmBusOption.id)
+	const pvwBus = pvwBusOption && deviceState.find((bus) => bus.busId === pvwBusOption.id)
 
 	const inPgm = pgmBus && pgmBus.sources.length > 0
 	const inPvw = pvwBus && pvwBus.sources.length > 0
@@ -2904,7 +2915,7 @@ function CheckListenerClients() {
 	}
 
 	for (let i = 0; i < listener_clients.length; i++) {
-		if (!GetDeviceByDeviceId(listener_clients[i].deviceId)) {
+		if (GetDeviceByDeviceId(listener_clients[i].deviceId).id === 'unassigned') {
 			//this device has been removed, so reassign it to the first index
 			ReassignListenerClient(listener_clients[i].id, listener_clients[i].deviceId, newDeviceId)
 		}


### PR DESCRIPTION
## Summary

Fixes a set of correctness bugs in `src/index.ts` (and a small, minimal, related change in `src/_helpers/auth.ts`) that are unrelated to authorization/security. This addresses items #11-#19 from `CODE_REVIEW.md`.

Note: a parallel security-focused PR is also touching `src/index.ts` (rate limiter key swap, substring role checks, missing auth on companion/control-plane handlers, cloud_data ownership, dead Socket.IO v2 API for cloud client disconnect). This PR intentionally avoids all of those areas, but some merge conflict with that PR is possible/expected since both touch the same file — the repo owner can resolve those manually.

- Fix `typeof tmpSocketAccessTokens[socket.id] === undefined` (always false, since `typeof` returns the string `"undefined"`) so the "Access token required" error path actually runs.
- Guard the `listenerclient_connect` handler against malformed/null client payloads: wrap the object normalization in try/catch so a bad payload logs and returns early instead of throwing an uncaught exception.
- Fix the `cloud_devices` sync handler reading updated field values from `data[j]` instead of `data[i]` inside the matched-index block, which corrupted device records (or threw on array length mismatch) during cloud sync.
- Fix `TallyArbiter_Add_User` treating `addUser()` as a synchronous boolean when it actually returned a `Promise<boolean>` (always truthy), making the "user already exists" branch unreachable and swallowing promise rejections. Converted `hashPassword`/`addUser` in `src/_helpers/auth.ts` to synchronous (`bcrypt.hashSync`), matching the already-synchronous `editUser`/`deleteUser` pattern, so `TallyArbiter_Add_User`'s existing `if (addUser(...))` check works as intended without any other changes needed there.
- Fix `CheckListenerClients`' dead guard: `GetDeviceByDeviceId` always returns a synthetic `{ id: 'unassigned', ... }` object rather than a falsy value, so `!GetDeviceByDeviceId(...)` never fired. Now checks `.id === 'unassigned'` instead, so stale listener clients are actually reassigned when their device disappears.
- Fix an off-by-one in several `splice(i, 1)` cleanup loops (missing `i--` after the splice) that caused every other stale entry to be skipped in a single pass: the `cloud_sources`, `cloud_devices`, `cloud_device_sources`, and `cloud_listeners` sync handlers, plus `removeTestDeviceSource()` (which also had its entire loop body duplicated — removed the duplicate and fixed the remaining copy).
- Stop leaking memory: delete the `SourceClients` map entry in `TallyArbiter_Delete_Source` after `StopConnection()` (not inside `StopConnection` itself, since that's also called for disable-without-delete in `TallyArbiter_Edit_Source`, which still needs the client reference around for `.reconnect()`); and delete the `tmpSocketAccessTokens` entry in the `disconnect` handler.
- Look up Program/Preview buses by `bus_options[].type` instead of the hardcoded default bus UUIDs (`334e4eda` / `e393251c`) in `UpdateCamera`, so camera tally continues to work if a user edits/recreates their bus options.
- Fixed a stale comment ("runs every 5 minutes" -> "runs every 5 seconds") on the `DeleteInactiveListenerClients` timeout, which already ran every 5 seconds.
- Routed several `.catch((err) => console.error(err))` one-liners in socket handlers through the app's own `logger(err, 'error')` helper so these errors reach the persisted log / UI log stream instead of only the server console.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [ ] Manual smoke test of cloud sync (`cloud_sources`/`cloud_devices`/`cloud_device_sources`/`cloud_listeners`) with stale entries removed across multiple simultaneous removals.
- [ ] Manual smoke test of adding a duplicate user via the settings UI to confirm the "user already exists" error now surfaces.
- [ ] Manual smoke test of editing Program/Preview bus options and confirming camera tally (canon_xc / etc.) still tracks correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>