### PR TITLE
fix: bound recursive URL generation and handle rejection in error report

### DIFF
--- a/UI/src/app/_components/error-report/error-report.component.ts
+++ b/UI/src/app/_components/error-report/error-report.component.ts
@@ -46,31 +46,37 @@ export class ErrorReportComponent implements OnInit, OnDestroy, AfterViewInit {
 	}
 
 	checkIfIssuesEnabled(url: string) {
-		/* @ts-ignore: All code paths resolve the promise */
 		return new Promise<boolean>((resolve, reject) => {
-			if (new URL(url).host !== 'github.com') resolve(false)
-			let repo = url.split('github.com/')[1].split('/', 2).join('/').toLowerCase()
+			try {
+				if (new URL(url).host !== 'github.com') {
+					resolve(false)
+					return
+				}
+				let repo = url.split('github.com/')[1].split('/', 2).join('/').toLowerCase()
 
-			switch (repo) {
-				case 'josephdadams/tallyarbiter':
-					resolve(true)
-					break
+				switch (repo) {
+					case 'josephdadams/tallyarbiter':
+						resolve(true)
+						break
 
-				default:
-					fetch(`https://api.github.com/repos/${repo}`, { cache: 'no-store' })
-						.then((response) => {
-							response
-								.json()
-								.then((data) => {
-									resolve(data.has_issues)
-								})
-								.catch(() => {
-									resolve(false)
-								})
-						})
-						.catch(() => {
-							resolve(false)
-						})
+					default:
+						fetch(`https://api.github.com/repos/${repo}`, { cache: 'no-store' })
+							.then((response) => {
+								response
+									.json()
+									.then((data) => {
+										resolve(data.has_issues)
+									})
+									.catch(() => {
+										resolve(false)
+									})
+							})
+							.catch(() => {
+								resolve(false)
+							})
+				}
+			} catch (error) {
+				reject(error)
 			}
 		})
 	}
@@ -82,13 +88,34 @@ export class ErrorReportComponent implements OnInit, OnDestroy, AfterViewInit {
 		logs: string,
 		stacktrace: string,
 		runningRecursive: boolean = false,
+		attempt: number = 0,
 	): string {
 		function truncateString(str: string, num: number) {
 			if (str.length <= num) return str
 			return str.slice(0, num) + '...'
 		}
 
+		function truncateStacktrace(trace: string, maxLines: number, maxChars: number) {
+			let lines: string[] = trace.split('\n')
+			if (lines.length > maxLines) {
+				lines = lines.slice(0, maxLines)
+			}
+			return truncateString(lines.join('\n'), maxChars)
+		}
+
+		// Hard safety net: no matter which fields get truncated above, never recurse
+		// more than this many times. This guarantees termination even if a future
+		// field is added to the URL without corresponding truncation logic.
+		const MAX_RECURSION_ATTEMPTS = 3
+
 		let bugReportUrl: string = `/issues/new?labels=bug&template=bug.yaml&title=${encodeURIComponent(bugTitle)}&version=${version}&config=${encodeURIComponent(JSON.stringify(config, null, 2))}&logs=${encodeURIComponent(logs)}&stacktrace=${encodeURIComponent(stacktrace)}`
+
+		if (bugReportUrl.length > 8140 && attempt >= MAX_RECURSION_ATTEMPTS) {
+			// Give up trying to shrink it further and return the best-effort (possibly
+			// still oversized) URL rather than risk unbounded recursion.
+			return bugReportUrl
+		}
+
 		if (bugReportUrl.length > 8140 && !runningRecursive) {
 			bugTitle = truncateString(bugTitle, 60)
 			let logs_split: string[] = logs.split('\n')
@@ -100,28 +127,44 @@ export class ErrorReportComponent implements OnInit, OnDestroy, AfterViewInit {
 			delete config.tsl_clients_1secupdate
 			delete config.cloud_destinations
 			delete config.cloud_keys
-			bugReportUrl = this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace, true)
+			// The stack trace is never reduced elsewhere and can alone be large
+			// enough to keep the URL over the length threshold, so truncate it too.
+			stacktrace = truncateStacktrace(stacktrace, 20, 2000)
+			bugReportUrl = this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace, true, attempt + 1)
 		}
 		if (bugReportUrl.length > 8140 && runningRecursive) {
 			config = { error: 'config redacted since the issue url was too long' }
-			bugReportUrl = this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace, true)
+			// Shrink the stack trace further each retry so this actually converges
+			// instead of recomputing an identically-sized URL forever.
+			stacktrace = truncateStacktrace(stacktrace, 10, 500)
+			bugReportUrl = this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace, true, attempt + 1)
 		}
 		return bugReportUrl
 	}
 
 	generateBugReportUrl(bugTitle: string, version: string, config: object, logs: string, stacktrace: string) {
 		return new Promise<string>((resolve, reject) => {
-			this.checkIfIssuesEnabled(versions.remote_url).then((issuesEnabled) => {
-				let repo_url: string = ''
-				if (issuesEnabled) {
-					repo_url = versions.remote_url
-				} else {
-					repo_url = 'https://github.com/josephdadams/TallyArbiter'
+			this.checkIfIssuesEnabled(versions.remote_url)
+				.then((issuesEnabled) => {
+					let repo_url: string = ''
+					if (issuesEnabled) {
+						repo_url = versions.remote_url
+					} else {
+						repo_url = 'https://github.com/josephdadams/TallyArbiter'
+						this.bugReportShowForkWarning = true
+					}
+					console.log(`Issues ${issuesEnabled ? 'enabled' : 'disabled'} for the repo ${repo_url}.`)
+					resolve(`${repo_url}${this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace)}`)
+				})
+				.catch((error) => {
+					// If we couldn't determine whether issues are enabled (e.g. a malformed
+					// configured remote_url), fall back to the official repo instead of
+					// leaving this promise unresolved/rejected.
+					console.log('Failed to check if issues are enabled for the configured repo:', error)
 					this.bugReportShowForkWarning = true
-				}
-				console.log(`Issues ${issuesEnabled ? 'enabled' : 'disabled'} for the repo ${repo_url}.`)
-				resolve(`${repo_url}${this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace)}`)
-			})
+					const repo_url = 'https://github.com/josephdadams/TallyArbiter'
+					resolve(`${repo_url}${this.generateBugReportUrlParams(bugTitle, version, config, logs, stacktrace)}`)
+				})
 		})
 	}
 


