### PR TITLE
feat: force a password change on first run

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,9 @@ Given that, a few things are **intentional** and aren't vulnerabilities on their
 
 Things we **do** consider security issues: authentication or role-check bypass on the Socket.IO API, ways to read or overwrite `config.json` (it holds credentials and JWT signing material) without authorization, injection into the commands sent to cameras and switchers, and anything that lets an unauthenticated LAN client take actions that should require a login.
 
-Also worth knowing: Tally Arbiter ships with **default credentials** (`admin`/`12345`, `producer`/`12345`). That's a known weakness we're addressing separately, not a new finding — please change them on any real deployment.
+Also worth knowing how the seeded accounts work. A new install still seeds `admin` and `producer` with the documented default password, but both accounts are flagged: the server refuses every privileged action for them and the UI forces a new password on first login, so the default is only ever valid for the one login that replaces it. Reporting that a **fresh** install accepts `admin`/`12345` is therefore not a finding.
+
+Installs created before that change are **not** forced to rotate — locking an operator out mid-production would be worse than the exposure. Those accounts keep working on the default password, and Tally Arbiter warns about them on every startup and in Settings > Users. If you find an install in that state, the fix is to change the password; it isn't a new vulnerability. What _would_ be a finding is a way to get past the forced change on a fresh install, or to clear the flag without knowing the current password.
 
 ## A note on automated scanners and AI-generated reports
 

--- a/UI/src/app/_components/change-password/change-password.component.html
+++ b/UI/src/app/_components/change-password/change-password.component.html
@@ -1,0 +1,59 @@
+<div class="container text-center d-flex justify-content-center mt-5 pt-5">
+	<main class="form-change-password">
+		<h1 class="h3 mb-3 fw-normal">Change your password</h1>
+
+		<div class="alert alert-warning text-start" *ngIf="forced">
+			<strong>{{ username }}</strong> is still using the default password that Tally Arbiter ships with. Please set your
+			own password before continuing — the rest of the application is locked until you do.
+		</div>
+
+		<div class="my-2 text-danger" *ngIf="!response.changeOk">{{ response.message }}</div>
+		<div class="my-2 text-danger" *ngIf="response.changeOk && validationError">{{ validationError }}</div>
+
+		<div class="form-floating">
+			<input
+				type="password"
+				class="form-control"
+				(keydown.enter)="inputNewPassword.focus()"
+				[(ngModel)]="currentPassword"
+				id="currentPassword"
+				placeholder="Current password"
+				autocomplete="current-password"
+			/>
+			<label for="currentPassword">Current password</label>
+		</div>
+		<div class="form-floating">
+			<input
+				type="password"
+				class="form-control"
+				(keydown.enter)="inputConfirmPassword.focus()"
+				[(ngModel)]="newPassword"
+				id="newPassword"
+				placeholder="New password"
+				autocomplete="new-password"
+				#inputNewPassword
+			/>
+			<label for="newPassword">New password</label>
+		</div>
+		<div class="form-floating">
+			<input
+				type="password"
+				class="form-control"
+				(keydown.enter)="changePassword()"
+				[(ngModel)]="confirmPassword"
+				id="confirmPassword"
+				placeholder="Confirm new password"
+				autocomplete="new-password"
+				#inputConfirmPassword
+			/>
+			<label for="confirmPassword">Confirm new password</label>
+		</div>
+
+		<div class="form-text text-start mb-3">At least {{ minLength }} characters.</div>
+
+		<button class="w-100 btn btn-lg btn-primary" (click)="changePassword()" [disabled]="!canSubmit">
+			<span *ngIf="!loading">Change password</span>
+			<div class="spinner-border spinner-border-sm text-white" *ngIf="loading"></div>
+		</button>
+	</main>
+</div>

--- a/UI/src/app/_components/change-password/change-password.component.scss
+++ b/UI/src/app/_components/change-password/change-password.component.scss
@@ -1,0 +1,25 @@
+.form-change-password {
+	width: 100%;
+	max-width: 400px;
+	padding: 15px;
+	margin: auto;
+}
+
+.form-change-password .form-floating:focus-within {
+	z-index: 2;
+}
+
+.form-change-password #currentPassword {
+	margin-bottom: 10px;
+}
+
+.form-change-password #newPassword {
+	margin-bottom: -1px;
+	border-bottom-right-radius: 0;
+	border-bottom-left-radius: 0;
+}
+
+.form-change-password #confirmPassword {
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+}

