### PR TITLE
fix: correct broken send callback and add error handler in UDP action

### DIFF
--- a/src/actions/UDP.ts
+++ b/src/actions/UDP.ts
@@ -37,9 +37,11 @@ export class UDP extends Action {
 
 			if (!this.action.data.type) this.action.data.type = 'udp4'
 			let client = dgram.createSocket(this.action.data.type)
-			client.on('message', function (msg, info) {})
+			client.on('error', (err) => {
+				logger(`An error occured sending the Generic UDP: ${err}`, 'error')
+			})
 
-			client.send(Uint8Array.from(sendBuf), this.action.data.port, this.action.data.ip, function (error) {
+			client.send(Uint8Array.from(sendBuf), this.action.data.port, this.action.data.ip, (error) => {
 				if (!error) {
 					logger(
 						`Generic UDP sent: ${this.action.data.ip}:${this.action.data.port} : ${this.action.data.string}`,


### PR DESCRIPTION
## Summary
- `client.send()`'s success callback in `src/actions/UDP.ts` was a plain `function` expression, so `this` did not refer to the `UDP` action instance in strict mode. This caused a `TypeError: Cannot read properties of undefined` on every successful send, because the log line accessed `this.action.data.ip/port/string`. Changed the callback to an arrow function so `this` is correctly bound to the enclosing scope.
- The dgram `client` had no `'error'` listener, unlike other socket-based actions in this codebase (e.g. `TCP.ts`). An unhandled `'error'` event on an EventEmitter throws, potentially crashing the process. Added `client.on('error', (err) => { logger(...) })` following the same pattern used in `TCP.ts`.
- Removed a dead no-op `client.on('message', function (msg, info) {})` listener — this socket is send-only, so the listener served no purpose.

This addresses item #53 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manually trigger a Generic UDP action and confirm the success log line ("Generic UDP sent: ...") appears without a TypeError
- [ ] Manually trigger a Generic UDP action against an unreachable/invalid target and confirm the error is logged instead of crashing the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)