### PR TITLE
fix: avoid destroy() truncating unflushed writes in TCP/RossTalk actions

### DIFF
--- a/src/actions/RossTalk.ts
+++ b/src/actions/RossTalk.ts
@@ -16,8 +16,7 @@ export class RossTalk extends Action {
 
 			tcpClient.on('connect', () => {
 				tcpClient.write(this.action.data.string + '\r\n')
-				tcpClient.end()
-				tcpClient.destroy() // kill client after sending data
+				tcpClient.end() // flushes pending writes, then closes the connection
 				logger(`RossTalk sent: ${this.action.data.ip}:${this.action.data.port} : ${this.action.data.string}`, 'info')
 			})
 

--- a/src/actions/TCP.ts
+++ b/src/actions/TCP.ts
@@ -29,8 +29,7 @@ export class TCP extends Action {
 			tcpClient.on('connect', () => {
 				let sendBuf = Buffer.from(unescape(this.action.data.string) + this.action.data.end, 'latin1')
 				tcpClient.write(Uint8Array.from(sendBuf))
-				tcpClient.end()
-				tcpClient.destroy() // kill client after sending data
+				tcpClient.end() // flushes pending writes, then closes the connection
 				logger(`Generic TCP sent: ${this.action.data.ip}:${this.action.data.port} : ${this.action.data.string}`, 'info')
 			})
 


### PR DESCRIPTION
## Summary
- `src/actions/TCP.ts` and `src/actions/RossTalk.ts` each called `client.write(...)` followed immediately by `client.end()` and then `client.destroy()` in the same synchronous tick.
- Per Node's `net.Socket` docs, `destroy()` is a hard, immediate teardown that can discard data not yet flushed to the OS socket buffer. Calling it right after `end()` risks truncating the outgoing TCP/RossTalk command before it reaches the wire, particularly for larger payloads or a slow/congested link.
- Removed the premature `destroy()` call in both files. `end()` alone flushes any pending writes before closing the connection, which is sufficient for this fire-and-forget, one-shot-socket-per-trigger pattern.

This addresses item #60 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manual verification against a real TCP/RossTalk device with a larger payload (not performed in this environment)