### PR TITLE
fix: unify duplicated fieldType unions across config field types

### DIFF
--- a/src/_models/OutputTypeDataFields.ts
+++ b/src/_models/OutputTypeDataFields.ts
@@ -1,13 +1,6 @@
+import { TallyInputConfigField } from '../_types/TallyInputConfigField'
+
 export interface OutputTypeDataFields {
 	outputTypeId: string
-	fields: {
-		fieldLabel: string
-		fieldName: string
-		fieldType: 'text' | 'port' | 'number' | 'dropdown' | 'info' | 'multiselect'
-		options?: {
-			id: string
-			label: string
-		}[]
-		text?: string
-	}[]
+	fields: TallyInputConfigField[]
 }

--- a/src/_models/SourceTypeDataFields.ts
+++ b/src/_models/SourceTypeDataFields.ts
@@ -1,14 +1,6 @@
+import { TallyInputConfigField } from '../_types/TallyInputConfigField'
+
 export interface SourceTypeDataFields {
 	sourceTypeId: string
-	fields: {
-		optional?: boolean
-		fieldLabel: string
-		fieldName: string
-		fieldType: 'text' | 'port' | 'number' | 'dropdown' | 'info' | 'multiselect'
-		options?: {
-			id: string
-			label: string
-		}[]
-		text?: string
-	}[]
+	fields: TallyInputConfigField[]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1220,23 +1220,17 @@ function getDeviceStates(deviceId?: string): DeviceState[] {
 }
 
 function getSourceTypeDataFields(): SourceTypeDataFields[] {
-	return Object.entries(TallyInputs).map(
-		([id, data]) =>
-			({
-				sourceTypeId: id,
-				fields: data.configFields,
-			}) as SourceTypeDataFields,
-	)
+	return Object.entries(TallyInputs).map(([id, data]) => ({
+		sourceTypeId: id,
+		fields: data.configFields,
+	}))
 }
 
 function getOutputTypeDataFields(): OutputTypeDataFields[] {
-	return Object.entries(Actions).map(
-		([id, data]) =>
-			({
-				outputTypeId: id,
-				fields: data.configFields,
-			}) as OutputTypeDataFields,
-	)
+	return Object.entries(Actions).map(([id, data]) => ({
+		outputTypeId: id,
+		fields: data.configFields,
+	}))
 }
 
 function getSourceTypes(): SourceType[] {


### PR DESCRIPTION
## Summary
- `SourceTypeDataFields.fields[]` and `OutputTypeDataFields.fields[]` each independently re-declared a `fieldType` union (`'text' | 'port' | 'number' | 'dropdown' | 'info' | 'multiselect'`) that omitted `'bool'`, even though `src/actions/Ember.ts` and `src/actions/TSL.ts` declare `configFields` entries with `fieldType: 'bool'`.
- This mismatch forced `as SourceTypeDataFields` / `as OutputTypeDataFields` type-assertion casts in `src/index.ts` (in `getSourceTypeDataFields()` / `getOutputTypeDataFields()`) to silently paper over the type error.
- Both interfaces were otherwise structurally identical to `TallyInputConfigField` (same field shape, same discriminated `fieldType` behavior), so `fields` in each now reuses `TallyInputConfigField[]` directly instead of re-declaring the union.
- Removed the now-unnecessary `as SourceTypeDataFields` / `as OutputTypeDataFields` casts in `src/index.ts`.

Addresses item #28 from `CODE_REVIEW.md`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` runs with zero errors after removing the casts.
- [x] Confirmed `configFields` on `TallyInputs`/`Actions` registries is already typed `TallyInputConfigField[]` (via `RegisterTallyInput`/`RegisterAction` decorators), so the cast removal is sound.
- [x] Grepped `src/actions/*.ts` and `src/sources/*.ts` for `fieldType: 'bool'` usages (Ember.ts, TSL.ts) to confirm they now type-check without assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)