### PR TITLE
fix: correct tally address field typo and heartbeat interval leak

### DIFF
--- a/src/sources/AnalogWayLivecore.ts
+++ b/src/sources/AnalogWayLivecore.ts
@@ -119,6 +119,9 @@ export class AWLivecoreSource extends TallyInput {
 		})
 
 		this.client.on('close', () => {
+			if (this.heartbeat_interval) {
+				clearInterval(this.heartbeat_interval)
+			}
 			this.connected.next(false)
 		})
 
@@ -160,13 +163,13 @@ export class AWLivecoreSource extends TallyInput {
 					// PVW
 					this.tallydata_AWLivecore[i].tally1 = tallyObj.tally1
 					this.tallydata_AWLivecore[i].preview = tallyObj.tally1
-					this.addBusToAddress(this.tallydata_AWLivecore[i].addresses, 'preview')
+					this.addBusToAddress(this.tallydata_AWLivecore[i].address, 'preview')
 				}
 				if (tallyObj.tally2 !== undefined) {
 					// PGM
 					this.tallydata_AWLivecore[i].tally2 = tallyObj.tally2
 					this.tallydata_AWLivecore[i].program = tallyObj.tally2
-					this.addBusToAddress(this.tallydata_AWLivecore[i].addresses, 'program')
+					this.addBusToAddress(this.tallydata_AWLivecore[i].address, 'program')
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Fixes item #29: `processAWLivecoreTally` called `this.addBusToAddress(this.tallydata_AWLivecore[i].addresses, ...)` with a nonexistent `.addresses` field. The tally object only ever has a singular `.address` field (set throughout the file). This meant `addBusToAddress` was always called with `undefined`, so per-input preview/program bus tracking never worked correctly for the Analog Way Livecore source.
- Fixes item #30: the heartbeat interval (`heartbeat_interval`) created in the socket's `'connect'` handler was only cleared inside its own stale-heartbeat timeout branch and in `exit()`. It was never cleared in the socket's `'close'` event handler. If the socket closed for any other reason (e.g. a network reset), the interval kept running and writing `'PCdgs\n'` to a dead/destroyed socket, and a new interval would be created on the next successful reconnect — causing overlapping heartbeat timers to accumulate over repeated reconnects.

## Changes
- `src/sources/AnalogWayLivecore.ts`: changed both `.addresses` references to `.address`.
- `src/sources/AnalogWayLivecore.ts`: added a guarded `clearInterval(this.heartbeat_interval)` in the socket `'close'` handler.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [x] Manually reviewed the full file to confirm no other `.addresses` usages remain and the `close` handler now mirrors the cleanup done in `exit()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)