### PR TITLE
fix: skip polling device sources with no address configured

### DIFF
--- a/src/sources/RolandSmartTally.ts
+++ b/src/sources/RolandSmartTally.ts
@@ -20,6 +20,15 @@ export class RolandSmartTallySource extends TallyInput {
 
 		for (const deviceSource of device_sources.filter((s) => s.sourceId === this.source.id)) {
 			let address = deviceSource.address
+
+			if (!address) {
+				logger(
+					`Device source ${deviceSource.id} has no address/input number configured; skipping Roland Smart Tally poll.`,
+					'error',
+				)
+				continue
+			}
+
 			axios
 				.get(`http://${ip}/tally/${address}/status`)
 				.then((response) => {


### PR DESCRIPTION
## Summary
- Fixes GitHub issue #673: Roland V-60HD Smart Tally polling returns HTTP 404 after upgrading from TallyArbiter v2.
- Root cause: configs migrated from an old v2 install can have `device_sources` entries with no `address` field (only `deviceId`/`sourceIdx`/`sourceId`/`id`). With `address` undefined, `checkRolandStatus()` built a poll URL like `http://<ip>/tally/undefined/status`, which always 404s against Roland's Smart Tally API (which expects a numeric input index in that URL segment). The code fired this doomed request every 500ms poll cycle with no guard against it.
- Fix: in the polling loop in `src/sources/RolandSmartTally.ts`, if `deviceSource.address` is falsy, skip firing the HTTP request for that specific device source, log a clear actionable error via `logger()`, and `continue` to the next device source in the same cycle. Other correctly-configured device sources in the same poll cycle are unaffected.

## Out of scope (intentionally not addressed here)
- Config-migration/backfill logic to populate missing `address` fields in `readConfig()`/`config.ts` — a separate, larger change.
- Authentication support for Roland Smart Tally — tracked separately in issue #876.

## Workaround for affected users (until backfill migration exists)
In Settings, delete and re-add the affected device↔source link so the `address` field gets populated correctly, then restart the poll.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors.
- [x] Manually re-read the full `checkRolandStatus()` function to confirm `continue` only skips the current device source and does not abort the loop or the poll cycle for other device sources.

Addresses #673.