### PR TITLE
fix: correct Aux 10 bus id typo and filter tally updates by source

### DIFF
--- a/src/sources/RossCarbonite.ts
+++ b/src/sources/RossCarbonite.ts
@@ -227,7 +227,7 @@ const RossSwitcherBusAddresses = {
 	{ bus: 'aux7', name: 'Aux 7' },
 	{ bus: 'aux8', name: 'Aux 8' },
 	{ bus: 'aux9', name: 'Aux 9' },
-	{ bus: 'au10', name: 'Aux 10' },
+	{ bus: 'aux10', name: 'Aux 10' },
 	{ bus: 'aux11', name: 'Aux 11' },
 	{ bus: 'aux12', name: 'Aux 12' },
 	{ bus: 'aux13', name: 'Aux 13' },
@@ -252,7 +252,7 @@ const RossSwitcherBusAddresses = {
 	{ bus: 'aux7', name: 'Aux 7' },
 	{ bus: 'aux8', name: 'Aux 8' },
 	{ bus: 'aux9', name: 'Aux 9' },
-	{ bus: 'au10', name: 'Aux 10' },
+	{ bus: 'aux10', name: 'Aux 10' },
 	{ bus: 'aux11', name: 'Aux 11' },
 	{ bus: 'aux12', name: 'Aux 12' },
 	{ bus: 'aux13', name: 'Aux 13' },
@@ -282,7 +282,7 @@ const RossSwitcherBusAddresses = {
 	{ bus: 'aux7', name: 'Aux 7' },
 	{ bus: 'aux8', name: 'Aux 8' },
 	{ bus: 'aux9', name: 'Aux 9' },
-	{ bus: 'au10', name: 'Aux 10' },
+	{ bus: 'aux10', name: 'Aux 10' },
 	{ bus: 'aux11', name: 'Aux 11' },
 	{ bus: 'aux12', name: 'Aux 12' },
 	{ bus: 'aux13', name: 'Aux 13' },
@@ -312,7 +312,7 @@ const RossSwitcherBusAddresses = {
 	{ bus: 'aux7', name: 'Aux 7' },
 	{ bus: 'aux8', name: 'Aux 8' },
 	{ bus: 'aux9', name: 'Aux 9' },
-	{ bus: 'au10', name: 'Aux 10' },
+	{ bus: 'aux10', name: 'Aux 10' },
 	{ bus: 'aux11', name: 'Aux 11' },
 	{ bus: 'aux12', name: 'Aux 12' },
 	{ bus: 'aux13', name: 'Aux 13' },
@@ -457,6 +457,9 @@ export class RossCarboniteSource extends TallyInput {
 		let found = false
 
 		for (let i = 0; i < device_sources.length; i++) {
+			if (device_sources[i].sourceId !== this.source.id) {
+				continue
+			}
 			inPreview = false
 			inProgram = false
 			if (device_sources[i].address === address) {


### PR DESCRIPTION
## Summary
- Fixed a typo (`'au10'` -> `'aux10'`) in the `@RegisterTallyInput` bus registration lists for the Ross Carbonite Black Solo, Ross Graphite, Ross Carbonite Black SD/HD, and Ross Carbonite Ultra switcher models. These registrations did not match the `'aux10'` key used in the corresponding address tables (`RossCarboniteBlackSoloBusAddresses` and siblings), so a device source configured for "Aux 10" on any of these 4 models never matched in the tally-update function and Aux 10 tally silently never fired.
- Fixed `updateRossCarboniteTallyData()` to filter the `device_sources` loop by `sourceId === this.source.id`, matching the pattern already used in `ContributionTally.ts`'s equivalent function. Previously the loop iterated the entire global `device_sources` array with no source filter, so a device source belonging to a different configured tally source with a matching address string could bleed state into this Ross Carbonite source's tally.

This addresses items #41 and #42 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manual verification against real Ross Carbonite hardware/switcher for Aux 10 tally on Black Solo, Graphite, Black SD/HD, and Ultra models
- [ ] Manual verification that tally no longer bleeds between two configured sources sharing an address string

🤖 Generated with [Claude Code](https://claude.com/claude-code)