### PR TITLE
fix: reset connected state when Roland Smart Tally polling fails

### DIFF
--- a/src/sources/RolandSmartTally.ts
+++ b/src/sources/RolandSmartTally.ts
@@ -23,6 +23,8 @@ export class RolandSmartTallySource extends TallyInput {
 			axios
 				.get(`http://${ip}/tally/${address}/status`)
 				.then((response) => {
+					this.connected.next(true)
+
 					let tallyObj: any = {}
 					tallyObj.address = address
 					tallyObj.label = address
@@ -48,6 +50,7 @@ export class RolandSmartTallySource extends TallyInput {
 					this.sendTallyData()
 				})
 				.catch((error) => {
+					this.connected.next(false)
 					logger(`Source: ${this.source.name}  Roland Smart Tally Error: ${error}`, 'error')
 				})
 		}


### PR DESCRIPTION
## Summary
- `connected` was set to `true` once in the constructor and never reset, so the UI reported the Roland Smart Tally source as "Connected" indefinitely even after the device became unreachable.
- Poll failures were caught and logged but did not update connection state; poll successes didn't re-affirm it either.
- This PR sets `this.connected.next(false)` in the `catch` block of `checkRolandStatus()` when a poll fails, and `this.connected.next(true)` in the `then` block when a poll succeeds, so `connected` accurately reflects the most recent poll result.

Addresses item #43 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manual verification against a real/simulated Roland Smart Tally device (poll success/failure toggling `connected`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)