### PR TITLE
fix: consider all three TSL5 tally fields, not just text_tally

### DIFF
--- a/src/sources/TSL.ts
+++ b/src/sources/TSL.ts
@@ -187,6 +187,22 @@ export class TSL5DataParser {
 }
 
 class TSL5Base extends TallyInput {
+	//Decodes a single 2-bit TSL 5.0 tally value into its preview/program state.
+	//0 = off, 1 = program (red), 2 = preview (green), 3 = both.
+	private static decodeTallyBusState(value: number): { inPreview: number; inProgram: number } {
+		switch (value) {
+			case 1:
+				return { inPreview: 0, inProgram: 1 }
+			case 2:
+				return { inPreview: 1, inProgram: 0 }
+			case 3:
+				return { inPreview: 1, inProgram: 1 }
+			case 0:
+			default:
+				return { inPreview: 0, inProgram: 0 }
+		}
+	}
+
 	protected processTSL5Tally(data) {
 		if (data.length >= 12) {
 			let tallyobj: any = TSL5DataParser.parseTSL5Data(data)
@@ -195,27 +211,15 @@ class TSL5Base extends TallyInput {
 				this.renameAddress(tallyobj.INDEX[0].toString(), tallyobj.INDEX[0].toString(), tallyobj.TEXT.toString().trim())
 			}
 
-			let inPreview = 0
-			let inProgram = 0
+			//Some TSL 5.0 senders (e.g. Panasonic Kairos) only pulse text_tally briefly
+			//around a cut and drive their steady-state on-air indication through
+			//rh_tally/lh_tally instead, so all three fields are combined with OR logic.
+			const rhState = TSL5Base.decodeTallyBusState(tallyobj.control.rh_tally)
+			const textState = TSL5Base.decodeTallyBusState(tallyobj.control.text_tally)
+			const lhState = TSL5Base.decodeTallyBusState(tallyobj.control.lh_tally)
 
-			switch (tallyobj.control.text_tally) {
-				case 0:
-					inPreview = 0
-					inProgram = 0
-					break
-				case 1:
-					inPreview = 0
-					inProgram = 1
-					break
-				case 2:
-					inPreview = 1
-					inProgram = 0
-					break
-				case 3:
-					inPreview = 1
-					inProgram = 1
-					break
-			}
+			const inPreview = rhState.inPreview || textState.inPreview || lhState.inPreview
+			const inProgram = rhState.inProgram || textState.inProgram || lhState.inProgram
 
 			const busses = []
 			if (inPreview) {


### PR DESCRIPTION
## Summary

`TSL5Base.processTSL5Tally()` in `src/sources/TSL.ts` decodes the TSL 5.0 control word into three independent 2-bit colour fields — `rh_tally`, `text_tally`, and `lh_tally` — but the on-air decision logic only ever inspected `text_tally` to decide whether a source was on program or preview. `rh_tally` and `lh_tally` were parsed into the tally object and then never read again.

Panasonic Kairos (and likely other TSL 5.0 senders) drives its steady-state on-air indication through `rh_tally`/`lh_tally`, only pulsing `text_tally` briefly around a cut. As a result, TallyArbiter would show a brief flash whenever `text_tally` pulsed and then immediately go dark, ignoring the switcher's actual ongoing tally state.

This addresses GitHub issue #696 (https://github.com/josephdadams/TallyArbiter/issues/696) and the corresponding finding in `ISSUE_TRIAGE.md`.

## Fix

- Factored the existing value-to-bus mapping (`0`=off, `1`=program, `2`=preview, `3`=both) out of the single `text_tally` switch into a small static helper `TSL5Base.decodeTallyBusState(value)`.
- Applied that helper to all three fields (`rh_tally`, `text_tally`, `lh_tally`) and combined the results with OR logic — a source is on program if any of the three indicates program, and on preview if any indicates preview.
- No new config field/UI was added; all three fields are combined unconditionally, per the recommended fix in the linked issue.
- Only `src/sources/TSL.ts` was touched (the TSL 5.0 incoming-source class). `src/_modules/TSL.ts`, the separate outgoing TSL client packet builder, was not modified.

## Test plan

- [x] Read the full file before and after the change to confirm the surrounding tally-update flow (`setBussesForAddress` / `sendIndividualTallyData`) is still invoked correctly with the combined decision.
- [x] Ran `npx tsc --noEmit -p tsconfig.json` — no errors.
- [x] Manually traced the reported scenario: `rh_tally = 1` (program), `text_tally = 0`, `lh_tally = 0` → `inProgram = 1 || 0 || 0 = 1`, `inPreview = 0` → correctly reports program instead of going dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)