### PR DESCRIPTION
## Summary
- `generateBugReportUrlParams` truncated `bugTitle`/`logs` and redacted `config` when the encoded bug-report URL exceeded 8140 chars, but never truncated `stacktrace`. If the URL was over the limit purely due to a large stack trace, the recursive retry recomputed an identically-sized URL forever (since nothing about it ever shrank), causing `RangeError: Maximum call stack size exceeded`. Now the stack trace is truncated on each retry (first pass: first 20 lines / 2000 chars, second pass: first 10 lines / 500 chars), and a hard cap of 3 recursive attempts is enforced regardless of which fields shrink, so a similar unbounded-recursion bug can't recur if another field is added later without matching truncation logic.
- `checkIfIssuesEnabled` fell through past an unreturned `resolve(false)` for non-GitHub URLs into code that would throw (`.split('/', 2)` on `undefined`) — this "worked" only because a throw after a promise has already settled is a silent no-op. Added an explicit `return` after `resolve(false)`, wrapped the body in try/catch so unexpected throws (e.g. a malformed configured `remote_url` in `new URL(url)`) call `reject(error)` instead of going unhandled, and added a `.catch()` in `generateBugReportUrl` (the caller) that falls back to the official repo URL instead of leaving the promise chain rejected.

## Test plan
- [x] Regenerated gitignored files (`node scripts/sync-ui-shared.js`, `node UI/git.version.js`) and ran `npx tsc --noEmit -p UI/tsconfig.app.json` — no errors introduced (two pre-existing, unrelated errors exist under `tsconfig.json` on `master` as well, confirmed via `git stash`).
- [x] Ran `npx prettier --check/--write` on the changed file to match repo style.
- [x] Manually traced the recursion with a hypothetical large stack trace: each retry shrinks the stack trace and increments an attempt counter, so the function now always terminates within at most 4 total calls (attempts 0-3), returning a best-effort URL if still oversized.

Addresses items #64 and #65 from the codebase review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)