### PR TITLE
fix: let the desktop build attach assets to an already-published release

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -63,3 +63,12 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # electron-builder refuses to attach assets to a release published more
+          # than two hours ago, on the assumption that it opened the release itself
+          # and is finishing its own run. Tally Arbiter publishes the release first
+          # and builds afterwards, so that window is measured against a release that
+          # already existed, and any re-run — after a build fix, or to replace a
+          # missing artifact — is silently skipped while the job still exits 0.
+          # That is how the v3.2.0 and v3.3.0 desktop artifacts went missing without
+          # anything going red. See electron-publish/out/gitHubPublisher.js.
+          EP_GH_IGNORE_TIME: true


### PR DESCRIPTION
## Summary

With the release type corrected in #1110 the upload got one step further — it reached `uploading file=tallyarbiter-v3.3.0-mac-arm64.dmg provider=github` — and then stopped again:

```
• GitHub release not created  reason=existing release published more than 2 hours ago
  tag=v3.3.0 version=3.3.0 date=Tue Jul 28 2026 14:42:51 GMT+0000
```

`electron-publish` refuses to touch a release published more than two hours ago, on the assumption that it opened the release itself and is finishing its own run. Tally Arbiter publishes the release first and builds afterwards, so that window is measured against a release that already existed. Any re-run — after a build fix, or to replace a missing artifact — falls outside it.

The switch the publisher checks for exactly this is `EP_GH_IGNORE_TIME`, at [`electron-publish/out/gitHubPublisher.js:88`](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/gitHubPublisher.ts):

```js
if (!isEnvTrue(process.env.EP_GH_IGNORE_TIME) && publishedAt != null
    && Date.now() - publishedAt > 2 * 3600 * 1000) {
```

## The real defect is the silent success

The skip doesn't fail the job. electron-builder logs it and exits 0, so the workflow goes green with nothing attached. That is why v3.2.0's desktop artifacts are missing as well, with nothing red anywhere to indicate it. This makes uploads depend on the build succeeding rather than on how recently the release was cut.

## The trade-off, stated plainly

The guard exists so a stray build can't overwrite assets on an old release. Because this workflow triggers on `push: tags: v*.*.*`, re-pushing an old version tag will now **replace** that release's binaries instead of skipping them. That's the cost of making re-runs work at all, and it's the deliberate choice here.

## Verification

- `build-desktop.yml` parses; the `Build and Release` step resolves `EP_GH_IGNORE_TIME`, with the Apple credential vars intact
- `builder-util`'s `isEnvTrue('true')` returns `true`, confirming the string Actions passes for a YAML boolean satisfies the check
- Prettier clean

The build itself is already proven: both prior runs notarized, stapled and signed successfully on all three platforms. Only the upload was blocked.

Third and final fix in this chain — follows #1108 (`mac.notarize` schema), #1110 (`releaseType`), and #1109 (npm OIDC environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)