### PR TITLE
fix: merge duplicate listener_clients handler and other socket.service bugs

### DIFF
--- a/UI/src/app/_services/socket.service.ts
+++ b/UI/src/app/_services/socket.service.ts
@@ -131,7 +131,7 @@ export class SocketService {
 				.map((l: any) => {
 					l.ipAddress = l.ipAddress.replace('::ffff:', '')
 					l.device = this.devices.find((d) => d.id == l.deviceId)
-					if (!l.inactive) l.device.listenerCount += 1
+					if (!l.inactive && l.device) l.device.listenerCount += 1
 					return l
 				})
 				.sort((a: any, b: any) => (a.inactive === b.inactive ? 0 : a.inactive ? 1 : -1))
@@ -167,13 +167,11 @@ export class SocketService {
 		})
 
 		this.socket.on('interfaces', (interfaces: any[]) => {
-			interfaces.forEach((net_interface) => {
-				this.interfaces.push({
-					name: net_interface.name,
-					address: net_interface.address,
-					url: `http://${net_interface.address}:4455/#/tally`,
-				})
-			})
+			this.interfaces = interfaces.map((net_interface) => ({
+				name: net_interface.name,
+				address: net_interface.address,
+				url: `http://${net_interface.address}:4455/#/tally`,
+			}))
 		})
 		this.socket.on('logs', (logs: LogItem[]) => {
 			this.logs = logs
@@ -271,12 +269,6 @@ export class SocketService {
 				this.deviceStateChanged.next(this.device_states)
 			},
 		)
-		this.socket.on('listener_clients', (listenerClients: ListenerClient[]) => {
-			this.listenerClients = listenerClients.map((l) => {
-				l.ipAddress = l.ipAddress.replace('::ffff:', '')
-				return l
-			})
-		})
 		this.socket.on('manage_response', (response: any) => {
 			switch (response.result) {
 				case 'source-added-successfully':
@@ -388,7 +380,6 @@ export class SocketService {
 		this.socket.emit('uiVersion')
 		this.socket.emit('externalAddress')
 		this.socket.emit('interfaces')
-		this.socket.emit('get_error_reports')
 	}
 
 	private prepareSources(sources: Source[]): Source[] {


### PR DESCRIPTION
## Summary

Fixes three bugs in `UI/src/app/_services/socket.service.ts`:

1. **Duplicate `listener_clients` socket handler.** Two separate `this.socket.on('listener_clients', ...)` handlers were registered in the constructor. Socket.IO invokes all listeners for an event, in registration order, on every emission — so the second handler (which only normalized `ipAddress`) silently overwrote the first handler's correct work (mapping `l.device`, computing `device.listenerCount`, and sorting active/inactive listeners) on every single `listener_clients` update. Merged the two into one handler that does both, and added a null guard (`if (!l.inactive && l.device)`) before incrementing `l.device.listenerCount`, since a listener's `deviceId` may not match any current device (e.g. the device was deleted while the listener stayed connected), which previously would throw.

2. **Duplicate `get_error_reports` emit.** The constructor emitted `get_error_reports` twice back-to-back. Removed the redundant second emit.

3. **`interfaces` handler accumulated instead of replacing.** Unlike sibling handlers (`sources`, `devices`, etc.) which replace their backing array on each emission, the `interfaces` handler pushed onto `this.interfaces` without clearing it first, so repeated `interfaces` events would accumulate duplicate entries. Changed it to reassign `this.interfaces` to a freshly mapped array.

This addresses issues #61 and #66 (partial) plus additional fixes found during review.

## Optional improvement considered (not applied)

The task also asked me to look at `getErrorReportById()`, which uses an un-correlated `socket.emit('get_error_report', id)` + `socket.once('error_report', cb)` pattern with no request correlation — a real race if the method is ever called concurrently. I checked the server side (`src/index.ts:1006`) and confirmed the `get_error_report` handler only does `socket.emit('error_report', getErrorReport(errorReportId))`; it does not accept or invoke an acknowledgement callback, and no handler anywhere in the server codebase uses the ack-callback pattern. Fixing this properly would require a server-side change to add ack support, which is out of scope for a UI-only change, so I left it as-is rather than applying a partial client-only fix that wouldn't actually solve the race.

## Test plan

- [x] Read the entire file to confirm there were no additional occurrences of these bugs (only two `listener_clients` handlers, two `get_error_reports` emits, one `interfaces` handler — all accounted for).
- [x] Regenerated gitignored files (`node scripts/sync-ui-shared.js` from repo root, `node UI/git.version.js`) needed for typechecking.
- [x] `cd UI && npx tsc --noEmit -p tsconfig.app.json` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)