### PR TITLE
fix: upload desktop artifacts to the published release, not a draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,10 @@
 			"output": "./release/"
 		},
 		"publish": [
-			"github"
+			{
+				"provider": "github",
+				"releaseType": "release"
+			}
 		],
 		"extraResources": [
 			"build/**"


### PR DESCRIPTION
## Summary

After #1108 the v3.3.0 desktop build succeeded on all three runners — macOS genuinely notarized and stapled, Windows signed — and then threw away everything it produced:

```
• GitHub release not created  reason=existing type not compatible with publishing type
  tag=v3.3.0 version=3.3.0 existingType=release publishingType=draft
• skipped publishing  file=tallyarbiter-v3.3.0-mac-arm64.dmg   reason=...
• skipped publishing  file=tallyarbiter-v3.3.0-win-x64.exe     reason=...
• skipped publishing  file=latest-mac.yml                      reason=...
```

`build.publish` was the shorthand `["github"]`, and electron-builder's GitHub publisher **defaults `releaseType` to `draft`**. Finding an already-published release for the tag, it declined to upload rather than write into something it hadn't created.

That default assumes electron-builder owns the release lifecycle: you tag, it opens a draft, you add notes and publish. Publishing the release first inverts that, so the release type needs stating explicitly.

```json
"publish": [{ "provider": "github", "releaseType": "release" }]
```

## Why this matters beyond the download links

The skipped files included `latest.yml` and `latest-mac.yml` — the electron-updater manifests. Without them, existing desktop installs are never offered the update, even if the binaries were attached to the release by hand. So this is an auto-update fix as much as a packaging one.

## Verification

Validated `build` against `scheme.json` in the installed `app-builder-lib` (26.8.1):

- `releaseType: "release"` → valid, no other violations
- out-of-enum value → rejected with `/publish/0/releaseType must be equal to one of the allowed values`, so the check isn't passing vacuously

Schema allows `draft | prerelease | release`, default `draft`.

As with #1108, the real proof is a tagged run — a signed and notarized build can't be reproduced locally without the Apple and Windows signing credentials.

## Likely retroactive

v3.2.0's release has no desktop artifacts either, and the same shorthand config would have behaved identically. This has probably been silently dropping desktop builds for a while, hidden because the job still exits 0 — electron-builder treats a skipped publish as success.

Follows #1108 and #1109 from the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)