### PR TITLE
fix: guard against empty OSC args and add dgram error handling

### DIFF
--- a/src/sources/OSC.ts
+++ b/src/sources/OSC.ts
@@ -27,6 +27,10 @@ export class OSCSource extends TallyInput {
 		})
 
 		this.server.on('message', (oscMsg, timeTag, info) => {
+			if (!oscMsg.args?.length) {
+				return
+			}
+
 			logger(
 				`Source: ${source.name} OSC message received: ${oscMsg.address} ${oscMsg.args[0].value.toString()}`,
 				'info-quiet',
@@ -61,6 +65,7 @@ export class OSCSource extends TallyInput {
 
 		this.server.on('error', (error) => {
 			logger(`Source: ${source.name} OSC Error: ${error}`, 'error')
+			this.connected.next(false)
 		})
 
 		this.server.on('ready', () => {


### PR DESCRIPTION
## Summary
- Fixes a crash in the OSC source (`src/sources/OSC.ts`): `oscMsg.args[0].value` was dereferenced without checking that `args` was non-empty, so any zero-argument OSC packet sent to the listening UDP port threw an uncaught `TypeError` inside the `'message'` handler. Added a guard that returns early when `oscMsg.args` is empty or undefined.
- Adds `this.connected.next(false)` to the underlying dgram socket's `'error'` handler (forwarded through the `osc` library's `UDPPort`), so a socket error (e.g. port already in use) is correctly reflected in the source's connection status instead of leaving it in whatever state it was previously.
- Confirmed `connected.next(true)` was already correctly gated behind the `'ready'` event (which the `osc` library only emits after the internal `dgram` socket's `bind()` callback succeeds), so no change was needed there for this file.

This addresses item #39 (and part of #48, which affects several other source files using raw `dgram` sockets) from the codebase review.

Note: only `src/sources/OSC.ts` was touched. `src/actions/OSC.ts` (outgoing OSC actions) is a separate file and was left untouched.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manually send a zero-argument OSC packet to the source's listening port and confirm no crash
- [ ] Manually trigger a dgram socket error (e.g. bind to an already-used port) and confirm `connected` status reflects `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)