### PR TITLE
fix: register the OS theme-change listener on a fresh auto-mode session

### DIFF
--- a/UI/src/app/_services/darkmode.service.ts
+++ b/UI/src/app/_services/darkmode.service.ts
@@ -40,14 +40,19 @@ export class DarkModeService {
 		}
 	}
 
+	private registerAutoModeListener() {
+		window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+			this.updatePageStyle()
+		})
+	}
+
 	public init() {
 		if (!this.getDarkMode()) {
 			this.setDarkMode('auto')
+			this.registerAutoModeListener()
 		} else {
 			if (this.getDarkMode() === 'auto') {
-				window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-					this.updatePageStyle()
-				})
+				this.registerAutoModeListener()
 			}
 			this.updatePageStyle()
 		}


### PR DESCRIPTION
## Summary
- Fixes `DarkModeService.init()` in `UI/src/app/_services/darkmode.service.ts` so a brand-new session (no stored `darkMode` preference) registers the `matchMedia('(prefers-color-scheme: dark)')` change listener when defaulting to `'auto'`, not just when `'auto'` was already read back from `localStorage` on a subsequent load.
- Extracted the listener registration into a small private `registerAutoModeListener()` method to avoid duplicating the `addEventListener` call between the "fresh default" and "stored preference" branches.
- This addresses the darkmode.service.ts improvement identified in a codebase review: previously, on a first-ever visit, live OS theme changes weren't reflected until the *next* app load.

## Test plan
- [x] Read the full (short) file before and after the change.
- [x] Regenerated gitignored generated files (`node scripts/sync-ui-shared.js` and `node UI/git.version.js`) before typechecking.
- [x] Installed UI dependencies (`npm ci --legacy-peer-deps` — plain `npm ci` currently fails on a pre-existing `@angular/animations`/`@angular/core` peer-dependency mismatch in the lockfile, unrelated to this change).
- [x] `npx tsc --noEmit -p tsconfig.app.json` from `UI/` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)