### PR TITLE
fix: run the npm publish in the environment npm's trust policy names

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,6 +19,14 @@ jobs:
     name: Build and Publish to NPM
     runs-on: ubuntu-latest
 
+    # The trusted publisher registered for `tallyarbiter` on npmjs.com names this
+    # environment, so npm expects an `environment` claim in the OIDC token. Without
+    # this key the token carries no such claim, the subject does not match the trust
+    # policy, and the publish is rejected as an anonymous PUT — which the registry
+    # reports as a 404 rather than a 403, so that it does not reveal whether a
+    # package exists. Keep this in step with the Environment name field on npm.
+    environment: tallyarbiter
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

The v3.3.0 publish failed with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/tallyarbiter
```

That reads like a missing package, but it is how the registry reports an **unauthorized** publish — it withholds 403 so the response can't be used to probe which packages exist.

The trusted publisher on npmjs.com is registered correctly: right org, repository, workflow filename, and `npm publish` allowed. It also names an **Environment**, `tallyarbiter`, which makes npm expect a matching `environment` claim in the OIDC token. The publish job never declared one, so the token was minted without it, the subject didn't match the trust policy, and the publish arrived unauthenticated.

This declares the environment on the job — one key, plus a comment recording why it has to stay in step with the npm side.

## Why this is safe

The `tallyarbiter` environment already exists on the repository with:

- no protection rules → no approval gate, the job won't sit waiting for a reviewer
- no deployment branch policy → tag refs aren't restricted, which matters because this workflow runs against `v*` tags rather than a branch

Verified via the environments API before making the change.

## Verification

- `npm.yml` parses, and the publish job resolves `environment: tallyarbiter` with `permissions.id-token: write` still in place
- Prettier clean

The real proof is a publish attempt. Once this is on `master`:

```bash
gh workflow run npm.yml -f tag=v3.3.0
```

`3.3.0` was never accepted by the registry — `latest` is still `3.2.0` — so the version isn't burned and this can be retried against the existing tag.

## Note

The alternative fix is clearing the Environment name field on npmjs.com, which would let the current workflow authenticate as-is. Declaring it here is the better option: npm's own guidance describes that field as a way to keep publish rights scoped, and it's clearly deliberate, so the workflow should match the intent rather than the intent be relaxed to match the workflow.

Related: #1108 fixes the separate electron-builder failure from the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)