### PR TITLE
fix: unpublish mDNS advertisement on shutdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,32 @@ function processError(err) {
 
 process.on('uncaughtException', processError)
 
+// The embedded server (dist/index, running in this same process) publishes
+// an mDNS advertisement on startup using a stable, UUID-derived name. If we
+// let Electron tear the process down without unpublishing it first, the
+// stale record can trip the OS's mDNS conflict detection on the next
+// launch ("This computer's localhost name is already in use."). All of our
+// quit paths (tray "Quit", powerMonitor's shutdown event, and the
+// window-all-closed confirmation) funnel through app.quit(), so hooking
+// before-quit here covers them all. We block the actual quit just long
+// enough to let the server unpublish, then let it proceed.
+let mdnsCleanupDone = false
+
+app.on('before-quit', (event) => {
+	if (mdnsCleanupDone || !server || typeof server.shutdown !== 'function') {
+		return
+	}
+
+	event.preventDefault()
+	Promise.resolve()
+		.then(() => server.shutdown())
+		.catch(() => {})
+		.then(() => {
+			mdnsCleanupDone = true
+			app.quit()
+		})
+})
+
 function createWindow() {
 	mainWindow = new BrowserWindow({
 		width: WindowProperties.width,

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,14 @@ function startUp() {
 			generateAndSendErrorReport(err)
 		}
 	})
+
+	process.on('SIGINT', () => {
+		shutdown().finally(() => process.exit(0))
+	})
+
+	process.on('SIGTERM', () => {
+		shutdown().finally(() => process.exit(0))
+	})
 }
 
 //Sentry Monitoring Setup
@@ -2986,6 +2994,43 @@ function generateAndSendErrorReport(error: Error) {
 	io.emit('server_error', id)
 }
 
+// Unpublishes the mDNS advertisement (and tears down the underlying mDNS
+// server) so that a stable, UUID-derived service name doesn't linger as a
+// stale record after this process exits. Used both by the SIGINT/SIGTERM
+// handlers above and by the Electron wrapper's before-quit handler, since
+// the latter runs the server in-process and has no OS signal to rely on.
+// A safety timeout guarantees this always resolves, even if the mDNS
+// server can't reach the network to send its goodbye packets.
+let shuttingDown = false
+function shutdown(): Promise<void> {
+	if (shuttingDown) {
+		return Promise.resolve()
+	}
+	shuttingDown = true
+
+	return new Promise((resolve) => {
+		let settled = false
+		const finish = () => {
+			if (settled) return
+			settled = true
+			resolve()
+		}
+
+		const safetyTimer = setTimeout(finish, 2000)
+
+		try {
+			bonjour.unpublishAll(() => {
+				clearTimeout(safetyTimer)
+				bonjour.destroy()
+				finish()
+			})
+		} catch (err) {
+			clearTimeout(safetyTimer)
+			finish()
+		}
+	})
+}
+
 startUp()
 
-export { logFilePath, getConfigRedacted, generateAndSendErrorReport }
+export { logFilePath, getConfigRedacted, generateAndSendErrorReport, shutdown }


### PR DESCRIPTION
## Summary

- The server advertises itself over mDNS on startup (`src/_helpers/mdns.ts` + `bonjour.publish(...)` in `src/index.ts`) using a **stable** name derived from a persisted config UUID (`'tallyarbiter-' + (currentConfig['uuid'] || 'unknown')`), but it never called `unpublishAll()`/`destroy()` on shutdown.
- Because the name is stable rather than ephemeral, an unclean shutdown left a stale mDNS record behind. On the next launch, the OS's mDNS conflict detection saw the (still cached/lingering) record as live and threw up the **"This computer's localhost name is already in use."** dialog.
- Neither the standalone server (`src/index.ts`, which only had an `uncaughtException` handler) nor the Electron wrapper (`main.js`, whose various quit paths — tray "Quit", `powerMonitor.on('shutdown', ...)`, window-close confirmation — all eventually call `app.quit()`) ever triggered mDNS cleanup before the process went away.

## Fix

- `src/index.ts`: added a `shutdown()` function that calls `bonjour.unpublishAll()` then `bonjour.destroy()`, guarded against double-invocation and with a 2s safety timeout so it can't hang the process if the network is already down. Wired it up to new `process.on('SIGINT', ...)` and `process.on('SIGTERM', ...)` handlers (added alongside the existing `uncaughtException` handler in `startUp()`), and exported it so the Electron wrapper can reuse it.
- `main.js`: added an `app.on('before-quit', ...)` handler that calls the embedded server's exported `shutdown()` (since the server runs in-process via `require('./dist/index')`, there's no OS signal to send it — this reuses the same cleanup path directly). It `preventDefault()`s the quit just long enough to await the mDNS unpublish, then re-invokes `app.quit()`, so every existing quit path (tray Quit, powerMonitor shutdown, window-all-closed) is covered without duplicating logic.

Addresses #406.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors introduced.
- [x] `node --check main.js` passes (syntax valid).
- [x] Verified `main.js`'s existing quit paths (tray "Quit", `powerMonitor.on('shutdown', ...)`, `window-all-closed`) all still funnel through `app.quit()`, so the new `before-quit` hook covers all of them.
- [ ] Manual verification on a machine that reproduces the original mDNS conflict dialog (kill server abnormally, relaunch, confirm no dialog) — not done in this environment, recommend a maintainer/reporter of #406 confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)