### PR TITLE
fix: actually remove the wake-lock click listener after first use

### DIFF
--- a/UI/src/app/_services/wake-lock.service.ts
+++ b/UI/src/app/_services/wake-lock.service.ts
@@ -6,13 +6,15 @@ import NoSleep from 'nosleep.js'
 })
 export class WakeLockService {
 	private noSleep?: NoSleep
+	private clickHandler = () => this.enableWakeLock()
+
 	public init() {
 		this.noSleep = new NoSleep()
-		document.addEventListener('click', () => this.enableWakeLock())
+		document.addEventListener('click', this.clickHandler)
 	}
 
 	private enableWakeLock() {
-		document.removeAllListeners?.('click')
+		document.removeEventListener('click', this.clickHandler)
 		this.noSleep?.enable()
 	}
 }


### PR DESCRIPTION
## Summary
- `document.removeAllListeners` is a Node.js `EventEmitter` method, not a real DOM API — it is `undefined` in a browser, and the optional-chaining `?.` call silently made it a no-op.
- As a result, the `'click'` listener added in `WakeLockService.init()` was never removed, so `enableWakeLock()` (and `this.noSleep.enable()`) fired on every click for the entire app session instead of just once.
- Fix: store a bound handler reference (`clickHandler`) and remove it with the real `document.removeEventListener('click', this.clickHandler)` API.

Addresses item #62 from the codebase review.

## Test plan
- [x] Read the full file before editing
- [x] Regenerated gitignored files (`node scripts/sync-ui-shared.js` from repo root, `node UI/git.version.js` for `UI/src/environments/versions.ts`)
- [x] `cd UI && npx tsc --noEmit -p tsconfig.app.json` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)