### PR TITLE
fix: guard unguarded bus_options lookups from crashing every source

### DIFF
--- a/src/sources/ContributionTally.ts
+++ b/src/sources/ContributionTally.ts
@@ -822,7 +822,12 @@ export class CTPSource extends TallyInput {
 		}
 
 		//get the busType based on the busId
-		let busType = currentConfig.bus_options.find((obj) => obj.id === busId).type
+		const busOption = currentConfig.bus_options.find((obj) => obj.id === busId)
+		if (!busOption) {
+			logger(`Contribution Tally Source: No bus_option found for busId ${busId}; skipping tally add.`, 'error')
+			return
+		}
+		let busType = busOption.type
 
 		if (!found) {
 			//if there was not an entry in the array for this address and bus and busId

--- a/src/sources/RossCarbonite.ts
+++ b/src/sources/RossCarbonite.ts
@@ -465,7 +465,15 @@ export class RossCarboniteSource extends TallyInput {
 			if (device_sources[i].address === address) {
 				//this device_source has this address in it, so let's loop through the tallydata_carbonite array
 				//   and find all the busses that match this address
-				let busses = this.tallydata_RossCarbonite.find(({ address }) => address === device_sources[i].address).busses
+				const tallyEntry = this.tallydata_RossCarbonite.find(({ address }) => address === device_sources[i].address)
+				if (!tallyEntry) {
+					logger(
+						`RossCarbonite: No tally data found for address ${device_sources[i].address}; skipping update.`,
+						'error',
+					)
+					continue
+				}
+				let busses = tallyEntry.busses
 
 				for (let j = 0; j < busses.length; j++) {
 					let bus = RossSwitcherBusAddresses[this.source.sourceTypeId].find(

--- a/src/sources/_Source.ts
+++ b/src/sources/_Source.ts
@@ -140,12 +140,13 @@ export class TallyInput extends EventEmitter {
 
 	protected addBusToAddress(address: string, bus: string) {
 		//replace bus with its real id if it is "preview" or "program" or "aux"
-		if (bus === 'preview') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'preview').id
-		} else if (bus === 'program') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'program').id
-		} else if (bus === 'aux') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'aux').id
+		if (bus === 'preview' || bus === 'program' || bus === 'aux') {
+			const busOption = currentConfig.bus_options.find((b) => b.type === bus)
+			if (!busOption) {
+				logger(`No bus of type '${bus}' is configured; skipping addBusToAddress.`, 'error')
+				return
+			}
+			bus = busOption.id
 		}
 
 		if (!Array.isArray(this.tallyData[address])) {
@@ -158,12 +159,13 @@ export class TallyInput extends EventEmitter {
 
 	protected removeBusFromAddress(address: string, bus: string) {
 		//replace bus with its real id if it is "preview" or "program" or "aux"
-		if (bus === 'preview') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'preview').id
-		} else if (bus === 'program') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'program').id
-		} else if (bus === 'aux') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'aux').id
+		if (bus === 'preview' || bus === 'program' || bus === 'aux') {
+			const busOption = currentConfig.bus_options.find((b) => b.type === bus)
+			if (!busOption) {
+				logger(`No bus of type '${bus}' is configured; skipping removeBusFromAddress.`, 'error')
+				return
+			}
+			bus = busOption.id
 		}
 
 		if (!Array.isArray(this.tallyData[address])) {
@@ -175,12 +177,13 @@ export class TallyInput extends EventEmitter {
 
 	protected removeBusFromAllAddresses(bus: string) {
 		//replace bus with its real id if it is "preview" or "program" or "aux"
-		if (bus === 'preview') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'preview').id
-		} else if (bus === 'program') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'program').id
-		} else if (bus === 'aux') {
-			bus = currentConfig.bus_options.find((b) => b.type === 'aux').id
+		if (bus === 'preview' || bus === 'program' || bus === 'aux') {
+			const busOption = currentConfig.bus_options.find((b) => b.type === bus)
+			if (!busOption) {
+				logger(`No bus of type '${bus}' is configured; skipping removeBusFromAllAddresses.`, 'error')
+				return
+			}
+			bus = busOption.id
 		}
 
 		for (const address of Object.keys(this.tallyData)) {
@@ -192,12 +195,13 @@ export class TallyInput extends EventEmitter {
 		//if bus is "preview" or "program", find its real bus id and use that instead because many source types use those words instead of the actual busId
 		let realBusses = []
 		for (let bus of busses) {
-			if (bus === 'preview') {
-				realBusses.push(currentConfig.bus_options.find((b) => b.type === 'preview').id)
-			} else if (bus === 'program') {
-				realBusses.push(currentConfig.bus_options.find((b) => b.type === 'program').id)
-			} else if (bus === 'aux') {
-				realBusses.push(currentConfig.bus_options.find((b) => b.type === 'aux').id)
+			if (bus === 'preview' || bus === 'program' || bus === 'aux') {
+				const busOption = currentConfig.bus_options.find((b) => b.type === bus)
+				if (!busOption) {
+					logger(`No bus of type '${bus}' is configured; skipping this bus for address ${address}.`, 'error')
+					continue
+				}
+				realBusses.push(busOption.id)
 			} else {
 				realBusses.push(bus)
 			}
@@ -222,12 +226,13 @@ export class TallyInput extends EventEmitter {
 		//if bus is "preview" or "program", find its real bus id and use that instead because many source types use those words instead of the actual busId
 		let realBusses = []
 		for (let bus of busses) {
-			if (bus === 'preview') {
-				realBusses.push(currentConfig.bus_options.find((b) => b.type === 'preview').id)
-			} else if (bus === 'program') {
-				realBusses.push(currentConfig.bus_options.find((b) => b.type === 'program').id)
-			} else if (bus === 'aux') {
-				realBusses.push(currentConfig.bus_options.find((b) => b.type === 'aux').id)
+			if (bus === 'preview' || bus === 'program' || bus === 'aux') {
+				const busOption = currentConfig.bus_options.find((b) => b.type === bus)
+				if (!busOption) {
+					logger(`No bus of type '${bus}' is configured; skipping this bus for address ${address}.`, 'error')
+					continue
+				}
+				realBusses.push(busOption.id)
 			} else {
 				realBusses.push(bus)
 			}


### PR DESCRIPTION
## Summary

`src/sources/_Source.ts` is the base class every tally source extends. Several of its methods looked up a `bus_options` entry by `type` (`'preview'`, `'program'`, `'aux'`) with `Array.prototype.find(...)` and immediately dereferenced a property (`.id`) on the result with no null check:

```ts
bus = currentConfig.bus_options.find((b) => b.type === 'preview').id
```

`bus_options` entries are user-deletable via the Settings UI (`TallyArbiter_Delete_Bus_Option` in `src/index.ts`). If a user deletes the last bus of type `program`, `preview`, or `aux`, `find` returns `undefined` and `.id` throws a `TypeError` — crashing on the very next tally update for **every configured source**, since they all share this base class.

The same class of bug (unguarded `.find(...).type` / `.find(...).busses`) also existed in two subclasses:
- `ContributionTally.ts` looks up a `bus_options` entry by `id` to get its `type`.
- `RossCarbonite.ts` looks up a `tallydata_RossCarbonite` entry by `address` to get its `busses`.

## Fix

Each lookup now checks for a missing result, logs a warning via the existing `logger()` helper, and skips just that specific operation (`return`/`continue` as appropriate for the surrounding control flow) instead of throwing. The happy path (bus/entry found) is unchanged.

### Call sites fixed

**`src/sources/_Source.ts`**
- `addBusToAddress` (was ~line 141-149): guard added before using `busOption.id`; returns early (skips adding this bus) if the type isn't configured.
- `removeBusFromAddress` (was ~line 159-167): same guard; returns early.
- `removeBusFromAllAddresses` (was ~line 176-184): same guard; returns early.
- `setBussesForAddress` (was ~line 191-204): same guard inside the `for (let bus of busses)` loop; `continue`s to skip just that bus, so other busses in the same call still get processed.
- `sendIndividualTallyData` (was ~line 221-234): same guard inside its `for (let bus of busses)` loop; `continue`s per-bus.

**`src/sources/ContributionTally.ts`**
- `addTally` (was line 825): guard added before using `.type`; returns early (skips adding the tally entry) if no `bus_options` entry matches the given `busId`.

**`src/sources/RossCarbonite.ts`**
- `updateRossCarboniteTallyData` (was line 468): guard added before using `.busses`; `continue`s the `for (let i = 0; i < device_sources.length; i++)` loop to skip just this `device_source`, leaving other device sources' updates unaffected.

This addresses the high-priority finding from `ISSUE_TRIAGE.md` (not modified by this PR).

## Test plan

- [x] Read `src/sources/_Source.ts` fully before and after editing; cross-checked with `grep -n "bus_options.find"` to confirm all 5 occurrences in that file are now guarded.
- [x] Confirmed `ContributionTally.ts` and `RossCarbonite.ts` each had exactly one instance of the analogous pattern, and fixed both.
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [ ] Manual repro: delete the last `program`/`preview`/`aux` bus in Settings while a source is running and confirm a warning is logged instead of a crash (not run in this environment; recommend verifying in a running instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)