--- a/UI/src/app/_components/change-password/change-password.component.ts
+++ b/UI/src/app/_components/change-password/change-password.component.ts
@@ -3,8 +3,7 @@ import { Component, ElementRef, ViewChild } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { ActivatedRoute, Router } from '@angular/router'
 import { AuthService, ChangePasswordResponse } from 'src/app/_services/auth.service'
-
-export const MIN_PASSWORD_LENGTH = 8
+import { MIN_PASSWORD_LENGTH } from '../../../../../src/_helpers/passwordPolicy'
 
 @Component({
 	selector: 'app-change-password',

--- a/UI/src/app/_components/change-password/change-password.component.ts
+++ b/UI/src/app/_components/change-password/change-password.component.ts
@@ -1,0 +1,90 @@
+import { CommonModule } from '@angular/common'
+import { Component, ElementRef, ViewChild } from '@angular/core'
+import { FormsModule } from '@angular/forms'
+import { ActivatedRoute, Router } from '@angular/router'
+import { AuthService, ChangePasswordResponse } from 'src/app/_services/auth.service'
+
+export const MIN_PASSWORD_LENGTH = 8
+
+@Component({
+	selector: 'app-change-password',
+	standalone: true,
+	imports: [CommonModule, FormsModule],
+	templateUrl: './change-password.component.html',
+	styleUrls: ['./change-password.component.scss'],
+})
+export class ChangePasswordComponent {
+	public loading = false
+	public response: ChangePasswordResponse = { changeOk: true, message: '', accessToken: '' }
+	public currentPassword = ''
+	public newPassword = ''
+	public confirmPassword = ''
+	public minLength = MIN_PASSWORD_LENGTH
+	private redirectParam = 'home'
+	@ViewChild('inputNewPassword') public inputNewPassword!: ElementRef
+	@ViewChild('inputConfirmPassword') public inputConfirmPassword!: ElementRef
+
+	constructor(
+		public route: ActivatedRoute,
+		private router: Router,
+		public authService: AuthService,
+	) {
+		this.route.params.subscribe((params) => {
+			if (params.redirect) this.redirectParam = params.redirect
+		})
+
+		switch (this.redirectParam) {
+			case 'producer':
+			case 'errors':
+			case 'settings':
+				break
+			default:
+				this.redirectParam = 'home'
+				break
+		}
+	}
+
+	//true when this is the forced first-run change rather than a voluntary one
+	public get forced(): boolean {
+		return this.authService.mustChangePassword
+	}
+
+	public get username(): string {
+		return this.authService.profile?.username || ''
+	}
+
+	public get validationError(): string {
+		if (this.newPassword.length > 0 && this.newPassword.length < MIN_PASSWORD_LENGTH) {
+			return `Your new password must be at least ${MIN_PASSWORD_LENGTH} characters long.`
+		}
+		if (this.confirmPassword.length > 0 && this.newPassword !== this.confirmPassword) {
+			return 'The two new passwords do not match.'
+		}
+		return ''
+	}
+
+	public get canSubmit(): boolean {
+		return (
+			!this.loading &&
+			this.currentPassword.length > 0 &&
+			this.newPassword.length >= MIN_PASSWORD_LENGTH &&
+			this.newPassword === this.confirmPassword
+		)
+	}
+
+	changePassword(): void {
+		if (!this.canSubmit) return
+		this.loading = true
+		this.authService.changePassword(this.currentPassword, this.newPassword).then((response) => {
+			this.response = response
+			this.loading = false
+
+			if (response.changeOk === true) {
+				this.currentPassword = ''
+				this.newPassword = ''
+				this.confirmPassword = ''
+				this.router.navigate([this.redirectParam])
+			}
+		})
+	}
+}

--- a/UI/src/app/_components/login/login.component.ts
+++ b/UI/src/app/_components/login/login.component.ts
@@ -49,6 +49,11 @@ export class LoginComponent {
 			this.loading = false
 
 			if (response.loginOk === true) {
+				if (this.authService.mustChangePassword) {
+					//'home' is not guarded, so the guard alone would not catch this
+					this.router.navigate(['change-password', this.redirectParam])
+					return
+				}
 				let navigateParams = [this.redirectParam]
 				if (this.extraParam !== '') navigateParams.push(this.extraParam)
 				this.router.navigate(navigateParams)

--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -1433,10 +1433,21 @@
 		</div>
 		<div class="mb-3" *ngIf="!editingUser">
 			<label for="userPassword" class="form-label">Password</label>
-			<input required type="text" class="form-control" id="userPassword" [(ngModel)]="currentUser.password" />
+			<input
+				required
+				type="password"
+				class="form-control"
+				id="userPassword"
+				autocomplete="new-password"
+				[(ngModel)]="currentUser.password"
+			/>
+			<small class="form-text">At least {{ minPasswordLength }} characters.</small>
+			<div class="text-danger mt-1" *ngIf="currentUser.password && newUserPasswordError">
+				{{ newUserPasswordError }}
+			</div>
 		</div>
 		<div class="d-flex justify-content-end">
-			<button class="btn btn-primary" (click)="saveCurrentUser()">
+			<button class="btn btn-primary" (click)="saveCurrentUser()" [disabled]="newUserPasswordError !== ''">
 				<i class="fas fa-save"></i> {{ editingUser ? 'Save Changes' : 'Add User' }}
 			</button>
 		</div>

--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -543,6 +543,13 @@
 						</button>
 					</h3>
 					<div>
+						<div class="alert alert-warning" *ngIf="socketService.defaultPasswordUsers.length > 0">
+							<i class="fas fa-exclamation-triangle me-2"></i>
+							<strong>{{ socketService.defaultPasswordUsers.join(', ') }}</strong>
+							{{ socketService.defaultPasswordUsers.length === 1 ? 'is' : 'are' }} still using the default password that
+							Tally Arbiter ships with. Anyone who can reach this server can sign in. Please set a real password below —
+							this will be enforced in a future release.
+						</div>
 						<span class="text-muted mt-3 d-block" *ngIf="socketService.users.length == 0"
 							>No user found. This should not happen... Please, open a bug report on Github.</span
 						>
@@ -861,11 +868,15 @@
 				[(ngModel)]="currentDevice.tslAddress"
 			/>
 		</div>
-		<hr class="my-3">
+		<hr class="my-3" />
 		<div class="mb-3">
 			<label for="deviceCameraIP" class="form-label">
 				Camera IP
-				<span class="ta-tooltip" data-tip="If your camera supports tally natively, use this feature to send tally commands directly to it.">ⓘ</span>
+				<span
+					class="ta-tooltip"
+					data-tip="If your camera supports tally natively, use this feature to send tally commands directly to it."
+					>ⓘ</span
+				>
 			</label>
 			<input type="text" class="form-control" id="deviceCameraIP" [(ngModel)]="currentDevice.cameraIP" />
 			<label for="deviceCameraModel" class="form-label mt-2">Camera Model</label>
@@ -876,7 +887,7 @@
 				</option>
 			</select>
 		</div>
-		<hr class="my-3">
+		<hr class="my-3" />
 		<div class="mb-3">
 			<b>Linked Busses:</b><br />
 			<small>

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -216,6 +216,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 		}
 		if (this.authService.requireRole('settings:users')) {
 			this.socketService.socket.emit('users')
+			this.socketService.socket.emit('default_password_users')
 		}
 		if (this.authService.requireRole('settings:config')) {
 			this.socketService.socket.on('config', this.handleConfigReceived)

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -37,6 +37,7 @@ import { User } from 'src/app/_models/User'
 import { AuthService } from 'src/app/_services/auth.service'
 import { JsonEditorComponent, JsonEditorOptions } from 'ang-jsoneditor'
 import { default as configSchema } from 'src/app/_schemas/configSchema'
+import { MIN_PASSWORD_LENGTH } from '../../../../../src/_helpers/passwordPolicy'
 
 const globalSwalOptions = {
 	confirmButtonColor: '#2a70c7',
@@ -125,6 +126,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 	public editingUser = false
 	public currentUser: User = {} as User
 	public selectedUserRoles: string[] = []
+	public minPasswordLength = MIN_PASSWORD_LENGTH
 
 	public newCloudKey = ''
 
@@ -745,13 +747,23 @@ export class SettingsComponent implements OnInit, OnDestroy {
 		return this.currentUser.roles && this.currentUser.roles.split(';').includes(role)
 	}
 
+	//a new user needs a real password. this used to fall back to '12345', which quietly
+	//created accounts on the password Tally Arbiter ships with.
+	public get newUserPasswordError(): string {
+		if (this.editingUser) return ''
+		const password = this.currentUser.password || ''
+		if (password.length === 0) return 'Please set a password for this user.'
+		if (password.length < MIN_PASSWORD_LENGTH) {
+			return `The password must be at least ${MIN_PASSWORD_LENGTH} characters long.`
+		}
+		return ''
+	}
+
 	public saveCurrentUser() {
+		if (this.newUserPasswordError !== '') return
 		const userObj = {
 			...this.currentUser,
 		} as any
-		if (!userObj.password) {
-			userObj.password = '12345'
-		}
 		if (!userObj.roles) {
 			userObj.roles = 'tally_view'
 		}

--- a/UI/src/app/_guards/authorize.guard.ts
+++ b/UI/src/app/_guards/authorize.guard.ts
@@ -41,6 +41,12 @@ export class AuthorizeGuard {
 			console.log('Not logged in. Navigating to the login page...')
 			this.router.navigate(destination)
 			return false
+		} else if (this.authService.mustChangePassword) {
+			//the server rejects every privileged action for this account, so there is
+			//nothing worth landing on until the password is replaced
+			console.log('Password change required. Navigating to the change password page...')
+			this.router.navigate(['change-password', currentSection || 'home'])
+			return false
 		} else {
 			// The /settings route hosts every settings tab, so anyone holding any
 			// 'settings:*' sub-role (or admin) should reach the page shell; individual

--- a/UI/src/app/_services/auth.service.ts
+++ b/UI/src/app/_services/auth.service.ts
@@ -10,6 +10,12 @@ export interface LoginResponse {
 	accessToken: string
 }
 
+export interface ChangePasswordResponse {
+	changeOk: boolean
+	message: string
+	accessToken: string
+}
+
 @Injectable({
 	providedIn: 'root',
 })
@@ -67,6 +73,27 @@ export class AuthService {
 			this.socketService.socket.emit('login', username, password)
 			this.socketService.socket.once('login_response', (response: LoginResponse) => {
 				if (response.loginOk === true) {
+					this.setToken(response.accessToken)
+				}
+				resolve(response)
+			})
+		})
+	}
+
+	//true while the account is still on the password Tally Arbiter shipped with. the
+	//server blocks everything else for these accounts, so the UI sends them straight
+	//to the change-password page.
+	public get mustChangePassword(): boolean {
+		if (this.profile === undefined) return false
+		return this.profile.mustChangePassword === true
+	}
+
+	public changePassword(currentPassword: string, newPassword: string) {
+		return new Promise<ChangePasswordResponse>((resolve) => {
+			this.socketService.socket.emit('change_password', currentPassword, newPassword)
+			this.socketService.socket.once('change_password_response', (response: ChangePasswordResponse) => {
+				if (response.changeOk === true) {
+					//the old token still says mustChangePassword; swap in the fresh one
 					this.setToken(response.accessToken)
 				}
 				resolve(response)

--- a/UI/src/app/_services/socket.service.ts
+++ b/UI/src/app/_services/socket.service.ts
@@ -72,6 +72,9 @@ export class SocketService {
 	public messages: Message[] = []
 	public errorReports: ErrorReportsListElement[] = [] as ErrorReportsListElement[]
 	public users: User[] = []
+	//usernames still on the password Tally Arbiter ships with; existing installs are
+	//warned rather than locked out, so the settings page nags until this is empty
+	public defaultPasswordUsers: string[] = []
 
 	public accessToken: string | undefined
 
@@ -339,6 +342,7 @@ export class SocketService {
 				case 'user-deleted-successfully':
 					this.closeModals.next()
 					this.socket.emit('users')
+					this.socket.emit('default_password_users')
 					break
 				case 'error':
 					alert('Unexpected Error Occurred: ' + response.error)
@@ -368,6 +372,9 @@ export class SocketService {
 		})
 		this.socket.on('users', (users: User[]) => {
 			this.users = users
+		})
+		this.socket.on('default_password_users', (usernames: string[]) => {
+			this.defaultPasswordUsers = usernames
 		})
 
 		this.socket.on('remote_error_opt', (optStatus: boolean) => {

--- a/UI/src/app/app-routing.module.ts
+++ b/UI/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core'
 import { RouterModule, Routes } from '@angular/router'
 import { AboutComponent } from './_components/about/about.component'
+import { ChangePasswordComponent } from './_components/change-password/change-password.component'
 import { ErrorReportComponent } from './_components/error-report/error-report.component'
 import { ErrorReportsListComponent } from './_components/error-reports-list/error-reports-list.component'
 import { HomeComponent } from './_components/home/home.component'
@@ -21,6 +22,8 @@ const routes: Routes = [
 	{ path: 'about', component: AboutComponent },
 	{ path: 'login/:redirect/:extraParam', component: LoginComponent },
 	{ path: 'login/:redirect', component: LoginComponent },
+	{ path: 'change-password/:redirect', component: ChangePasswordComponent },
+	{ path: 'change-password', component: ChangePasswordComponent },
 	//
 	{ path: '**', redirectTo: '/home', pathMatch: 'full' },
 ]

--- a/docs/docs/usage/control-interface.md
+++ b/docs/docs/usage/control-interface.md
@@ -12,7 +12,9 @@ If you're running the Desktop App, you get a window showing the GUI. However, th
 ## Configuration
 
 In the configuration interface, the settings page is available at `/settings`: http://127.0.0.1:4455/settings
-**This page is restricted by a username and password. The default username is `admin` and the default password is `12345`.**
+**This page is restricted by a username and password. On a new installation the username is `admin` and the password is `12345`, but that password only works for your very first sign-in: Tally Arbiter immediately asks you to choose your own, and the rest of the interface stays locked until you do.** Pick something you'll remember: there is no password reset link. If you do get locked out, close Tally Arbiter, set `"users": []` in the `config.json` described below, and start it again — the `admin` and `producer` accounts come back at `12345` and the rest of your configuration is left alone.
+
+If you're upgrading an existing installation, your current passwords keep working. If any account is still on `12345`, Tally Arbiter says so at startup and on the Users tab of the settings page; change it under **Settings > Users**.
 
 All the changes you make there are saved to a `config.json` file. This file should also be backed up frequently to prevent data loss when updating. It's path is different depending on the OS that you're running:
 

--- a/docs/docs/usage/sections/listener-clients.md
+++ b/docs/docs/usage/sections/listener-clients.md
@@ -19,7 +19,7 @@ If you include `?chat=false` to the request, you can turn off the Messaging/Chat
 ## Viewing all tally data
 
 Navigate to `/producer` on the Tally Arbiter server in your browser to view all Devices and their current states. This information is also available in the Settings GUI but is displayed in a minimal fashion here for in-service viewing. Messages can be sent and received to supported clients.
-**This page is restricted by a username and password. The default username is `producer` and the default password is `12345`.**
+**This page is restricted by a username and password. On a new installation the username is `producer` and the password is `12345`, but that password only works for the first sign-in — Tally Arbiter then asks the producer to choose their own before the page will load.** On an upgraded installation the existing password keeps working.
 
 ## Using an M5StickC for tally output
 

--- a/src/_helpers/auth.ts
+++ b/src/_helpers/auth.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 import { logger } from '../index'
 import { currentConfig, DEFAULT_PASSWORD, SaveConfig } from './config'
+import { MIN_PASSWORD_LENGTH } from './passwordPolicy'
 import { clone } from './clone'
 
 import { AuthenticateSuccessResponse } from '../_models/AuthenticateSuccessResponse'
@@ -47,8 +48,6 @@ export function authenticate(username: string, password: string): Promise<Authen
 		if (!userFound) reject(new Error('Invalid username or password'))
 	})
 }
-
-export const MIN_PASSWORD_LENGTH = 8
 
 //lets a signed-in user replace their own password. the current password is required
 //so that a leaked token on its own cannot lock the real operator out of the account.
@@ -132,6 +131,16 @@ export function addUser(user: User): boolean {
 		}
 	})
 	if (!userFound) {
+		//a caller that has an opinion about the forced change (the first-run seeding in
+		//config.ts) sets it explicitly. otherwise, an account handed the password we ship
+		//with has to replace it, so a blank password in the add-user form cannot quietly
+		//create a second account on '12345'.
+		if (user.mustChangePassword === undefined && user.password === DEFAULT_PASSWORD) {
+			user.mustChangePassword = true
+		}
+		if (!user.mustChangePassword) {
+			delete user.mustChangePassword
+		}
 		user.password = hashPassword(user.password)
 		currentConfig.users.push(user)
 		SaveConfig()

--- a/src/_helpers/auth.ts
+++ b/src/_helpers/auth.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 import { logger } from '../index'
-import { currentConfig, SaveConfig } from './config'
+import { currentConfig, DEFAULT_PASSWORD, SaveConfig } from './config'
 import { clone } from './clone'
 
 import { AuthenticateSuccessResponse } from '../_models/AuthenticateSuccessResponse'
@@ -46,6 +46,60 @@ export function authenticate(username: string, password: string): Promise<Authen
 		})
 		if (!userFound) reject(new Error('Invalid username or password'))
 	})
+}
+
+export const MIN_PASSWORD_LENGTH = 8
+
+//lets a signed-in user replace their own password. the current password is required
+//so that a leaked token on its own cannot lock the real operator out of the account.
+export function changeOwnPassword(username: string, current_password: string, new_password: string): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		if (typeof new_password !== 'string' || new_password.length < MIN_PASSWORD_LENGTH) {
+			reject(new Error(`Your new password must be at least ${MIN_PASSWORD_LENGTH} characters long.`))
+			return
+		}
+		if (new_password === DEFAULT_PASSWORD) {
+			reject(new Error('That is the default password. Please choose a different one.'))
+			return
+		}
+		const index = currentConfig.users.findIndex((user) => user.username === username)
+		if (index === -1) {
+			reject(new Error('Invalid username or password'))
+			return
+		}
+		if (new_password === current_password) {
+			reject(new Error('Your new password must be different from your current one.'))
+			return
+		}
+		checkPassword(current_password, currentConfig.users[index].password)
+			.then((password_valid) => {
+				if (!password_valid) {
+					reject(new Error('Invalid username or password'))
+					return
+				}
+				currentConfig.users[index].password = hashPassword(new_password)
+				delete currentConfig.users[index].mustChangePassword
+				SaveConfig()
+				logger(`User ${username} changed their password.`)
+				resolve()
+			})
+			.catch(reject)
+	})
+}
+
+//existing installs are not forced to rotate, but we do want to say so on every boot.
+//accounts already flagged mustChangePassword are left out: they cannot do anything
+//until they rotate, so warning about them as well would just be noise.
+export function usersWithDefaultPassword(): Promise<string[]> {
+	return Promise.all(
+		currentConfig.users.map((user) =>
+			user.mustChangePassword
+				? Promise.resolve('')
+				: checkPassword(DEFAULT_PASSWORD, user.password)
+						.then((matches) => (matches ? user.username : ''))
+						.catch(() => ''),
+		),
+	).then((usernames) => usernames.filter((username) => username !== ''))
 }
 
 export function validateAccessToken(access_token: string): Promise<User> {
@@ -95,8 +149,14 @@ export function editUser(user: User) {
 	currentConfig.users.forEach((user_original, index) => {
 		if (user.username === user_original.username) {
 			userFound = true
-			if (user.password && !BCRYPT_HASH_PATTERN.test(user.password)) {
+			const passwordChanged = !!user.password && !BCRYPT_HASH_PATTERN.test(user.password)
+			if (passwordChanged) {
 				user.password = hashPassword(user.password)
+			}
+			//the whole record is replaced here, so an edit that does not touch the password
+			//(changing roles, say) must not quietly clear a pending forced change
+			if (!passwordChanged && user_original.mustChangePassword) {
+				user.mustChangePassword = true
 			}
 			currentConfig.users[index] = user
 		}

--- a/src/_helpers/config.ts
+++ b/src/_helpers/config.ts
@@ -67,6 +67,11 @@ export const ConfigDefaults: Config = {
 export let currentConfig: Config = clone(ConfigDefaults)
 export let isConfigLoaded: boolean = false
 
+//the password the seeded accounts have always shipped with; new configs still get
+//it so the documented first login works, but the accounts are flagged so it has to
+//be replaced before anything can be done with them
+export const DEFAULT_PASSWORD = '12345'
+
 export function SaveConfig() {
 	try {
 		let tsl_clients_clean: ConfigTSLClient[] = []
@@ -100,7 +105,12 @@ export function SaveConfig() {
 export function readConfig(): void {
 	isConfigLoaded = true
 	const configPath = getConfigFilePath()
-	if (!fs.pathExistsSync(configPath)) {
+	//a config we are creating right now is a first run; the seeded accounts get
+	//flagged so the operator has to replace the default password before using them.
+	//an existing install is only warned about default passwords, never locked out
+	//of a running system by an upgrade.
+	const isFirstRun = !fs.pathExistsSync(configPath)
+	if (isFirstRun) {
 		try {
 			SaveConfig()
 		} catch (e) {}
@@ -134,13 +144,15 @@ export function readConfig(): void {
 		currentConfig.users = []
 		addUser({
 			username: loadedConfig.security.username_producer || 'producer',
-			password: loadedConfig.security.password_producer || '12345',
+			password: loadedConfig.security.password_producer || DEFAULT_PASSWORD,
 			roles: 'producer',
+			mustChangePassword: isFirstRun,
 		})
 		addUser({
 			username: loadedConfig.security.username_settings || 'admin',
-			password: loadedConfig.security.password_settings || '12345',
+			password: loadedConfig.security.password_settings || DEFAULT_PASSWORD,
 			roles: 'admin',
+			mustChangePassword: isFirstRun,
 		})
 		delete currentConfig.security.username_producer
 		delete currentConfig.security.password_producer

--- a/src/_helpers/passwordPolicy.ts
+++ b/src/_helpers/passwordPolicy.ts
@@ -1,0 +1,3 @@
+//shared between the server and the UI, in the same way authRoles.ts is, so the rule
+//the server enforces and the rule the forms advertise cannot drift apart
+export const MIN_PASSWORD_LENGTH = 8

--- a/src/_models/User.ts
+++ b/src/_models/User.ts
@@ -2,4 +2,7 @@ export interface User {
 	username: string
 	password?: string
 	roles: string
+	//set on the users seeded into a brand new config; the user must pick their own
+	//password before the account can be used for anything else
+	mustChangePassword?: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,16 @@ import { TSLListenerProvider } from './_modules/TSL'
 import { MQTTService } from './_modules/MQTT'
 import { ListenerProvider } from './_modules/_ListenerProvider'
 import { InternalTestModeSource } from './sources/InternalTestMode'
-import { authenticate, validateAccessToken, getUsersList, addUser, editUser, deleteUser } from './_helpers/auth'
+import {
+	authenticate,
+	validateAccessToken,
+	getUsersList,
+	addUser,
+	editUser,
+	deleteUser,
+	changeOwnPassword,
+	usersWithDefaultPassword,
+} from './_helpers/auth'
 import { Config } from './_models/Config'
 import { bonjour } from './_helpers/mdns'
 
@@ -199,6 +208,7 @@ function startUp() {
 	loadClassesFromFolder('sources')
 	loadConfig()
 	initialSetup()
+	WarnAboutDefaultPasswords()
 	DeleteInactiveListenerClients()
 
 	process.on('uncaughtException', (err: Error) => {
@@ -304,6 +314,15 @@ function initialSetup() {
 				let access_token = tmpSocketAccessTokens[socket.id]
 				validateAccessToken(access_token)
 					.then((user) => {
+						if (user.mustChangePassword) {
+							//the account is still on the password it shipped with; the only thing
+							//it can do is set a real one
+							let error_msg = 'You must change your password before you can use this feature.'
+							socket.emit('error', error_msg)
+							socket.emit('must_change_password')
+							reject(error_msg)
+							return
+						}
 						if (user.roles.split(';').includes(role) || user.roles.split(';').includes('admin')) {
 							resolve(user)
 						} else {
@@ -359,6 +378,43 @@ function initialSetup() {
 
 		socket.on('access_token', (access_token: string) => {
 			tmpSocketAccessTokens[socket.id] = access_token
+		})
+
+		//deliberately not behind requireRole: an account flagged mustChangePassword is
+		//blocked from everything else, so this has to stay reachable. the username comes
+		//from the token rather than the client so nobody can rotate someone else's password.
+		socket.on('change_password', (current_password: string, new_password: string) => {
+			const access_token = tmpSocketAccessTokens[socket.id]
+			if (typeof access_token === 'undefined') {
+				socket.emit('change_password_response', {
+					changeOk: false,
+					message: 'Access token required. Please login again.',
+					accessToken: '',
+				})
+				return
+			}
+			validateAccessToken(access_token)
+				.then((user) => {
+					return changeOwnPassword(user.username, current_password, new_password).then(() => {
+						//the old token still carries mustChangePassword, so hand back a fresh one
+						return authenticate(user.username, new_password).then((result) => {
+							WarnAboutDefaultPasswords()
+							socket.emit('change_password_response', {
+								changeOk: true,
+								message: '',
+								accessToken: result.access_token,
+							})
+						})
+					})
+				})
+				.catch((error) => {
+					logger(`User (ip addr ${ipAddr}) failed to change their password (${error.message || error})`)
+					socket.emit('change_password_response', {
+						changeOk: false,
+						message: error.message || 'Could not change the password.',
+						accessToken: '',
+					})
+				})
 		})
 
 		socket.on('version', () => {
@@ -1122,6 +1178,16 @@ function initialSetup() {
 				})
 		})
 
+		socket.on('default_password_users', () => {
+			requireRole('settings:users')
+				.then((user) => {
+					socket.emit('default_password_users', defaultPasswordUsers)
+				})
+				.catch((err) => {
+					logger(err, 'error')
+				})
+		})
+
 		socket.on('get_config', () => {
 			requireRole('settings:config')
 				.then((user) => {
@@ -1519,6 +1585,32 @@ function writeTallyDataFile(log) {
 	} catch (error) {
 		logger(`Error saving logs to file: ${error}`, 'error')
 	}
+}
+
+//usernames still using the password Tally Arbiter ships with. cached because the
+//check is a bcrypt compare per user, and the UI asks for it on every settings load.
+export var defaultPasswordUsers: string[] = []
+
+//existing installs are never locked out by an upgrade, but we do say something about
+//it on every boot and in the settings UI until it is dealt with
+export function WarnAboutDefaultPasswords(): Promise<string[]> {
+	return usersWithDefaultPassword()
+		.then((usernames) => {
+			defaultPasswordUsers = usernames
+			if (usernames.length > 0) {
+				logger(
+					`WARNING: ${usernames.map((u) => `'${u}'`).join(', ')} ${
+						usernames.length === 1 ? 'is' : 'are'
+					} still using the default password. Change it in Settings > Users.`,
+					'error',
+				)
+			}
+			return usernames
+		})
+		.catch((error) => {
+			logger(`Could not check for default passwords: ${error}`, 'error')
+			return []
+		})
 }
 
 function loadConfig() {
@@ -2604,6 +2696,7 @@ function TallyArbiter_Remove_Cloud_Client(obj: Manage): ManageResponse {
 function TallyArbiter_Add_User(obj: Manage): ManageResponse {
 	if (addUser(obj.user)) {
 		logger(`User Added: ${obj.user.username}`, 'info')
+		WarnAboutDefaultPasswords()
 		return { result: 'user-added-successfully' }
 	} else {
 		return { result: 'error', error: 'User already exists.' }
@@ -2613,6 +2706,7 @@ function TallyArbiter_Add_User(obj: Manage): ManageResponse {
 function TallyArbiter_Edit_User(obj: Manage): ManageResponse {
 	if (editUser(obj.user)) {
 		logger(`User Edited: ${obj.user.username}`, 'info')
+		WarnAboutDefaultPasswords()
 		return { result: 'user-edited-successfully' }
 	} else {
 		return { result: 'error', error: 'User not found.' }
@@ -2622,6 +2716,7 @@ function TallyArbiter_Edit_User(obj: Manage): ManageResponse {
 function TallyArbiter_Delete_User(obj: Manage): ManageResponse {
 	if (deleteUser(obj.user)) {
 		logger(`User Deleted: ${obj.user.username}`, 'info')
+		WarnAboutDefaultPasswords()
 		return { result: 'user-deleted-successfully' }
 	} else {
 		return { result: 'error', error: 'User not found.' }


### PR DESCRIPTION
## Summary

Tally Arbiter seeds an `admin` and a `producer` account with a documented default password (`12345`). On a fresh install those credentials stay valid until someone thinks to change them, and the Socket.IO API is gated on nothing more than a successful login.

**New configs** now seed both accounts with `mustChangePassword`. The flag travels in the JWT, so `requireRole` refuses every privileged socket action for such an account, and the UI routes it to a forced change-password page until it sets its own. Enforcement is server-side — the UI redirect is convenience, not the control.

A new `change_password` socket event sits deliberately outside `requireRole`, since it is the only thing a flagged account may do. It takes the username from the token rather than the client, requires the current password, enforces a minimum length of 8, and hands back a fresh token.

**Existing installs are not forced.** An upgrade that demanded a new password mid-production would be worse than the exposure it closes, so a startup warning plus a banner on the settings Users tab name the accounts still on the default instead.

## Notable detail

`editUser` now preserves a pending flag when an edit doesn't touch the password. Without that, an admin changing a flagged user's *roles* would silently clear the forced change while the password stayed `12345`.

## Verification

Run against an isolated app-data folder, so no real config was involved:

- Fresh run seeds both accounts flagged, passwords bcrypt-hashed.
- A **valid** admin token carrying the flag is refused for `users` over the socket — probed with a direct socket.io client, independent of the UI.
- Login redirects to the change-password page; navigating straight to `#/settings` bounces back to `#/change-password/settings`.
- Completing the change clears the flag on disk, rejects the old password, accepts the new one, issues a fresh token, and lands on the originally requested page.
- A simulated existing install on the same password logs the warning, shows the banner, and signs in unimpeded.
- `tsc --noEmit` clean; Angular build clean.

There is no test harness in this repo, so the above is manual verification rather than automated coverage. Adding one is worth doing separately.

## Follow-ups, not in this PR

- The docs still tell people to sign in with `admin`/`12345`. That is now true only for the length of one login on a new install.
- #1106 describes the default credentials as a known weakness being addressed separately; once this lands, that line should point at this behavior instead.
- Pre-existing bug found along the way: if the server restarts while you are on the Settings page, the client reconnects and re-sends its token but never re-emits `settings`, so the page hangs on the loading spinner until you navigate away and back. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)