### PR TITLE
fix: parse quoted multi-word OSC arguments correctly

### DIFF
--- a/src/actions/OSC.ts
+++ b/src/actions/OSC.ts
@@ -38,29 +38,46 @@ oscUDP.on('ready', function () {
 ])
 export class OSC extends Action {
 	public run(): void {
-		let args = []
 		let data = []
 
 		const isNumeric = (string) => /^[+-]?\d+(\.\d+)?$/.test(string)
 
 		if (this.action.data.args !== '') {
-			args = this.action.data.args.split(' ')
+			// Quote-aware tokenizer: a double-quoted span (which may contain
+			// spaces) is treated as a single argument; everything else is
+			// split on whitespace, matching the documented behavior that
+			// "Strings must be encapsulated by double quotes."
+			const tokens: { value: string; quoted: boolean }[] = []
+			const tokenRegex = /"([^"]*)"|(\S+)/g
+			let match: RegExpExecArray | null
+
+			while ((match = tokenRegex.exec(this.action.data.args)) !== null) {
+				if (match[1] !== undefined) {
+					tokens.push({ value: match[1], quoted: true })
+				} else {
+					tokens.push({ value: match[2], quoted: false })
+				}
+			}
+
 			let arg: any
 
-			for (let i = 0; i < args.length; i++) {
-				// Check if OSC-string
-				if (!isNumeric(args[i])) {
+			for (let i = 0; i < tokens.length; i++) {
+				const { value, quoted } = tokens[i]
+				// Check if OSC-string. A quoted argument is always treated as a
+				// string, even if its contents look numeric, since quoting is
+				// how the user explicitly opts into string type.
+				if (quoted || !isNumeric(value)) {
 					arg = {
 						type: 's',
-						value: args[i].replace(/"/g, '').replace(/'/g, ''),
+						value: value.replace(/"/g, '').replace(/'/g, ''),
 					}
 					data.push(arg)
 				}
 				// Check if float32
-				else if (args[i].toString().indexOf('.') > -1) {
+				else if (value.toString().indexOf('.') > -1) {
 					arg = {
 						type: 'f',
-						value: parseFloat(args[i]),
+						value: parseFloat(value),
 					}
 					data.push(arg)
 				}
@@ -68,7 +85,7 @@ export class OSC extends Action {
 				else {
 					arg = {
 						type: 'i',
-						value: parseInt(args[i]),
+						value: parseInt(value),
 					}
 					data.push(arg)
 				}


### PR DESCRIPTION
## Summary
- The OSC action's help text documents that arguments should be space-separated and that "Strings must be encapsulated by double quotes," implying quoted values may contain spaces.
- The implementation split the raw `args` string with `args.split(' ')` *before* any quote handling occurred, so a quoted multi-word value like `"hello world"` became two malformed tokens (`'"hello'`, `'world"'`) instead of a single string argument.
- Replaced the naive split with a quote-aware tokenizer (`/"([^"]*)"|(\S+)/g`) that treats a double-quoted span as one token (spaces preserved inside, quotes stripped) and splits on whitespace everywhere else.
- Also fixed a latent bug this exposed: the existing numeric/string/float/int type-detection ran on tokens *before* quotes were stripped, so a quoted numeric-looking value (e.g. `"123"`) was incidentally forced to string type only because the leftover quote characters made the numeric regex fail. Now that quotes are stripped at tokenization, each token retains a `quoted` flag so a quoted value is still explicitly treated as an OSC string type even if its contents look numeric — preserving the original (if accidental) "quoting forces string" behavior.

Addresses item #59 from the codebase review.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [x] Manually traced `foo 123 "hello world" true` → 4 tokens: `foo` (string), `123` (int32), `hello world` (string, quotes stripped), `true` (string).
- [x] Manually traced a quoted numeric value like `"123"` → still produces an OSC string type (not int32), preserving prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)