### PR TITLE
fix: bump trivy-action to a resolvable version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,7 +69,7 @@ jobs:
           docker build -t tallyarbiter-scan:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.18.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'tallyarbiter-scan:${{ github.sha }}'
           ignore-unfixed: true


### PR DESCRIPTION
## Summary

The **Analyze Docker Image** CI job (in `.github/workflows/codeql-analysis.yml`) pinned `aquasecurity/trivy-action@0.18.0`, a tag that no longer resolves. The job failed at setup on every PR with:

```
Unable to resolve action `aquasecurity/trivy-action@0.18.0`, unable to find version `0.18.0`
```

This surfaced red checks on unrelated PRs even though it's a workflow/infra issue, not a code problem.

## Change

Bump the pin to `0.36.0` (current release). All existing inputs (`image-ref`, `ignore-unfixed`, `format`, `template`, `output`, `severity`, `vuln-type`) remain valid in this version, so behaviour is unchanged apart from the action now resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)