### PR TITLE
fix: correct duplicate RecordingStatus.Stopping case in ATEM source

### DIFF
--- a/src/sources/BlackmagicATEM.ts
+++ b/src/sources/BlackmagicATEM.ts
@@ -99,8 +99,8 @@ export class BlackmagicATEMSource extends TallyInput {
 			this.processATEMTally()
 		})
 
-		// this.atemClient.on('info', console.log);
-		this.atemClient.on('error', console.error)
+		// this.atemClient.on('info', (info) => logger(`Source: ${source.name} ATEM info: ${info}`, 'info-quiet'));
+		this.atemClient.on('error', (error) => logger(`Source: ${source.name} ATEM Error: ${error}`, 'error'))
 
 		this.atemClient.connect(atemIP)
 	}
@@ -139,7 +139,7 @@ export class BlackmagicATEMSource extends TallyInput {
 			case RecordingStatus.Stopping:
 				this.prvList.add('{{RECORDING}}')
 				break
-			case RecordingStatus.Stopping:
+			case RecordingStatus.Recording:
 				this.pgmList.add('{{RECORDING}}')
 				break
 			default:


### PR DESCRIPTION
## Summary
- The switch statement in `src/sources/BlackmagicATEM.ts` that maps ATEM recording status to tally state had `case RecordingStatus.Stopping:` duplicated. The second occurrence was clearly meant to be `case RecordingStatus.Recording:` (confirmed against the `RecordingStatus` enum in `atem-connection` v3.4.0: `Idle = 0`, `Recording = 1`, `Stopping = 128`), so active recording was never surfaced on the program bus — only the "stopping" state was ever reachable.
- Fixed the second case to `RecordingStatus.Recording`.
- Replaced the raw `console.error` (and commented-out `console.log`) calls on the ATEM client's `error`/`info` events with the app's `logger()` helper (`src/_helpers/logger.ts` via `src/index.ts`), matching the logging convention used in the other source files (e.g. `BlackmagicVideoHub.ts`, `AnalogWayLivecore.ts`).

This addresses item #31 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manual verification against a live ATEM switcher: confirm that starting a recording now surfaces `{{RECORDING}}` on the program bus tally, and that "stopping" continues to surface on preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)