### PR TITLE
fix: only re-broadcast/log tally state that actually changed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1642,12 +1642,30 @@ function initializeSource(source: Source): TallyInput {
 	return sourceClient
 }
 
+// Some sources (e.g. VMix) report their entire cumulative tally state on every
+// message, even when only one address actually changed. Comparing against the
+// previously cached busses per-address lets us avoid re-broadcasting/re-logging
+// state that hasn't actually changed. Bus order isn't significant, so this
+// compares as sets (same approach as the areSetsEqual helper in BlackmagicATEM.ts).
+function areBussesEqual(a: string[] | undefined, b: string[] | undefined): boolean {
+	if (a === b) return true
+	if (!a || !b) return false
+	if (a.length !== b.length) return false
+	const setA = new Set(a)
+	return b.every((bus) => setA.has(bus))
+}
+
 function processSourceTallyData(sourceId: string, tallyData: SourceTallyData) {
 	writeTallyDataFile(tallyData)
 
 	for (const [address, busses] of Object.entries(tallyData)) {
 		//console.log('tally_data', sourceId, address, busses);
-		io.to('settings').emit('tally_data', sourceId, address, busses)
+		// Only emit if this specific address's busses actually changed since the
+		// last time we processed data for it (an absent previous value counts as
+		// "changed" so the first real update for an address still fires).
+		if (!areBussesEqual(currentSourceTallyData[address], busses)) {
+			io.to('settings').emit('tally_data', sourceId, address, busses)
+		}
 	}
 
 	currentSourceTallyData = {


### PR DESCRIPTION
## Summary

vMix's TCP tally protocol sends its entire tally byte-string (one byte per input, covering every input in the production) whenever ANY single input's tally state changes anywhere in the switcher - not just the input that actually changed. `src/sources/VMix.ts` reprocesses every byte position on every such message and calls `sendTallyData()` once per message with the full cumulative per-address state. That part is inherent to vMix's wire protocol and isn't something TallyArbiter controls, so it's left unchanged.

Downstream, `initializeSource`'s `tally.subscribe(...)` callback in `src/index.ts` forwards this into `processSourceTallyData`, which previously emitted a `tally_data` socket event (and fed the tally log shown on the Settings page) for **every** mapped device on **every** message - even when that specific device's bus state hadn't changed since the last update. In a production with, say, 3 TallyArbiter-mapped cameras out of 20 total vMix inputs, a tally change on any of the other 17 unmapped inputs would re-trigger a full re-log of all 3 mapped cameras' current state (mostly "None"), flooding the tally log and drowning out genuine state changes.

This bug isn't specific to vMix - any source that reports full cumulative state on every message (rather than a true delta) would trigger the same flooding - so the fix lives in the generic dispatch path in `src/index.ts` (`processSourceTallyData`) rather than in `VMix.ts`.

## Fix

`processSourceTallyData` now compares each address's incoming busses against the previously cached value in `currentSourceTallyData` (comparing as sets, same approach as the existing `areSetsEqual` helper in `BlackmagicATEM.ts`) and only emits the `tally_data` socket event when that specific address's state actually differs from what was last recorded. An absent previous value (i.e. the very first update for that address) is treated as "changed," so the first legitimate emission for a device still fires normally.

## Scope

This addresses the log-flooding symptom described in [#756](https://github.com/josephdadams/TallyArbiter/issues/756) ("vMix reporting NONE from API") and the corresponding finding in `ISSUE_TRIAGE.md`. It does **not** address the separate "sendTallyData fails" claim in the same issue - that part still needs more information from the original reporter to reproduce/diagnose.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors
- [x] Traced a 3-mapped-device scenario (A, B, C): a vMix message that only changes the input mapped to device A results in only device A's `tally_data` event/log firing; B and C are suppressed since their cached busses are unchanged
- [x] Confirmed the very first tally update for a device still emits (no cached previous state = treated as changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)