### PR TITLE
fix: use the boolean notarize form electron-builder 26 expects

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,9 +115,7 @@
 			"gatekeeperAssess": true,
 			"entitlements": "entitlements.mac.plist",
 			"entitlementsInherit": "entitlements.mac.plist",
-			"notarize": {
-				"teamId": "R2PY2DC3A4"
-			}
+			"notarize": true
 		},
 		"win": {
 			"target": [


### PR DESCRIPTION
## Summary

The v3.3.0 desktop build ([run](https://github.com/josephdadams/TallyArbiter/actions/workflows/build-desktop.yml)) failed on **all three runners** with:

```
Invalid configuration object. electron-builder 26.15.3 has been initialized
using a configuration object that does not match the API schema.
 - configuration.mac.notarize should be a boolean
```

`build.mac.notarize` in `package.json` was the object form:

```json
"notarize": { "teamId": "R2PY2DC3A4" }
```

electron-builder 26 dropped that form — `notarize` is boolean-only now, and the team id comes from the environment instead. `build-desktop.yml` already exports `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD` and `APPLE_TEAM_ID`, which is one of the credential combinations the schema documents, so no workflow change is needed. `R2PY2DC3A4` also remains in `mac.extendInfo.electronTeamId`, so dropping it here loses nothing.

Config validation runs before any per-platform work, which is why the Windows and Linux jobs failed too despite having nothing to do with notarization.

## Verification

Validated the whole `build` section against `scheme.json` in the installed `app-builder-lib` (electron-builder 26.8.1):

- old object form → invalid, `/mac/notarize must be boolean` — the same error CI reported
- new boolean form → valid, no other violations anywhere in `build`

I did not run a signed desktop build, since that needs the Apple certificate and notarization secrets. The failure was pure schema validation and reproduces locally, but the first real proof will be the next tag.

## Note

This is pre-existing, not introduced by 3.3.0 — the same config would have failed under electron-builder 26 whenever it was bumped. Worth checking whether v3.2.0's desktop artifacts actually published, since they may have been missing for a while.

The v3.3.0 release, tag, and notes are live; the listener-client pipelines succeeded. NPM publishing failed separately and needs a trusted publisher registered for the package on npmjs.com — nothing to fix in the repo for that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)