### PR TITLE
fix: close socket on exit and cap receive buffer in Panasonic source

### DIFF
--- a/src/sources/PanasonicAVHS410.ts
+++ b/src/sources/PanasonicAVHS410.ts
@@ -95,6 +95,18 @@ export class PanasonicAVHS410Source extends TallyInput {
 				offset = 0
 			receivebuffer += message
 
+			// Guard against unbounded growth if a packet without an ETX terminator
+			// keeps arriving (e.g. malformed/partial data that never completes).
+			const maxReceiveBufferSize = 65536
+			if (receivebuffer.length > maxReceiveBufferSize && receivebuffer.indexOf(ETX) === -1) {
+				logger(
+					`Source: ${source.name}  Panasonic AV-HS410 receive buffer exceeded ${maxReceiveBufferSize} bytes without finding an ETX terminator. Resetting buffer.`,
+					'error',
+				)
+				receivebuffer = ''
+				return
+			}
+
 			// If we receve a data package from the unit - Parse it
 			while ((i = receivebuffer.indexOf(ETX, offset)) !== -1) {
 				packet = receivebuffer.substr(offset, i - offset)
@@ -124,9 +136,9 @@ export class PanasonicAVHS410Source extends TallyInput {
 									this.sendTallyData()
 									break
 								case '03': // PVW
-									// Clear the old input from Program Bus
+									// Clear the old input from Preview Bus
 									this.removeBusFromAllAddresses('preview')
-									// Set new input to Program Bus
+									// Set new input to Preview Bus
 									this.addBusToAddress(address.toString(), 'preview')
 									this.sendTallyData()
 									break
@@ -222,5 +234,7 @@ export class PanasonicAVHS410Source extends TallyInput {
 		}
 
 		this.client.write('QUIT\r\n')
+		this.client.end()
+		this.client.destroy()
 	}
 }


### PR DESCRIPTION
## Summary
- `exit()` in `PanasonicAVHS410Source` wrote a final `QUIT` command to the TCP socket but never closed it, leaking a socket on every source teardown/reconnect. Now calls `.end()` then `.destroy()` after the final write, matching the pattern used in `RolandVR.ts`, `NewtekTricaster.ts`, and `AnalogWayLivecore.ts`.
- The UDP multicast handler accumulated incoming `Buffer` chunks into `receivebuffer` via `+=` while waiting for an ETX terminator. A malformed/partial packet stream that never produces an ETX would grow this buffer unbounded. Added a 65536-byte cap: if exceeded without an ETX present, logs an error-level warning via `logger()` and resets the buffer.
- Corrected a stale/copy-pasted comment on the `case '03': // PVW` branch that described the code as operating on the "Program Bus" when it actually clears/sets the Preview bus. No logic changes.

This addresses item #49 (part) from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manual code review against sibling TCP sources for the exit()/socket-cleanup idiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)