### PR TITLE
fix: correct port cleanup and cap incoming webhook body size

### DIFF
--- a/src/sources/IncomingWebhook.ts
+++ b/src/sources/IncomingWebhook.ts
@@ -11,21 +11,45 @@ import { logger } from '..'
 ])
 export class IncomingWebhookSource extends TallyInput {
 	private server: http.Server
+	private port: number
+
+	private static readonly MAX_BODY_SIZE = 1024 * 1024 // 1MB
 
 	constructor(source: Source) {
 		super(source)
 		const port = source.data.port || 8080
 		const path = source.data.path || '/webhook'
 
-		UsePort(port, this.source.id)
+		this.port = port
+
+		UsePort(this.port, this.source.id)
 
 		this.server = http.createServer((req, res) => {
 			if (req.method === 'POST' && req.url === path) {
 				let body = ''
+				let bodySize = 0
+				let tooLarge = false
 				req.on('data', (chunk) => {
+					if (tooLarge) {
+						return
+					}
+
+					bodySize += chunk.length
+
+					if (bodySize > IncomingWebhookSource.MAX_BODY_SIZE) {
+						tooLarge = true
+						res.writeHead(413)
+						res.end('Payload Too Large')
+						req.destroy()
+						return
+					}
+
 					body += chunk
 				})
 				req.on('end', () => {
+					if (tooLarge) {
+						return
+					}
 					try {
 						interface IncomingWebhookData {
 							[address: string]: string[]
@@ -58,9 +82,9 @@ export class IncomingWebhookSource extends TallyInput {
 			}
 		})
 
-		this.server.listen(port, () => {
+		this.server.listen(this.port, () => {
 			this.connected.next(true)
-			logger(`Incoming Webhook listening on port ${port}${path}`, 'info')
+			logger(`Incoming Webhook listening on port ${this.port}${path}`, 'info')
 		})
 
 		this.server.on('error', (err) => {
@@ -71,7 +95,7 @@ export class IncomingWebhookSource extends TallyInput {
 	public exit(): void {
 		super.exit()
 		this.server.close()
-		FreePort(this.source.data.port, this.source.id)
+		FreePort(this.port, this.source.id)
 		this.connected.next(false)
 	}
 }


### PR DESCRIPTION
## Summary
- `exit()` was freeing the port using the raw, un-fallback-adjusted `source.data.port`, while the listener actually started on `source.data.port || 8080`. When `source.data.port` was falsy, `FreePort`'s lookup (`port == port && sourceId == sourceId`) would miss the actual entry registered at port 8080, potentially corrupting an unrelated port registry entry. The resolved port is now stored once as `this.port` and reused consistently in both `UsePort(...)` and `FreePort(...)`.
- The incoming webhook request body was accumulated with no size limit (`body += chunk` in `req.on('data', ...)`), allowing a client to POST an arbitrarily large body and exhaust server memory. The body is now capped at 1MB; exceeding it responds with `413 Payload Too Large` and destroys the request without further processing.

Addresses items #37 and #38 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manual: start an Incoming Webhook source with no port configured, confirm it listens on 8080, and confirm `exit()` frees the correct port entry
- [ ] Manual: POST a body larger than 1MB to the webhook endpoint and confirm a 413 response with no memory blowup

🤖 Generated with [Claude Code](https://claude.com/claude-code)