### PR TITLE
fix: handle OBS groups correctly and add missing v5 visibility handler

### DIFF
--- a/src/sources/OBS.ts
+++ b/src/sources/OBS.ts
@@ -544,6 +544,46 @@ export class OBSSource extends TallyInput {
 			})
 		})
 
+		this.obsClient5.on('SceneItemEnableStateChanged', (data) => {
+			this.obsClient5
+				.call('GetSceneItemList', { sceneName: data.sceneName })
+				.then((sceneItems) => this.findSceneItemSourceName5(sceneItems.sceneItems, data.sceneItemId))
+				.then((sourceName) => {
+					if (!sourceName) {
+						logger(
+							`Source: ${this.source.name}  Could not resolve scene item ${data.sceneItemId} in scene "${data.sceneName}" to a source name`,
+							'error',
+						)
+						return
+					}
+
+					const parentSceneBusses = this.tally.getValue()[data.sceneName] //Yes, I know that doing this is not good with RxJS, but I don't want to update the entire codebase just for this
+					if (!parentSceneBusses) {
+						//Scene not yet tracked in tally (e.g. event fired before initial sync completed); nothing to update
+						return
+					}
+
+					if (data.sceneItemEnabled) {
+						if (parentSceneBusses.includes('program')) {
+							this.addBusToAddress(sourceName, 'program')
+						}
+						if (parentSceneBusses.includes('preview')) {
+							this.addBusToAddress(sourceName, 'preview')
+						}
+					} else {
+						this.removeBusFromAddress(sourceName, 'preview')
+						this.removeBusFromAddress(sourceName, 'program')
+					}
+					this.sendTallyData()
+				})
+				.catch((error) => {
+					logger(
+						`Source: ${this.source.name}  Error while handling scene item visibility change in scene "${data.sceneName}": ${error}`,
+						'error',
+					)
+				})
+		})
+
 		this.obsClient5.on('InputCreated', (data) => {
 			this.obsClient5
 				.call('GetInputVolume', { inputName: data.inputName })
@@ -700,27 +740,86 @@ export class OBSSource extends TallyInput {
 	 * @param bus - Bus to assign (preview/program).
 	 */
 	private processSceneChange5(sceneName: string, bus: string): void {
-		// No support for specific handling for Groups since Group usage is discouraged in OBS, see https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#getsceneitemlist
-		this.obsClient5.call('GetSceneItemList', { sceneName: sceneName }).then((sceneItems) => {
-			let sceneSources = 0
-			for (let i = 0; i < sceneItems.sceneItems.length; i++) {
-				// All scene source items to the bus
-				// Should a check be done for audio input if they are enabled?
-				this.addBusToAddress(sceneItems.sceneItems[i].sourceName as string, bus)
-				if (sceneItems.sceneItems[i].sourceType == 'OBS_SOURCE_TYPE_INPUT') {
-					sceneSources++
-				} else if (sceneItems.sceneItems[i].sourceType == 'OBS_SOURCE_TYPE_SCENE') {
-					// Nested scene, dig deeper...
-					this.processSceneChange5(sceneItems.sceneItems[i].sourceName as string, bus)
-				}
-			}
+		this.obsClient5
+			.call('GetSceneItemList', { sceneName: sceneName })
+			.then((sceneItems) => {
+				this.processSceneItemList5(sceneItems.sceneItems, bus)
+			})
+			.catch((error) => {
+				logger(
+					`Source: ${this.source.name}  Error while getting scene item list for scene "${sceneName}": ${error}`,
+					'error',
+				)
+			})
+	}
 
-			// If this scene doesn't contain a scene then we trigger this.sendTallyData().
-			// The check is done to keep uncessary updates to a minimum.
-			if (sceneSources == sceneItems.sceneItems.length) {
-				this.sendTallyData()
+	/** Adds a bus for each item in a scene item list (as returned by GetSceneItemList/GetGroupSceneItemList),
+	 * recursing into nested scenes and groups.
+	 *
+	 * Groups report sourceType 'OBS_SOURCE_TYPE_SCENE', the same as a genuine nested scene, but OBS websocket
+	 * rejects GetSceneItemList for a group (it requires GetGroupSceneItemList instead) - see the `isGroup` field
+	 * documented at https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#getsceneitemlist
+	 * @param sceneItems - Array of scene items (SceneItem) as returned by GetSceneItemList/GetGroupSceneItemList.
+	 * @param bus - Bus to assign (preview/program).
+	 */
+	private processSceneItemList5(sceneItems: any[], bus: string): void {
+		let sceneSources = 0
+		for (let i = 0; i < sceneItems.length; i++) {
+			const sceneItem = sceneItems[i]
+			// All scene source items to the bus
+			// Should a check be done for audio input if they are enabled?
+			this.addBusToAddress(sceneItem.sourceName as string, bus)
+			if (sceneItem.isGroup) {
+				// Group: enumerate its children via GetGroupSceneItemList, not GetSceneItemList.
+				this.obsClient5
+					.call('GetGroupSceneItemList', { sceneName: sceneItem.sourceName as string })
+					.then((groupItems) => {
+						this.processSceneItemList5(groupItems.sceneItems, bus)
+					})
+					.catch((error) => {
+						logger(
+							`Source: ${this.source.name}  Error while getting group scene item list for group "${sceneItem.sourceName}": ${error}`,
+							'error',
+						)
+					})
+			} else if (sceneItem.sourceType == 'OBS_SOURCE_TYPE_INPUT') {
+				sceneSources++
+			} else if (sceneItem.sourceType == 'OBS_SOURCE_TYPE_SCENE') {
+				// Nested scene, dig deeper...
+				this.processSceneChange5(sceneItem.sourceName as string, bus)
 			}
-		})
+		}
+
+		// If this scene doesn't contain a nested scene or group then we trigger this.sendTallyData().
+		// The check is done to keep uncessary updates to a minimum.
+		if (sceneSources == sceneItems.length) {
+			this.sendTallyData()
+		}
+	}
+
+	/** Recursively searches a scene item list (and any groups within it) for the item with the given numeric ID,
+	 * returning the underlying source name.
+	 * @param sceneItems - Array of scene items (SceneItem) as returned by GetSceneItemList/GetGroupSceneItemList.
+	 * @param sceneItemId - Numeric ID of the scene item to find.
+	 */
+	private findSceneItemSourceName5(sceneItems: any[], sceneItemId: number): Promise<string | undefined> {
+		const directMatch = sceneItems.find((sceneItem) => sceneItem.sceneItemId === sceneItemId)
+		if (directMatch) {
+			return Promise.resolve(directMatch.sourceName as string)
+		}
+
+		const groups = sceneItems.filter((sceneItem) => sceneItem.isGroup)
+
+		return groups.reduce<Promise<string | undefined>>(
+			(promise, group) =>
+				promise.then((found) => {
+					if (found) return found
+					return this.obsClient5
+						.call('GetGroupSceneItemList', { sceneName: group.sourceName as string })
+						.then((groupItems) => this.findSceneItemSourceName5(groupItems.sceneItems, sceneItemId))
+				}),
+			Promise.resolve(undefined as string | undefined),
+		)
 	}
 
 	/** Adds audio input to addresses, to the "audioInputs" list and change tally bus if it's not muted. */


### PR DESCRIPTION
## Summary

Two related bugs in the OBS v5 websocket integration (`src/sources/OBS.ts`), found via direct code reading. Both are v5-specific; v4 code paths are untouched.

### 1. Groups broke tally computation for their entire containing scene (fixes #846)

`processSceneChange5()` recursed into any scene item reporting `sourceType: 'OBS_SOURCE_TYPE_SCENE'` by calling `GetSceneItemList` again. OBS groups also report that `sourceType` (the protocol's only way to tell a group apart is the `isGroup` boolean field on the scene item), but OBS websocket **rejects** `GetSceneItemList` for an actual group — it requires the separate `GetGroupSceneItemList` request, and returns an error like "The specified source is not a scene. (Is group)" otherwise.

Worse, that recursive call had no `.catch()`, so the rejection was an unhandled promise rejection: nothing after the failed call ever ran, silently breaking tally computation for the **entire scene** containing the group, not just the group's own contents.

Fix: extracted the per-item processing into `processSceneItemList5()`, which checks `isGroup` before checking `sourceType`. If an item is a group, it now calls `GetGroupSceneItemList` (mirroring the same recursion pattern used for nested scenes) instead of `GetSceneItemList`. Added `.catch()` (logging via `logger()`) to both the scene-level and group-level calls so a failure in one branch logs an error instead of silently breaking the rest of the scene tree.

### 2. Source visibility toggles inside the active scene were invisible to TallyArbiter on v5 (fixes #751)

OBS v5 never registered a handler for `SceneItemEnableStateChanged` — the event that fires when a source's visibility is toggled *within* the currently active scene (e.g. hide/show a camera), without switching scenes. v4 already handles the equivalent case via `SceneItemVisibilityChanged`. Without this, toggling a source's visibility inside the active scene on v5 (a common way to fake a "switcher" using OBS scene items) never recomputed tally — only a full scene switch did.

Fix: added a `SceneItemEnableStateChanged` handler. The event payload only gives `sceneItemId` (a numeric ID), not the source name, so the handler resolves it via `GetSceneItemList`/`GetGroupSceneItemList` for `data.sceneName` (recursing into groups, reusing the same lookup logic added for bug 1) to find the matching item's `sourceName`. It then mirrors v4's `SceneItemVisibilityChanged` logic: checks whether `data.sceneName` is currently on program/preview (with the same "scene not yet tracked" null-guard used in v4, to avoid reintroducing that previously-fixed null-deref), and calls `addBusToAddress`/`removeBusFromAddress` for the resolved source accordingly, then `sendTallyData()`.

Also addresses the corresponding findings in `ISSUE_TRIAGE.md` (not modified by this PR).

## Confidence / verification notes

- `isGroup` (boolean) on `GetSceneItemList`/`GetGroupSceneItemList` response items, and the `GetGroupSceneItemList` request shape (`sceneName`/`sceneUuid`, same as `GetSceneItemList`), were confirmed against the upstream obs-websocket protocol docs (obsproject/obs-websocket `docs/generated/protocol.md`) since the `obs-websocket-js-5` npm package's own TypeScript types only expose `sceneItems` as an untyped `JsonObject[]` (no compile-time field guarantees either way).
- `SceneItemEnableStateChanged`'s exact field names (`sceneName`, `sceneUuid`, `sceneItemId`, `sceneItemEnabled`) were confirmed directly from `obs-websocket-js-5`'s bundled `.d.ts` (`dist/base-C5oEliFC.d.ts`).
- `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- This could not be exercised against a live OBS instance in this environment — recommend a manual smoke test with a scene containing a group, and toggling a source's visibility within the active program/preview scene, before merging.

## Test plan

- [ ] Manually verify against a live OBS 5.x websocket: scene containing a group renders correct tally for the group's children without breaking tally for sibling items in the same scene.
- [ ] Manually verify toggling a source's visibility (eye icon) within the currently active program/preview scene updates that source's tally state without a full scene switch.
- [x] `npx tsc --noEmit -p tsconfig.json` passes.

Closes #846
Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)