### PR TITLE
fix: add missing error handlers to dgram sockets in SimplyLive/TSL sources

### DIFF
--- a/src/sources/SimplyLive.ts
+++ b/src/sources/SimplyLive.ts
@@ -1,3 +1,4 @@
+import { logger } from '..'
 import { RegisterTallyInput } from '../_decorators/RegisterTallyInput.decorator'
 import { FreePort, UsePort } from '../_decorators/UsesPort.decorator'
 import { Source } from '../_models/Source'
@@ -18,7 +19,15 @@ export class SimplyLivePSource extends TallyInput {
 
 		UsePort(port, this.source.id)
 		this.server = dgram.createSocket('udp4')
-		this.server.bind(port)
+
+		this.server.on('error', (err) => {
+			logger(`Source: ${source.name} SimplyLive Error: ${err}`, 'error')
+			this.connected.next(false)
+		})
+
+		this.server.on('listening', () => {
+			this.connected.next(true)
+		})
 
 		this.server.on('message', (message) => {
 			if (message.length >= 12) {
@@ -55,7 +64,7 @@ export class SimplyLivePSource extends TallyInput {
 			}
 		})
 
-		this.connected.next(true)
+		this.server.bind(port)
 	}
 
 	public exit(): void {

--- a/src/sources/TSL.ts
+++ b/src/sources/TSL.ts
@@ -1,3 +1,4 @@
+import { logger } from '..'
 import { RegisterTallyInput } from '../_decorators/RegisterTallyInput.decorator'
 import { FreePort, UsePort } from '../_decorators/UsesPort.decorator'
 import { Source } from '../_models/Source'
@@ -238,13 +239,21 @@ export class TSL5UDPSource extends TSL5Base {
 
 		UsePort(port, this.source.id)
 		this.server = dgram.createSocket('udp4')
-		this.server.bind(port)
+
+		this.server.on('error', (err) => {
+			logger(`Source: ${source.name} TSL 5.0 UDP Error: ${err}`, 'error')
+			this.connected.next(false)
+		})
+
+		this.server.on('listening', () => {
+			this.connected.next(true)
+		})
 
 		this.server.on('message', (message) => {
 			this.processTSL5Tally(message)
 		})
 
-		this.connected.next(true)
+		this.server.bind(port)
 	}
 
 	public exit(): void {


### PR DESCRIPTION
## Summary

- `SimplyLivePSource` (`src/sources/SimplyLive.ts`) and `TSL5UDPSource` (`src/sources/TSL.ts`) each create a raw `dgram.createSocket('udp4')` socket with no `'error'` listener attached. An unhandled `'error'` event on an `EventEmitter` throws, which can crash the process (e.g. on `EADDRINUSE` if the configured port is already in use).
- Both sockets also called `this.connected.next(true)` immediately after `.bind(port)`, before the OS confirmed the bind actually succeeded, so the UI could report "connected" even when binding failed.

## Fix

For both `dgram.createSocket('udp4')` instances:
- Added a `socket.on('error', (err) => { logger(...); this.connected.next(false) })` handler that logs via the app's `logger()` helper and marks the source as disconnected.
- Moved `this.connected.next(true)` out from right after `.bind(port)` and into the socket's `'listening'` event callback, so connected status only reflects a confirmed successful bind.

Note: `TSL3UDPSource` in `src/sources/TSL.ts` uses the third-party `tsl-umd` package (which wraps its own internal `dgram` socket), not a raw `dgram.createSocket` call in this file, so it was left untouched per the scope of this fix. `src/actions/TSL.ts` and `src/_modules/TSL.ts` are unrelated files and were not touched.

This addresses item #48 from the codebase review.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [ ] Manually start a `SimplyLive` source and a `TSL 5.0 UDP` source, confirm normal operation still reports connected once listening.
- [ ] Manually trigger `EADDRINUSE` (start two sources on the same port) and confirm the process no longer crashes, and `connected` is not falsely reported as `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)