### PR TITLE
fix: close socket on exit and correct array indexOf usage in VMix source

### DIFF
--- a/src/sources/VMix.ts
+++ b/src/sources/VMix.ts
@@ -54,7 +54,7 @@ export class VMixSource extends TallyInput {
 				//we received some other command, so lets process it
 				if (data[0].indexOf('ACTS OK Recording ') > -1) {
 					this.setBussesForAddress('{{RECORDING}}', [])
-					if (data.indexOf('ACTS OK Recording 1') > -1) {
+					if (data[0].indexOf('ACTS OK Recording 1') > -1) {
 						this.setBussesForAddress('{{RECORDING}}', ['program'])
 					}
 					this.sendTallyData()
@@ -62,7 +62,7 @@ export class VMixSource extends TallyInput {
 
 				if (data[0].indexOf('ACTS OK Streaming ') > -1) {
 					this.setBussesForAddress('{{STREAMING}}', [])
-					if (data.indexOf('ACTS OK Streaming 1') > -1) {
+					if (data[0].indexOf('ACTS OK Streaming 1') > -1) {
 						this.setBussesForAddress('{{STREAMING}}', ['program'])
 						this.sendTallyData()
 					}
@@ -93,5 +93,7 @@ export class VMixSource extends TallyInput {
 	public exit(): void {
 		super.exit()
 		this.client.write('QUIT\r\n')
+		this.client.end()
+		this.client.destroy()
 	}
 }


### PR DESCRIPTION
## Summary
- `exit()` in `src/sources/VMix.ts` wrote a final `QUIT\r\n` command to the TCP socket but never called `.end()`/`.destroy()`, leaking the socket on every source teardown. Fixed to match the pattern used by sibling raw-`net.Socket` sources (`RolandVR.ts`, `NewtekTricaster.ts`, `AnalogWayLivecore.ts`), which call `.end()` then `.destroy()` after writing their final command.
- The recording/streaming detection block called `data.indexOf('ACTS OK Recording 1')` and `data.indexOf('ACTS OK Streaming 1')` where `data` is the array of split lines (from an earlier `.split(/\r?\n/)`), not a string. This only happened to work by accident via `Array.prototype.indexOf`'s exact-match semantics. Fixed both to use `data[0].indexOf(...)`, matching the sibling substring check two lines above.

Addresses items #49 (part) and #50 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manually reviewed `RolandVR.ts` and `NewtekTricaster.ts` to confirm the exit()/socket-cleanup idiom matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)