### PR TITLE
cleanup: extract shared getAppDataFolder helper

### DIFF
--- a/src/_helpers/appDataFolder.ts
+++ b/src/_helpers/appDataFolder.ts
@@ -1,0 +1,9 @@
+import path from 'path'
+
+export function getAppDataFolder(): string {
+	return path.join(
+		process.env.APPDATA ||
+			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + '/.local/share'),
+		'TallyArbiter',
+	)
+}

--- a/src/_helpers/config.ts
+++ b/src/_helpers/config.ts
@@ -8,13 +8,10 @@ import { randomBytes } from 'crypto'
 import { clone } from './clone'
 import { uuidv4 } from './uuid'
 import { addUser } from './auth'
+import { getAppDataFolder } from './appDataFolder'
 
 function getConfigFilePath(): string {
-	const configFolder = path.join(
-		process.env.APPDATA ||
-			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + '/.local/share'),
-		'TallyArbiter',
-	)
+	const configFolder = getAppDataFolder()
 	if (!fs.existsSync(configFolder)) {
 		fs.mkdirSync(configFolder, { recursive: true })
 	}

--- a/src/_helpers/errorReports.ts
+++ b/src/_helpers/errorReports.ts
@@ -4,16 +4,11 @@ import { ErrorReportsListElement } from '../_models/ErrorReportsListElement'
 import { ErrorReport } from '../_models/ErrorReport'
 import { logger, logFilePath, getConfigRedacted } from '..'
 import { uuidv4 } from './uuid'
