### PR TITLE
fix: recompute tally on SuperSource changes and dedupe RECORDING/STREAMING entries

### DIFF
--- a/src/sources/BlackmagicATEM.ts
+++ b/src/sources/BlackmagicATEM.ts
@@ -73,10 +73,14 @@ export class BlackmagicATEMSource extends TallyInput {
 			this.processATEMState(this.atemClient.state)
 			this.processATEMTally()
 			if (this.atemClient.state.recording) {
-				this.addAddress('{{RECORDING}}', '{{RECORDING}}')
+				if (!this.addresses.value.some((a) => a.address === '{{RECORDING}}')) {
+					this.addAddress('{{RECORDING}}', '{{RECORDING}}')
+				}
 			}
 			if (this.atemClient.state.streaming) {
-				this.addAddress('{{STREAMING}}', '{{STREAMING}}')
+				if (!this.addresses.value.some((a) => a.address === '{{STREAMING}}')) {
+					this.addAddress('{{STREAMING}}', '{{STREAMING}}')
+				}
 			}
 		})
 
@@ -89,6 +93,8 @@ export class BlackmagicATEMSource extends TallyInput {
 				if (path.indexOf('video.mixEffects') > -1 || path.indexOf('video.downstreamKeyers') > -1) {
 					this.processATEMState(state)
 				} else if (path.indexOf('video.auxilliaries') > -1) {
+					this.processATEMState(state)
+				} else if (path.indexOf('video.superSources') > -1) {
 					this.processATEMState(state)
 				} else if (path == 'streaming.status') {
 					this.processATEMState(state)


### PR DESCRIPTION
## Summary
- Fixes GitHub issue #453 (Atem supersource tally): the `stateChanged` handler in `src/sources/BlackmagicATEM.ts` only recomputed program/preview tally state when a changed path matched `video.mixEffects`, `video.downstreamKeyers`, `video.auxilliaries`, `streaming.status`, or `recording.status`. Changing which source is routed into a SuperSource box reports a `video.superSources.<ssrcId>.boxes.<boxId>` path, which matched none of these, so SuperSource content changes never triggered a tally recompute (it only appeared to work when the SuperSource itself was cut out of/back onto program, which happens to touch `video.mixEffects`). Added a branch matching `path.indexOf('video.superSources') > -1` that also calls `processATEMState(state)`.
- Fixes the secondary complaint in GitHub issue #890 (repeating `{{RECORDING}}`/`{{STREAMING}}` dropdown entries): the `connected` handler unconditionally called `this.addAddress('{{RECORDING}}', '{{RECORDING}}')` / `this.addAddress('{{STREAMING}}', '{{STREAMING}}')` whenever `state.recording`/`state.streaming` were true, with no de-duplication. Since `atem-connection` re-emits a full-state `connected` event on every reconnect (not just the first connection), any connection that reconnects after a transient network blip accumulated duplicate `{{RECORDING}}`/`{{STREAMING}}` entries in the address dropdown. Both calls are now guarded with an existence check (`this.addresses.value.some((a) => a.address === '{{RECORDING}}')`, matching the address-lookup style already used elsewhere in `_Source.ts`) before adding.

This addresses the findings for these two issues captured in `ISSUE_TRIAGE.md`.

Related issues:
- https://github.com/josephdadams/TallyArbiter/issues/453
- https://github.com/josephdadams/TallyArbiter/issues/890

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [ ] Manually verify: change SuperSource box source routing on a real/simulated ATEM and confirm tally updates without needing to also cut the SuperSource on/off program
- [ ] Manually verify: force a reconnect (e.g. brief network interruption) while recording/streaming and confirm `{{RECORDING}}`/`{{STREAMING}}` do not appear as duplicate entries in the address dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)