### PR TITLE
fix: reassign external LED pins off input-only/conflicting GPIOs

### DIFF
--- a/listener_clients/TTGO_T-listener/TTGO_T-listener.ino
+++ b/listener_clients/TTGO_T-listener/TTGO_T-listener.ino
@@ -51,9 +51,15 @@ bool LAST_MSG = true; // true = show messages on tally screen
 #define TALLY_EXTRA_OUTPUT false
 
 #if TALLY_EXTRA_OUTPUT
-const int led_program = 10;
-const int led_preview = 26; //OPTIONAL Led for preview on pin G26
-const int led_aux = 36;     //OPTIONAL Led for aux on pin G36
+// NOTE: TALLY_EXTRA_OUTPUT requires free, output-capable GPIOs. The original pins
+// didn't work on the TTGO T-Display: G10 is an SPI-flash-integration pin not
+// recommended (and typically not broken out) on WROOM modules, G26 collides with
+// led_blue's onboard status LED below, and G36 is input-only (no output driver).
+// G25/G27/G32 are free, output-capable, and don't conflict with the display or
+// onboard peripherals defined in this file.
+const int led_program = 25;
+const int led_preview = 27; //OPTIONAL Led for preview on pin G27
+const int led_aux = 32;     //OPTIONAL Led for aux on pin G32
 #endif
 const int led_blue = 26;     //blue led  connected with 270ohm resistor
 


### PR DESCRIPTION
## Summary

Fixes GitHub issue #592 ("TTGO T1 Display External LED not working") and the corresponding finding in `ISSUE_TRIAGE.md`.

The optional external-LED output (`TALLY_EXTRA_OUTPUT`) in `listener_clients/TTGO_T-listener/TTGO_T-listener.ino` hardcoded three GPIO pins that are all broken on the TTGO T-Display's ESP32:

- **`led_aux` (GPIO36)** is an ESP32 input-only pin (`ADC1_CH0`/`SENSOR_VP`) with no output driver at all — `pinMode(..., OUTPUT)` and `digitalWrite(...)` on it are silent no-ops, so voltage could never appear on this pin.
- **`led_preview` (GPIO26)** is the exact same physical pin already wired to the onboard status LED (`led_blue`), which the sketch drives continuously elsewhere for WiFi/boot status. Enabling external-LED mode made the two outputs fight over one pin.
- **`led_program` (GPIO10)** is one of the ESP32's SPI-flash-integration pins (GPIO6-11). Espressif's own guidance says not to use these as general-purpose I/O on WROOM modules, and this pin typically isn't even broken out on the TTGO T-Display's exposed headers.

## Changes

Reassigned all three constants to free, output-capable GPIOs that don't conflict with anything else in this file (TFT backlight `TFT_BL`=4, `ADC_EN`=14, `ADC_PIN`=34, top button=35, bottom button=0, onboard `led_blue`=26):

| Constant | Old pin | New pin | Why |
|---|---|---|---|
| `led_program` | GPIO10 | **GPIO25** | Free, output-capable (DAC1/ADC2_CH8), not a strapping pin, not used elsewhere in this file |
| `led_preview` | GPIO26 | **GPIO27** | Free, output-capable (ADC2_CH7), no longer collides with `led_blue` on GPIO26 |
| `led_aux` | GPIO36 | **GPIO32** | Free, output-capable (ADC1_CH4), moved off input-only GPIO36 |

Grepped the whole file for `25`, `27`, `32`, `33`, `2`, `15` to confirm none of these are already used as pin numbers anywhere else in the sketch (all matches found were unrelated numeric literals like text sizes, IP octets, and battery-voltage math — not pin assignments).

Also added a one-line comment above the constant definitions explaining why the original pins didn't work, so future maintainers don't reintroduce the same conflict.

No other logic was changed — diff is limited to the three constant values and the new comment.

## Test plan

- [ ] This is Arduino/ESP32 firmware; no compiler or hardware was available in this environment, so **no build or on-device test was attempted**. Verification here was limited to careful manual reading of every `led_program`/`led_preview`/`led_aux`/`led_blue` reference in the file and confirming the new pin numbers don't collide with any other pin used in this sketch.
- [ ] Recommend flashing to actual TTGO T-Display hardware with `TALLY_EXTRA_OUTPUT` enabled to confirm the external LEDs light up correctly on program/preview/aux before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)