### PR TITLE
fix: use protocol-aware port default and bound the webhook request

### DIFF
--- a/src/actions/OutgoingWebhook.ts
+++ b/src/actions/OutgoingWebhook.ts
@@ -49,15 +49,17 @@ export class OutgoingWebhook extends Action {
 				: ''
 			this.action.data.protocol = this.action.data.protocol || 'http://'
 
-			this.action.data.port = this.action.data.port
-				? this.action.data.port === ''
-					? '80'
-					: this.action.data.port
-				: '80' //explicitly set the port to 80 if they did not specify
+			//default the port based on the selected protocol if the port was not explicitly configured
+			const defaultPort = this.action.data.protocol === 'https://' ? '443' : '80'
+			this.action.data.port = this.action.data.port || defaultPort
 
 			let options = {
 				method: this.action.data.method,
 				url: this.action.data.protocol + this.action.data.ip + ':' + this.action.data.port + path,
+				timeout: 5000, // fire-and-forget tally notification, don't hang indefinitely
+				maxRedirects: 5,
+				maxContentLength: 5 * 1024 * 1024, // 5MB
+				maxBodyLength: 5 * 1024 * 1024, // 5MB
 			} as any
 
 			options.headers = options.headers || {}


### PR DESCRIPTION
## Summary
- Fix the Outgoing Webhook action's port default so it is protocol-aware: previously any blank/unset port defaulted to `80` even when `https://` was selected, producing a broken URL (`https://host:80/...`). Now defaults to `80` for `http://` and `443` for `https://`, and only applies when the port field is genuinely blank/unset — an explicitly configured port is never overridden.
- Add safety limits to the outgoing `axios(...)` request: `timeout: 5000` (this is a fire-and-forget tally notification and shouldn't hang indefinitely), `maxRedirects: 5`, and `maxContentLength`/`maxBodyLength` capped at 5MB. Without these, a hung or misbehaving endpoint could accumulate unbounded in-flight requests as tally state toggles repeatedly. The existing `.catch(...)` still catches timeout/error cases and logs them, so no unhandled rejections are introduced.

This addresses the OutgoingWebhook.ts improvements identified in a codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manually configure an Outgoing Webhook action with `https://` protocol and a blank port, verify the request is sent to port 443
- [ ] Manually configure an Outgoing Webhook action pointed at a non-responsive endpoint, verify the request times out after ~5s and logs an error instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)