### PR TITLE
fix: filter hidden busses and guard against missing source data

### DIFF
--- a/src/sources/InternalTestMode.ts
+++ b/src/sources/InternalTestMode.ts
@@ -37,7 +37,7 @@ export class InternalTestModeSource extends TallyInput {
 	currentAddressNumber = 0
 	currentAddressIterations = 0
 
-	busses = currentConfig.bus_options.map((bus) => bus.id)
+	busses = currentConfig.bus_options.filter((bus) => bus.visible !== false).map((bus) => bus.id)
 
 	testModeInterval: NodeJS.Timeout
 
@@ -46,6 +46,7 @@ export class InternalTestModeSource extends TallyInput {
 	constructor(source: Source) {
 		super(source)
 
+		if (!this.source.data) this.source.data = {}
 		if (!this.source.data.interval) this.source.data.interval = 100
 		if (!this.source.data.changeMode) this.source.data.changeMode = 'one-at-a-time'
 		if (!this.source.data.addressesNumber) this.source.data.addressesNumber = 10


### PR DESCRIPTION
## Summary

Two bug fixes in `src/sources/InternalTestMode.ts`, the Internal Test Mode tally source:

1. **Rotation cycle diluted by hidden busses** (fixes #855). The `busses` rotation list was built from *all* configured `bus_options`, including ones marked `visible: false`. The default config ships 10 bus options (Preview, Program, Aux 1-8, with Aux 3-8 hidden by default), so a full rotation cycle grew to up to 10 ticks instead of only cycling through the visible/meaningful busses — diluting how often any given test address got a real preview/program flash, especially with multiple devices configured. Now filters to `bus.visible !== false` before mapping to ids, matching the same convention the Angular UI already uses in `UI/src/app/_services/socket.service.ts` (`busOptions.filter((b) => b.visible == true || b.visible == undefined)`).

2. **Crash at server startup on missing `source.data`** (fixes #687, fixes #928). The constructor read/wrote `this.source.data.interval` without first checking that `this.source.data` itself exists. `data` is not in the `required` list for a `sources[]` entry in `configSchema.ts`, so a legacy/hand-edited config with a `TESTMODE` source entry but no `data` key crashed the server at startup with `TypeError: Cannot read properties of undefined (reading 'interval')`, before login was even possible. Now defaults `this.source.data = {}` first, before any other access to `this.source.data.*` in the constructor.

This also addresses the corresponding findings recorded in `ISSUE_TRIAGE.md` for these three issues (not modified in this PR).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manually confirmed the `data` guard is the first statement in the constructor to touch `this.source.data`, ahead of the `interval`/`changeMode`/`addressesNumber` reads that follow
- [x] Confirmed `BusOption.visible` semantics against `src/_helpers/config.ts` defaults and the UI's existing filter convention

Closes #855
Closes #687
Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)