### PR TITLE
fix: arbitrate simultaneously-active busses by priority in M5Atom firmware

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -608,12 +608,24 @@ int getBusPriorityById(String busId) {
 
 void processTallyData() {
   bool typeChanged = false;
+  // Sentinel lower than any valid bus priority (priorities are >= 0), so the
+  // first active bus encountered always wins the initial comparison below.
+  int bestPriority = -1;
   for (int i = 0; i < DeviceStates.length(); i++) {
     if (DeviceStates[i]["sources"].length() > 0) {
-      typeChanged = true;
-      actualType = getBusTypeById(JSON.stringify(DeviceStates[i]["busId"]));
-      actualColor = getBusColorById(JSON.stringify(DeviceStates[i]["busId"]));
-      actualPriority = getBusPriorityById(JSON.stringify(DeviceStates[i]["busId"]));
+      String busId = JSON.stringify(DeviceStates[i]["busId"]);
+      int busPriority = getBusPriorityById(busId);
+      // Only adopt this bus's tally if it outranks the highest-priority
+      // active bus seen so far (higher priority number = higher precedence,
+      // e.g. Program=200 outranks Aux=100), instead of always taking the
+      // last active bus in DeviceStates regardless of its priority.
+      if (busPriority > bestPriority) {
+        typeChanged = true;
+        bestPriority = busPriority;
+        actualType = getBusTypeById(busId);
+        actualColor = getBusColorById(busId);
+        actualPriority = busPriority;
+      }
     }
   }
   if(!typeChanged) {


### PR DESCRIPTION
## Summary

Fixes GitHub issue #738: the M5Atom listener client did not tally Program if the same device/source was also assigned to any ATEM Aux output.

- `processTallyData()` in `listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino` iterates `DeviceStates`, which mirrors the server's `bus_options` config order (Preview, Program, Aux1, Aux2, ... by default). For every bus entry with a non-empty `sources` array, it unconditionally overwrote `actualType`/`actualColor`/`actualPriority` — so whichever active bus happened to appear *last* in the array won, regardless of actual importance. Since Aux busses come after Program in the default order, a device assigned to both Program and an Aux output would silently display the Aux color instead of Program.
- A `getBusPriorityById()` helper already existed in the file (returns the numeric `priority` field from `bus_options`, e.g. Program=200, Aux=100, Preview=50 by default — confirmed against `src/_helpers/config.ts` and the server default config) but was never actually used to arbitrate between busses.
- Fix: track the highest-priority active bus seen while iterating `DeviceStates` (initialized to a sentinel of `-1`, lower than any valid priority) and only update `actualType`/`actualColor`/`actualPriority` when the current bus's priority is strictly greater than the best seen so far. This matches the same `priority` comparison the web UI already uses to pick the winning bus (`a?.priority > b?.priority ? a : b` in `UI/src/app/_components/tally/tally.component.ts`).

Only `tallyarbiter-m5atom.ino`'s `processTallyData()` function was touched; no other functions or files were modified.

## Scope note

The same last-bus-wins pattern likely exists in the other listener-client firmwares (m5stickc, esp32-neopixel, TTGO_T), as mentioned in the original issue thread and in the `ISSUE_TRIAGE.md` finding for this issue. That is intentionally out of scope for this PR, which only addresses the M5Atom firmware.

## Test plan

- [ ] This is Arduino/ESP32 firmware; no compiler toolchain was available or attempted in this environment. Verified by manual code reading: re-read the modified `processTallyData()` in full, confirmed the sentinel (`-1`) guarantees the first active bus always "wins" its comparison, and traced through the reported scenario (device active on both an Aux bus and Program) to confirm Program's higher priority value now correctly wins regardless of array order.
- [ ] Recommend a maintainer with real M5Atom hardware confirms behavior against a live ATEM/TSL source assigned to both Program and an Aux bus.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>