### PR TITLE
fix: guard TallyArbiter_Add_Device_Source against a stale sourceId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2210,8 +2210,21 @@ function TallyArbiter_Add_Device_Source(obj: Manage): ManageResponse {
 	deviceSourceObj.id = uuidv4()
 	device_sources.push(deviceSourceObj)
 
-	let deviceName = GetDeviceByDeviceId(deviceSourceObj.deviceId).name
-	let sourceName = GetSourceBySourceId(deviceSourceObj.sourceId).name
+	let deviceName = ''
+	try {
+		deviceName = GetDeviceByDeviceId(deviceSourceObj.deviceId).name
+	} catch (error) {
+		//sometimes the device is already deleted, so we can't get the name
+		deviceName = 'Unknown'
+	}
+
+	let sourceName = ''
+	try {
+		sourceName = GetSourceBySourceId(deviceSourceObj.sourceId).name
+	} catch (error) {
+		//sometimes the source is already deleted, so we can't get the name
+		sourceName = 'Unknown'
+	}
 
 	UpdateCloud('device_sources')
 


### PR DESCRIPTION
## Summary

`TallyArbiter_Add_Device_Source` (a `'manage'` socket-handler dispatch target in `src/index.ts`) calls:

```ts
let deviceName = GetDeviceByDeviceId(deviceSourceObj.deviceId).name
let sourceName = GetSourceBySourceId(deviceSourceObj.sourceId).name
```

`GetDeviceByDeviceId` has a built-in fallback (`{id: 'unassigned', name: 'Unassigned'}`) for a non-matching id, but `GetSourceBySourceId` has no such fallback and returns raw `undefined` when the id doesn't match any currently configured source (e.g. a stale/deleted source referenced due to a race condition, or a client sending manage data with an outdated `sourceId`). Calling `.name` on that `undefined` throws `TypeError: Cannot read properties of undefined (reading 'name')`, crashing the handler.

This exact scenario is already handled in the two sibling functions, `TallyArbiter_Edit_Device_Source` and `TallyArbiter_Delete_Device_Source`, which wrap the identical lookup in a try/catch with an `'Unknown'` fallback string (with a comment noting the source may already be deleted). This protection was simply never applied to the `Add` function - this fix brings it in line with its siblings, wrapping both the device and source lookups in the same try/catch/fallback pattern for consistency.

Addresses #793.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Manually verified the three sibling functions (`Add`/`Edit`/`Delete_Device_Source`) now use visually identical try/catch/fallback handling for the device/source name lookups