### PR TITLE
fix: repair reconnect logic and guard buffer parsing in DataVideoIP

### DIFF
--- a/src/sources/DataVideoIP.ts
+++ b/src/sources/DataVideoIP.ts
@@ -97,6 +97,7 @@ export class DataVideoIP extends TallyInput {
 
 		this.socket_request.on('error', (err) => {
 			logger(`DataVideoIP: Network error: ${err.message}`, 'error')
+			this.connected.next(false)
 		})
 
 		this.socket_request.connect(5009, this.source.data.ip, () => {
@@ -117,10 +118,10 @@ export class DataVideoIP extends TallyInput {
 
 					this.setupConnection()
 				} else {
-					this.reconnect()
+					this.connected.next(false)
 				}
 			} else {
-				this.reconnect()
+				this.connected.next(false)
 			}
 		})
 	}
@@ -166,10 +167,27 @@ export class DataVideoIP extends TallyInput {
 
 	/**
 	 * Reconnects by cleaning up and re-initializing TCP connections after a short delay.
-	 * If the reconnection happens to fast, the vision mixer may crash
+	 * If the reconnection happens to fast, the vision mixer may crash.
+	 *
+	 * Note: this deliberately does NOT call this.exit(), which would reset the base
+	 * class's `tryReconnecting` flag and cause the next `connected.next(false)` to be
+	 * treated as a fresh "startup" event instead of a reconnect-worthy disconnect. That
+	 * would stop the base class from scheduling any further reconnect attempts after
+	 * this one. Sockets are cleaned up directly instead, and listeners are removed
+	 * first so a delayed/stale 'close' or 'error' event from the old socket can't fire
+	 * an extra, duplicate connected.next(false) after we've already moved on.
 	 */
 	public reconnect(): void {
-		this.exit()
+		if (this.socket_realtime) {
+			this.socket_realtime.removeAllListeners()
+			this.socket_realtime.destroy()
+			delete this.socket_realtime
+		}
+		if (this.socket_request) {
+			this.socket_request.removeAllListeners()
+			this.socket_request.destroy()
+			delete this.socket_request
+		}
 		setTimeout(() => this.initTCP(), 500)
 	}
 
@@ -198,6 +216,15 @@ export class DataVideoIP extends TallyInput {
 	 */
 	processBuffer(buffer: Buffer) {
 		// logger(`DataVideoIP: Received buffer: ${buffer.toString('hex')}`, 'info-quiet');
+
+		// Minimum valid frame is an 8-byte header (commandId lives at offset 4-7).
+		// A short/malformed TCP segment could otherwise throw a RangeError here.
+		// Each 'data' event is treated as a self-contained frame (there is no
+		// cross-event carry-over buffer in this class), so we simply drop/ignore
+		// anything shorter than a header rather than attempting to parse it.
+		if (buffer.length < 8) {
+			return
+		}
 
 		// Parse command ID (little-endian, offset 4)
 		const commandId = buffer.readInt32LE(4)


### PR DESCRIPTION
## Summary

This addresses items #34, #35, #36 from the codebase review, all in `src/sources/DataVideoIP.ts`. All four bugs revolve around how this source interacts with the reconnect state machine in `src/sources/_Source.ts` (`TallyInput`), and were investigated together since they touch the same connect/reconnect/data flow.

Background on the base class: `TallyInput` tracks a private `tryReconnecting` flag. `exit()` sets it to `false`. When `connected.next(false)` fires while `tryReconnecting` is `false`, the base class treats it as a fresh "startup" event (no reconnect timer scheduled) rather than a real disconnect. Only when `tryReconnecting` is already `true` does a `connected.next(false)` schedule a backoff timer that eventually calls the subclass's `reconnect()`.

1. **Control-port `error` handler never touched `connected`.** `socket_request`'s `'error'` handler only logged. An initial connection failure to the control port (e.g. `ECONNREFUSED` when negotiating the realtime port) never told the base class the connection failed, so no reconnect was ever scheduled — the source would just sit dead. Fixed by calling `this.connected.next(false)` from that handler.

2. **`reconnect()` called `this.exit()`, disabling reconnection after one cycle.** `exit()` sets `tryReconnecting = false`. Since `reconnect()` called `this.exit()` before reinitializing, the very next `connected.next(false)` (from the next failed attempt) was treated as a "startup" event instead of a disconnect, so the base class never scheduled a second reconnect attempt — auto-reconnect silently died after exactly one retry. Fixed by having `reconnect()` clean up the sockets directly (`removeAllListeners()` + `destroy()`) without calling `exit()`, leaving `tryReconnecting` untouched. Listeners are removed before destroying so a delayed/stale `'close'`/`'error'` from the old socket can't sneak in an extra `connected.next(false)` after `reconnect()` has already moved on to reinitializing.

3. **Bad handshake response caused an uncapped 500ms retry loop.** On a malformed/unexpected control-port response, `requestPort()` called `this.reconnect()` directly, which re-tried every ~500ms forever, completely bypassing the base class's `connected`-driven backoff and `max_reconnects` limit. Fixed by routing this failure path through `this.connected.next(false)` instead, so it goes through the same counter/backoff logic as every other disconnect.

4. **`processBuffer()` had no length check before parsing.** It called `buffer.readInt32LE(4)` (needs at least 8 bytes) and read 8-byte blocks with no guard that the buffer was long enough. A short/malformed TCP segment would throw a `RangeError` synchronously inside the `'data'` handler, crashing the source. Fixed by returning early when `buffer.length < 8`. Note: each `'data'` event is already treated as a self-contained frame in this class (there's no persistent cross-event buffer), so the early return just ignores the too-short chunk rather than introducing new buffering state.

I re-read the full connect/reconnect/data flow after making all four changes to confirm they interact correctly — in particular, that removing `exit()` from `reconnect()` doesn't reopen a "duplicate reconnect from a stale socket event" problem (handled via `removeAllListeners()` before `destroy()`), and that this pattern (`reconnect()` not touching `exit()`/`tryReconnecting`) matches the convention already used by every other source in `src/sources/*.ts`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Read `_Source.ts` and the full `DataVideoIP.ts` before and after changes to trace the connect/reconnect/data flow end-to-end
- [x] Confirmed the `reconnect()` pattern (call the connect routine directly, don't call `exit()`) matches every other source in the repo (`BlackmagicVideoHub.ts`, `AnalogWayLivecore.ts`, `OBS.ts`, `NewtekTricaster.ts`, `RolandVR.ts`, `VMix.ts`, `PanasonicAVHS410.ts`)
- [ ] No hardware available in this environment to test against a real DVIP switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)