### PR TITLE
fix: correct several bugs in the TSL action (typo, validation, bounds)

### DIFF
--- a/src/actions/TSL.ts
+++ b/src/actions/TSL.ts
@@ -88,7 +88,16 @@ export class TSL extends Action {
 			// TSL 3.1
 			try {
 				let bufUMD = Buffer.alloc(18, 0) //ignores spec and pad with 0 for better aligning on Decimator etc
-				bufUMD[0] = 0x80 + parseInt(this.action.data.address)
+
+				let address = parseInt(this.action.data.address)
+				if (isNaN(address) || address < 0 || address > 126) {
+					logger(
+						`Error in TSL 3.1 ${this.action.outputTypeId == '7dcd66b5' ? 'UDP' : 'TCP'} Action. Address must be a number between 0 and 126.`,
+						'error',
+					)
+					return
+				}
+				bufUMD[0] = 0x80 + address
 				bufUMD.write(this.action.data.label, 2)
 
 				let bufTally = 0x30
@@ -119,12 +128,19 @@ export class TSL extends Action {
 				} else {
 					// TCP
 					let client = new net.Socket()
+					client.setTimeout(5000, () => {
+						client.destroy() // kill client if the destination never responds
+					})
 					client.connect(this.action.data.port, this.action.data.ip, () => {
 						client.write(Uint8Array.from(bufUMD))
 					})
 
 					client.on('data', () => {
 						client.destroy() // kill client after server's response
+					})
+
+					client.on('error', (error) => {
+						logger(`An error occured sending the TSL 3.1 TCP Message: ${error}`, 'error')
 					})
 
 					client.on('close', () => {})
@@ -148,8 +164,18 @@ export class TSL extends Action {
 						`Error in TSL 5 ${this.action.outputTypeId == '8b99d588' ? 'UDP' : 'TCP'} Action. IP and Port must be given`,
 						'error',
 					)
+					return
 				}
-				if (!this.action.data.index) {
+
+				for (const [key, value] of Object.entries(this.action.data)) {
+					if (display_fields.includes(key)) {
+						tally.display[key] = value
+					} else {
+						tally[key] = value
+					}
+				}
+
+				if (this.action.data.index === undefined || this.action.data.index === null) {
 					logger(
 						`TSL 5 ${this.action.outputTypeId == '8b99d588' ? 'UDP' : 'TCP'} Action. No index given. Using index 1 by default`,
 						'info',
@@ -160,16 +186,8 @@ export class TSL extends Action {
 				if (this.action.data.sequence == 'ON') {
 					sequence = true
 				}
-				if (this.action.data.sequnece == 'OFF') {
+				if (this.action.data.sequence == 'OFF') {
 					sequence = false
-				}
-
-				for (var [key, value] of Object.entries(this.action.data)) {
-					if (display_fields.includes(key)) {
-						tally.display[key] = value
-					} else {
-						tally[key] = value
-					}
 				}
 
 				if (this.action.outputTypeId == '8b99d588') {


### PR DESCRIPTION
## Summary

Fixes several bugs in `src/actions/TSL.ts` (the TSL 3.1 / TSL 5 output **action**, not `src/sources/TSL.ts` or `src/_modules/TSL.ts`), addressing items #54-#58 from the codebase review:

1. **Missing `error` handler on the TSL 3.1 TCP socket.** The raw `net.Socket` used for "TSL 3.1 TCP" had no `.on('error', ...)` handler, unlike the equivalent sockets in `src/actions/TCP.ts` and `src/actions/RossTalk.ts`. An unhandled `error` event on a `net.Socket` throws and can crash the process. Added a handler that logs via `logger()`, matching the sibling files' idiom.

2. **`sequnece` typo.** `if (this.action.data.sequnece == 'OFF')` referenced a field name that doesn't exist (the real field, defined in the "DLE/STX sequence" dropdown config a few lines above and used correctly on the previous `if`, is `sequence`). This meant the "OFF" option could never take effect. Fixed to `this.action.data.sequence`.

3. **Missing `return` after IP/port validation.** When `ip`/`port` were missing, the code logged an error but fell through and called `sendTallyUDP`/`sendTallyTCP` anyway with empty destination data. Added a `return` right after the log.

4. **Falsy `index: 0` treated as "not given".** `!this.action.data.index` incorrectly treated a legitimate `index: 0` as absent and overwrote it with `1`. Additionally, a later unconditional `for (const [key, value] of Object.entries(this.action.data)) { tally[key] = value }` copied the raw `index` back over `tally.index` whenever the key existed at all, silently undoing the "default to 1" logic in most cases. Fixed by: (a) reordering so the `Object.entries` copy happens first, (b) changing the check to `this.action.data.index === undefined || this.action.data.index === null`, and (c) applying the default only after the copy, so it no longer gets clobbered.

5. **No bounds check on the TSL 3.1 address byte.** `bufUMD[0] = 0x80 + parseInt(this.action.data.address)` had no min/max validation on the "Address" number field. Since `Buffer` indexing silently truncates to 8 bits, an out-of-range value would corrupt the packet instead of erroring clearly. Added a validation check (NaN or out of `0-126`) that logs via `logger()` and returns early. The `0-126` bound matches the existing convention already established in this codebase for the analogous TSL address field (`UI/src/app/_components/settings/settings.component.ts`, which clamps the Device-level `tslAddress` field to `0-126`), which in turn respects the single-byte constraint of `0x80 + address` fitting in a `Buffer` byte.

## Improvement

- Added an idle timeout on the TSL 3.1 TCP client (`client.setTimeout(5000, () => client.destroy())`) so a destination that accepts the connection but never replies doesn't leak the socket for the life of the process.

## Notes / things worth double-checking

- The valid address range (item 5) is not explicitly documented anywhere for this specific action field. I aligned it with the `0-126` bound already enforced in the UI for the closely related Device-level `tslAddress` field used by the built-in TSL module, rather than the theoretical byte-level max of `127`. Flagging this in case the intended range for this particular action field differs.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [x] Manually re-read the full `run()` method after all edits to confirm the index/Object.entries interaction (bug 4) composes correctly with the reordering.
- [ ] Manual/integration testing against real TSL 3.1/5 UDP and TCP receivers (not performed in this environment).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>