### PR TITLE
feat: HTTP Basic auth for Roland Smart Tally sources

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -750,6 +750,18 @@
 							[(ngModel)]="currentSource.data[field.fieldName]"
 						/>
 					</div>
+					<div class="mb-3" *ngSwitchCase="'password'">
+						<label [for]="field.fieldName" class="form-label"
+							>{{ field.fieldLabel }}<span class="text-danger" *ngIf="!field.optional">*</span></label
+						>
+						<input
+							type="password"
+							autocomplete="new-password"
+							class="form-control"
+							[id]="field.fieldName"
+							[(ngModel)]="currentSource.data[field.fieldName]"
+						/>
+					</div>
 					<div class="mb-3" *ngSwitchCase="['port', 'number'].includes(field.fieldType) ? field.fieldType : ''">
 						<label [for]="field.fieldName" class="form-label"
 							>{{ field.fieldLabel }}<span class="text-danger" *ngIf="!field.optional">*</span></label
@@ -1090,6 +1102,16 @@
 							<label [for]="field.fieldName" class="form-label">{{ field.fieldLabel }}</label>
 							<input
 								type="text"
+								class="form-control"
+								[id]="field.fieldName"
+								[(ngModel)]="currentDeviceAction.data[field.fieldName]"
+							/>
+						</div>
+						<div class="mb-3" *ngSwitchCase="'password'">
+							<label [for]="field.fieldName" class="form-label">{{ field.fieldLabel }}</label>
+							<input
+								type="password"
+								autocomplete="new-password"
 								class="form-control"
 								[id]="field.fieldName"
 								[(ngModel)]="currentDeviceAction.data[field.fieldName]"

--- a/src/_types/TallyInputConfigField.ts
+++ b/src/_types/TallyInputConfigField.ts
@@ -1,7 +1,7 @@
 export type TallyInputConfigField = {
 	fieldName: string
 	fieldLabel: string
-	fieldType: 'text' | 'port' | 'number' | 'bool' | 'dropdown' | 'multiselect' | 'info'
+	fieldType: 'text' | 'password' | 'port' | 'number' | 'bool' | 'dropdown' | 'multiselect' | 'info'
 	help?: string
 	optional?: boolean
 	// Only meaningful when fieldType is 'dropdown' or 'multiselect'.

--- a/src/sources/RolandSmartTally.ts
+++ b/src/sources/RolandSmartTally.ts
@@ -4,9 +4,16 @@ import { RegisterTallyInput } from '../_decorators/RegisterTallyInput.decorator'
 import { Source } from '../_models/Source'
 import { TallyInput } from './_Source'
 
-@RegisterTallyInput('4a58f00f', 'Roland Smart Tally', '', [
-	{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
-])
+@RegisterTallyInput(
+	'4a58f00f',
+	'Roland Smart Tally',
+	'Username and password are only required if your switcher (e.g. the V-80HD) has web authentication enabled. Leave them blank otherwise.',
+	[
+		{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+		{ fieldName: 'username', fieldLabel: 'Username', fieldType: 'text', optional: true },
+		{ fieldName: 'password', fieldLabel: 'Password', fieldType: 'password', optional: true },
+	],
+)
 export class RolandSmartTallySource extends TallyInput {
 	private interval: NodeJS.Timeout
 	constructor(source: Source) {
@@ -17,6 +24,12 @@ export class RolandSmartTallySource extends TallyInput {
 
 	public checkRolandStatus() {
 		let ip = this.source.data.ip
+		let username = this.source.data.username
+		let password = this.source.data.password
+
+		// Only send HTTP Basic credentials if a username was actually configured;
+		// switchers without web auth (the common case) must not receive an auth header.
+		const requestConfig = username ? { auth: { username, password: password || '' } } : undefined
 
 		for (const deviceSource of device_sources.filter((s) => s.sourceId === this.source.id)) {
 			let address = deviceSource.address
@@ -30,7 +43,7 @@ export class RolandSmartTallySource extends TallyInput {
 			}
 
 			axios
-				.get(`http://${ip}/tally/${address}/status`)
+				.get(`http://${ip}/tally/${address}/status`, requestConfig)
 				.then((response) => {
 					this.connected.next(true)
 


### PR DESCRIPTION
## Summary

Adds optional authentication to the Roland Smart Tally source so switchers that require web authentication (e.g. the Roland V-80HD) can be polled. Closes #876.

Previously the source only exposed an IP field and sent no credentials, so switchers with web auth enabled returned auth errors.

## Changes

- **`src/sources/RolandSmartTally.ts`** — added optional `username`/`password` config fields plus help text. Credentials are passed as axios HTTP Basic `auth` on the poll request, but **only when a username is configured** — switchers without web auth (the common case) receive no auth header, so existing installs are unaffected.
- **`src/_types/TallyInputConfigField.ts`** — introduced a `'password'` config field type.
- **`UI/src/app/_components/settings/settings.component.html`** — rendered the new masked (`type="password"`) field in both the source and action settings forms.

Also included: a small `tsconfig.json` fix — `moduleResolution` was set to the invalid value `node22`, which broke `npm run build`; changed to `node10` (the modern spelling of the previous `node` setting).

## Testing

Built the server + Angular UI (AOT clean) and ran the app against a fresh config. Verified the Add Source → Roland Smart Tally form renders the optional Username field and a masked Password field with help text, and that leaving them blank preserves existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)