### PR TITLE
fix: correct RGB565 vs RGB888 mismatch on M5StickC Plus2 display

### DIFF
--- a/listener_clients/m5stickc-listener/m5stickc-listener.ino
+++ b/listener_clients/m5stickc-listener/m5stickc-listener.ino
@@ -771,7 +771,14 @@ void evaluateMode() {
 
     if (actualType != "") {
       m5_setTextColor(BLACK);
-      m5_fillScreen(M5.Lcd.color565(r, g, b));
+#if defined(STICK_C_PLUS2)
+      // StickCP2.Display (Arduino_GFX) expects a full 24-bit RGB888 value,
+      // not a 16-bit RGB565-packed one.
+      uint32_t fillColor = ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+#else
+      uint32_t fillColor = (uint32_t)M5.Lcd.color565(r, g, b);
+#endif
+      m5_fillScreen(fillColor);
       m5_println(DeviceName);
 
     } else {


### PR DESCRIPTION
## Summary

Fixes #822 — "M5StickC Plus2 LCD does not show Red".

`evaluateMode()` in `listener_clients/m5stickc-listener/m5stickc-listener.ino` always built its tally fill color via `M5.Lcd.color565(r, g, b)`, which packs the color into a 16-bit RGB565 value. That value is then passed to `m5_fillScreen()`, which for the `STICK_C_PLUS2` board variant calls `StickCP2.Display.fillScreen(color)` — backed by Arduino_GFX (via `M5StickCPlus2.h`), which expects a full 24-bit RGB888 value (`0xRRGGBB`), not an RGB565-packed one.

Reinterpreting the 16-bit RGB565 value as 24-bit RGB888 systematically drops/misplaces the red bits, so white renders as cyan/blue and red is missing entirely on the Plus2 — exactly the symptom reported in #822.

This fix branches the color construction on `#if defined(STICK_C_PLUS2)`: that variant now builds a raw RGB888 value directly from the already-parsed `r`/`g`/`b` components, while every other board variant (StickC, StickC-Plus, both TFT_eSPI-based) keeps calling `M5.Lcd.color565(r, g, b)` exactly as before.

Credit: this root cause and fix approach was independently diagnosed and validated by community members `adamjonfuller` and `Varacek06` in the GitHub issue thread (https://github.com/josephdadams/TallyArbiter/issues/822).

I also checked the rest of the file for the same `M5.Lcd.color565(...)` pattern feeding into board-variant-dispatching draw/fill calls — this was the only occurrence; no other instances needed the same fix.

## Test plan

- [ ] Flash to an M5StickC Plus2 device and confirm program/preview tally colors (especially red/white) render correctly
- [ ] Confirm M5StickC and M5StickC-Plus variants are unaffected (still use `color565` as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)