### PR TITLE
fix: add missing ngOnDestroy cleanup to prevent listener/subscription leaks

### DIFF
--- a/UI/src/app/_components/chat/chat.component.ts
+++ b/UI/src/app/_components/chat/chat.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common'
-import { Component, ElementRef, Input, ViewChild } from '@angular/core'
+import { Component, ElementRef, Input, OnDestroy, ViewChild } from '@angular/core'
 import { FormsModule } from '@angular/forms'
+import { Subscription } from 'rxjs'
 import { SocketService } from 'src/app/_services/socket.service'
 
 @Component({
@@ -10,15 +11,21 @@ import { SocketService } from 'src/app/_services/socket.service'
 	templateUrl: './chat.component.html',
 	styleUrls: ['./chat.component.scss'],
 })
-export class ChatComponent {
+export class ChatComponent implements OnDestroy {
 	public message = ''
 	@Input() type: 'producer' | any
 	@ViewChild('chatContainer') private chatContainer!: ElementRef
 
+	private scrollChatSubscription: Subscription
+
 	constructor(public socketService: SocketService) {
-		this.socketService.scrollChatSubject.subscribe(() => {
+		this.scrollChatSubscription = this.socketService.scrollChatSubject.subscribe(() => {
 			this.scrollToBottom(this.chatContainer)
 		})
+	}
+
+	ngOnDestroy(): void {
+		this.scrollChatSubscription?.unsubscribe()
 	}
 
 	public sendMessage(): void {

--- a/UI/src/app/_components/error-reports-list/error-reports-list.component.ts
+++ b/UI/src/app/_components/error-reports-list/error-reports-list.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, OnInit } from '@angular/core'
+import { Component, OnDestroy, OnInit } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { Router } from '@angular/router'
 import { Confirmable } from 'src/app/_decorators/confirmable.decorator'
@@ -15,9 +15,14 @@ import { LocationBackService } from 'src/app/_services/locationBack.service'
 	templateUrl: './error-reports-list.component.html',
 	styleUrls: ['./error-reports-list.component.scss'],
 })
-export class ErrorReportsListComponent implements OnInit {
+export class ErrorReportsListComponent implements OnInit, OnDestroy {
 	public unread_error_reports: any = []
 	public errorReportsLoaded: boolean = false
+
+	private unreadErrorReportsHandler = (list: ErrorReportsListElement[]) => {
+		this.unread_error_reports = list.map((report) => report.id)
+		this.errorReportsLoaded = true
+	}
 
 	constructor(
 		private router: Router,
@@ -25,12 +30,7 @@ export class ErrorReportsListComponent implements OnInit {
 		public navbarVisibilityService: NavbarVisibilityService,
 		public locationBackService: LocationBackService,
 	) {
-		this.socketService.socket.on('unread_error_reports', (list) => {
-			list.forEach((report: ErrorReportsListElement) => {
-				this.unread_error_reports.push(report.id)
-			})
-			this.errorReportsLoaded = true
-		})
+		this.socketService.socket.on('unread_error_reports', this.unreadErrorReportsHandler)
 		this.socketService.socket.emit('get_unread_error_reports')
 	}
 
@@ -48,4 +48,8 @@ export class ErrorReportsListComponent implements OnInit {
 	}
 
 	ngOnInit(): void {}
+
+	ngOnDestroy(): void {
+		this.socketService.socket.off('unread_error_reports', this.unreadErrorReportsHandler)
+	}
 }

--- a/UI/src/app/_components/producer/producer.component.ts
+++ b/UI/src/app/_components/producer/producer.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common'
-import { Component } from '@angular/core'
+import { Component, OnDestroy } from '@angular/core'
+import { Subscription } from 'rxjs'
 import { ChatComponent } from '../chat/chat.component'
 import { SocketService } from 'src/app/_services/socket.service'
 
@@ -10,19 +11,25 @@ import { SocketService } from 'src/app/_services/socket.service'
 	templateUrl: './producer.component.html',
 	styleUrls: ['./producer.component.scss'],
 })
-export class ProducerComponent {
+export class ProducerComponent implements OnDestroy {
 	public deviceBusColors: Record<string, string[]> = {}
+
+	private deviceStateChangedSubscription: Subscription
 
 	constructor(public socketService: SocketService) {
 		this.socketService.joinProducers()
 		this.socketService.dataLoaded
 
-		this.socketService.deviceStateChanged.subscribe((deviceStates) => {
+		this.deviceStateChangedSubscription = this.socketService.deviceStateChanged.subscribe((deviceStates) => {
 			for (const device of this.socketService.devices) {
 				this.deviceBusColors[device.id] = deviceStates
 					.filter((d) => d.deviceId == device.id && d.sources.length > 0)
 					.map((d) => d.busId)
 			}
 		})
+	}
+
+	ngOnDestroy(): void {
+		this.deviceStateChangedSubscription?.unsubscribe()
 	}
 }

--- a/UI/src/app/_components/tally/tally.component.ts
+++ b/UI/src/app/_components/tally/tally.component.ts
@@ -1,7 +1,8 @@
 import { CommonModule } from '@angular/common'
-import { Component } from '@angular/core'
+import { Component, OnDestroy } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { ActivatedRoute, Router } from '@angular/router'
+import { Subscription } from 'rxjs'
 import { BusOption } from 'src/app/_models/BusOption'
 import { SocketService } from 'src/app/_services/socket.service'
 import { ChatComponent } from '../chat/chat.component'
@@ -13,7 +14,7 @@ import { ChatComponent } from '../chat/chat.component'
 	templateUrl: './tally.component.html',
 	styleUrls: ['./tally.component.scss'],
 })
-export class TallyComponent {
+export class TallyComponent implements OnDestroy {
 	public currentDeviceIdx?: number
 	public currentBus?: BusOption
 	private supportsVibrate?: boolean = false
@@ -23,6 +24,13 @@ export class TallyComponent {
 	}
 
 	public enableChatOptions = true
+
+	private deviceStateChangedSubscription: Subscription
+
+	private reassignHandler = (oldDeviceId: string, deviceId: string) => {
+		this.socketService.socket.emit('listener_reassign', oldDeviceId, deviceId)
+		this.currentDeviceIdx = this.socketService.devices.findIndex((d) => d.id === deviceId)
+	}
 
 	constructor(
 		private router: Router,
@@ -63,7 +71,7 @@ export class TallyComponent {
 			}, 500)
 		})
 
-		this.socketService.deviceStateChanged.subscribe((deviceStates) => {
+		this.deviceStateChangedSubscription = this.socketService.deviceStateChanged.subscribe((deviceStates) => {
 			if (this.currentDeviceIdx === undefined) return
 
 			const currentDevice = this.socketService.devices[this.currentDeviceIdx]
@@ -92,10 +100,7 @@ export class TallyComponent {
 			this.currentBus = hightestPriorityBus
 		})
 
-		this.socketService.socket.on('reassign', (oldDeviceId: string, deviceId: string) => {
-			this.socketService.socket.emit('listener_reassign', oldDeviceId, deviceId)
-			this.currentDeviceIdx = this.socketService.devices.findIndex((d) => d.id === deviceId)
-		})
+		this.socketService.socket.on('reassign', this.reassignHandler)
 	}
 
 	public selectDevice(id: any) {
@@ -114,5 +119,7 @@ export class TallyComponent {
 
 	public ngOnDestroy() {
 		this.socketService.socket.off('flash')
+		this.socketService.socket.off('reassign', this.reassignHandler)
+		this.deviceStateChangedSubscription?.unsubscribe()
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes socket-listener / RxJS-subscription leaks that occur because Angular's router destroys and recreates these components on every navigation, but nothing was cleaning up what was registered in the constructor/`ngOnInit`. Each re-visit stacked another live listener/subscriber that kept firing against a torn-down component for the rest of the session.
- `error-reports-list.component.ts`: added `OnDestroy`, stored the `unread_error_reports` handler as a named class field so it can be removed via `socket.off('unread_error_reports', handler)`, and changed the handler to replace `unread_error_reports` via assignment (`list.map(...)`) instead of unconditionally pushing onto the existing array (the server always emits the full current list, so pushing caused duplicate ids to accumulate across emissions even before considering the leak).
- `tally.component.ts`: `ngOnDestroy` previously only did `socket.off('flash')`. Added removal of the `'reassign'` listener via a stored named handler, and stored + unsubscribed the `deviceStateChanged` subscription.
- `chat.component.ts`: didn't implement `OnDestroy` at all. Added it, storing the `scrollChatSubject` subscription and unsubscribing in `ngOnDestroy`.
- `producer.component.ts`: didn't implement `OnDestroy` at all. Added it, storing the `deviceStateChanged` subscription and unsubscribing in `ngOnDestroy`.

This addresses item #67 (partial) from the codebase review — `settings.component.ts`'s portion of that item is handled in a separate PR.

## Test plan
- [x] `cd UI && npx tsc --noEmit -p tsconfig.app.json` passes with no errors after regenerating gitignored generated files (`node scripts/sync-ui-shared.js`, `node UI/git.version.js`)
- [x] `npx prettier --check` on the 4 changed files (formatting matches repo style: tabs, no semicolons, single quotes)
- [ ] Manual smoke test: navigate to `/tally`, `/producer`, chat, and error-reports-list views repeatedly and confirm no duplicate socket event handling / errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)