+import { getAppDataFolder } from './appDataFolder'
 
 export function getErrorReportsList(): ErrorReportsListElement[] {
 	try {
-		const ErrorReportsFolder = path.join(
-			process.env.APPDATA ||
-				(process.platform == 'darwin'
-					? process.env.HOME + '/Library/Preferences/'
-					: process.env.HOME + '/.local/share/'),
-			'TallyArbiter/ErrorReports',
-		)
+		const ErrorReportsFolder = path.join(getAppDataFolder(), 'ErrorReports')
 		const ErrorReportsFiles = fs.readdirSync(ErrorReportsFolder)
 		let errorReports = []
 		ErrorReportsFiles.forEach((file) => {
@@ -29,13 +24,7 @@ export function getErrorReportsList(): ErrorReportsListElement[] {
 
 export function getReadErrorReports(): string[] {
 	try {
-		const readErrorReportsFilePath = path.join(
-			process.env.APPDATA ||
-				(process.platform == 'darwin'
-					? process.env.HOME + '/Library/Preferences/'
-					: process.env.HOME + '/.local/share/'),
-			'TallyArbiter/readErrorReports.json',
-		)
+		const readErrorReportsFilePath = path.join(getAppDataFolder(), 'readErrorReports.json')
 		return JSON.parse(fs.readFileSync(readErrorReportsFilePath, 'utf8'))
 	} catch (e) {
 		return []
@@ -44,13 +33,7 @@ export function getReadErrorReports(): string[] {
 
 export function markErrorReportAsRead(errorReportId: string): boolean {
 	try {
-		const readErrorReportsFilePath = path.join(
-			process.env.APPDATA ||
-				(process.platform == 'darwin'
-					? process.env.HOME + '/Library/Preferences/'
-					: process.env.HOME + '/.local/share/'),
-			'TallyArbiter/readErrorReports.json',
-		)
+		const readErrorReportsFilePath = path.join(getAppDataFolder(), 'readErrorReports.json')
 		let readErrorReportsList = getReadErrorReports()
 		readErrorReportsList.push(errorReportId)
 		fs.writeFileSync(readErrorReportsFilePath, JSON.stringify(readErrorReportsList))
@@ -71,13 +54,7 @@ export function getUnreadErrorReportsList(): ErrorReportsListElement[] {
 export function getErrorReport(reportId: string): ErrorReport | false {
 	try {
 		if (!reportId.match(/^[a-zA-Z0-9]+$/i)) return false
-		const ErrorReportsFolder = path.join(
-			process.env.APPDATA ||
-				(process.platform == 'darwin'
-					? process.env.HOME + '/Library/Preferences/'
-					: process.env.HOME + '/.local/share/'),
-			'TallyArbiter/ErrorReports',
-		)
+		const ErrorReportsFolder = path.join(getAppDataFolder(), 'ErrorReports')
 		const ErrorReportFile = path.join(ErrorReportsFolder, reportId + '.json')
 		return JSON.parse(fs.readFileSync(ErrorReportFile, 'utf8'))
 	} catch (e) {
@@ -86,11 +63,7 @@ export function getErrorReport(reportId: string): ErrorReport | false {
 }
 
 export function getErrorReportPath(id: string): string {
-	const ErrorReportsFolder = path.join(
-		process.env.APPDATA ||
-			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + '/.local/share/'),
-		'TallyArbiter/ErrorReports',
-	)
+	const ErrorReportsFolder = path.join(getAppDataFolder(), 'ErrorReports')
 
 	if (!fs.existsSync(ErrorReportsFolder)) {
 		fs.mkdirSync(ErrorReportsFolder, { recursive: true })
@@ -123,23 +96,11 @@ export function generateErrorReport(error: Error) {
 
 export function markErrorReportsAsRead() {
 	try {
-		const ErrorReportsFolder = path.join(
-			process.env.APPDATA ||
-				(process.platform == 'darwin'
-					? process.env.HOME + '/Library/Preferences/'
-					: process.env.HOME + '/.local/share/'),
-			'TallyArbiter/ErrorReports',
-		)
+		const ErrorReportsFolder = path.join(getAppDataFolder(), 'ErrorReports')
 		const ErrorReportsFiles = fs.readdirSync(ErrorReportsFolder).map((file) => {
 			return file.replace(/\.[^/.]+$/, '')
 		})
-		const readErrorReportsFilePath = path.join(
-			process.env.APPDATA ||
-				(process.platform == 'darwin'
-					? process.env.HOME + '/Library/Preferences/'
-					: process.env.HOME + '/.local/share/'),
-			'TallyArbiter/readErrorReports.json',
-		)
+		const readErrorReportsFilePath = path.join(getAppDataFolder(), 'readErrorReports.json')
 		fs.writeFileSync(readErrorReportsFilePath, JSON.stringify(ErrorReportsFiles))
 		return true
 	} catch (e) {
@@ -148,16 +109,8 @@ export function markErrorReportsAsRead() {
 }
 
 export function deleteEveryErrorReport() {
-	const ErrorReportsFolder = path.join(
-		process.env.APPDATA ||
-			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + '/.local/share/'),
-		'TallyArbiter/ErrorReports',
-	)
+	const ErrorReportsFolder = path.join(getAppDataFolder(), 'ErrorReports')
 	fs.emptyDirSync(ErrorReportsFolder)
-	const readErrorReportsFilePath = path.join(
-		process.env.APPDATA ||
-			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + '/.local/share/'),
-		'TallyArbiter/readErrorReports.json',
-	)
+	const readErrorReportsFilePath = path.join(getAppDataFolder(), 'readErrorReports.json')
 	fs.writeFileSync(readErrorReportsFilePath, '[]')
 }

--- a/src/_helpers/logger.ts
+++ b/src/_helpers/logger.ts
@@ -4,15 +4,12 @@ import fs from 'fs'
 import winston from 'winston'
 import { io } from 'socket.io-client'
 import { LogItem } from '../_models/LogItem'
+import { getAppDataFolder } from './appDataFolder'
 
 function getLogFilePath(): string {
 	var today = new Date().toISOString().replace('T', ' ').replace(/\..+/, '').replace(/:/g, '-')
 
-	const logFolder = path.join(
-		process.env.APPDATA ||
-			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + '/.local/share/'),
-		'TallyArbiter/logs',
-	)
+	const logFolder = path.join(getAppDataFolder(), 'logs')
 
 	findRemoveSync(logFolder, { age: { seconds: 604800 }, extensions: '.talog', limit: 100 })
 
@@ -26,11 +23,7 @@ function getLogFilePath(): string {
 function getTallyDataPath(): string {
 	var today = new Date().toISOString().replace('T', ' ').replace(/\..+/, '').replace(/:/g, '-')
 
-	const TallyDataFolder = path.join(
-		process.env.APPDATA ||
-			(process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences/' : process.env.HOME + '/.local/share/'),
-		'TallyArbiter/TallyData',
-	)
+	const TallyDataFolder = path.join(getAppDataFolder(), 'TallyData')
 
 	findRemoveSync(TallyDataFolder, { age: { seconds: 604800 }, extensions: '.tadata', limit: 100 })
 


### PR DESCRIPTION
## Summary
- Addresses the app-data-folder duplication flagged in a codebase review: the `APPDATA`/`darwin`/`~/.local/share` path-resolution block (Windows uses `process.env.APPDATA`, macOS uses `~/Library/Preferences`, otherwise `~/.local/share`, joined with `TallyArbiter`) was copy-pasted independently in `src/_helpers/config.ts`, twice in `src/_helpers/logger.ts`, and five times in `src/_helpers/errorReports.ts`.
- Extracted the logic into a single `getAppDataFolder()` function in a new file, `src/_helpers/appDataFolder.ts`, which only imports `path` (no dependency on `config.ts`, `logger.ts`, or `errorReports.ts`), so there is no circular-import risk. All three files now import and call it instead of duplicating the block.
- Pure refactor — no behavior change. All copies already resolved to the same effective path; the only difference between them was a stray trailing slash in some string literals (e.g. `.../Preferences/` vs `.../Preferences`), which `path.join` normalizes away, so there was no actual behavioral difference to reconcile.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Verified the new helper file has no imports from `config.ts`, `logger.ts`, or `errorReports.ts` (only `path`), confirming no circular dependency was introduced
- [x] Manually diffed each call site to confirm the resulting paths are unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>