### PR TITLE
cleanup: replace implicit substring argument-swap with explicit charAt

### DIFF
--- a/src/sources/RolandVR.ts
+++ b/src/sources/RolandVR.ts
@@ -29,7 +29,7 @@ export class RolandVRSource extends TallyInput {
 					//clear out any old tally values
 					this.removeBusFromAllAddresses('program')
 					//now enter the new PGM value based on the received data
-					const address = dataString.substring(dataString.length - 1, dataString.length - 2)
+					const address = dataString.charAt(dataString.length - 2)
 					this.addBusToAddress(address, 'program')
 					this.sendTallyData()
 				}


### PR DESCRIPTION
## Summary
- `src/sources/RolandVR.ts` extracted the second-to-last character of the incoming data string via `dataString.substring(dataString.length - 1, dataString.length - 2)`, relying on `String.prototype.substring`'s implicit behavior of swapping its start/end arguments when start > end.
- This is functionally correct today but fragile and confusing — it would silently produce wrong results (or fail unexpectedly) if the response format ever changed, e.g. an extra trailing `\r`.
- Replaced with the equivalent, explicit `dataString.charAt(dataString.length - 2)`.

This addresses the RolandVR.ts improvement identified in a codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Verified the `charAt` call extracts the identical character as the original `substring` swap (both target index `length - 2`)