### PR TITLE
cleanup: remove unused import and fix off-by-one in test mode source

### DIFF
--- a/src/sources/InternalTestMode.ts
+++ b/src/sources/InternalTestMode.ts
@@ -1,5 +1,4 @@
 import { currentConfig } from '../_helpers/config'
-import { timeStamp } from 'console'
 import { RegisterTallyInput } from '../_decorators/RegisterTallyInput.decorator'
 import { Source } from '../_models/Source'
 import { TallyInput } from './_Source'
@@ -61,7 +60,7 @@ export class InternalTestModeSource extends TallyInput {
 		this.addresses.next(
 			this.addresses.value.filter((a) => {
 				let current_test_address_number = parseInt(a.address.replace('TEST_', ''))
-				return current_test_address_number <= this.source.data.addressesNumber
+				return current_test_address_number < this.source.data.addressesNumber
 			}),
 		)
 		this.sendTallyData()


### PR DESCRIPTION
## Summary
- Removed an unused `import { timeStamp } from 'console'` in `src/sources/InternalTestMode.ts` (confirmed no other references in the file).
- Fixed an off-by-one in the address-trimming filter: addresses are zero-indexed (`TEST_0 .. TEST_(addressesNumber-1)`), so the filter comparing `current_test_address_number` against `addressesNumber` should use `<` rather than `<=`. Previously, shrinking `addressesNumber` across a reconfiguration could leave one stale higher-indexed address (`TEST_<addressesNumber>`) behind.

This addresses improvements identified for `InternalTestMode.ts` from a codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [x] Manually reviewed address indexing logic (`getAddressForIdx`, the address-creation loop, and the filter) to confirm the `<=` was genuinely an off-by-one and not intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)