### PR TITLE
fix: correct swapped red/green in M5Atom listener colour constants

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -90,16 +90,19 @@ int actualPriority = 0;
 long colorNumber = 0;
 
 // default color values
+// NOTE: these words are in GRB byte order (0xGGRRBB), not RGB, because the
+// Atom Matrix LED driver expects GRB (see the conversion in evaluateMode()).
+// Any new colour added here must be written GRB or it will render wrong.
 int RGB_COLOR_WHITE = 0xffffff;
 int RGB_COLOR_DIMWHITE = 0x555555;
 int RGB_COLOR_WARMWHITE = 0xFFEBC8;
 int RGB_COLOR_DIMWARMWHITE = 0x877D5F;
 int RGB_COLOR_BLACK = 0x000000;
-int RGB_COLOR_RED = 0xff0000;
+int RGB_COLOR_RED = 0x00ff00;
 int RGB_COLOR_ORANGE = 0xa5ff00;
 int RGB_COLOR_YELLOW = 0xffff00;
 int RGB_COLOR_DIMYELLOW = 0x555500;
-int RGB_COLOR_GREEN = 0x008800; // toning this down as the green is way brighter than the other colours
+int RGB_COLOR_GREEN = 0x880000; // toning this down as the green is way brighter than the other colours
 int RGB_COLOR_BLUE = 0x0000ff;
 int RGB_COLOR_PURPLE = 0x008080;
 


### PR DESCRIPTION
Fixes #361.

## Root cause

The Atom Matrix LED driver (`M5.dis.drawpix`) expects colour words in **GRB** byte order. The sketch already knows this — `evaluateMode()` explicitly converts the server-supplied tally colour with `(g << 16) | (r << 8) | b` and carries a comment saying so.

The hard-coded `RGB_COLOR_*` constants were never converted, and they are mutually inconsistent. Read as GRB:

| Constant | Value | Renders as |
|---|---|---|
| `ORANGE` | `0xa5ff00` | orange ✅ (already GRB) |
| `YELLOW` | `0xffff00` | yellow ✅ (symmetric) |
| `PURPLE` | `0x008080` | purple ✅ (already GRB) |
| `RED` | `0xff0000` | **green** ❌ (written as RGB) |
| `GREEN` | `0x008800` | **red** ❌ (written as RGB) |

So `badcolor` (built from RED) displayed green and `readycolor` (built from GREEN) displayed red — the swap reported in the issue.

## Change

Two constants, plus a comment recording that the block is GRB so it does not regress:

- `RGB_COLOR_RED`: `0xff0000` → `0x00ff00`
- `RGB_COLOR_GREEN`: `0x008800` → `0x880000` (keeps the `0x88` magnitude so the existing "toning this down" comment stays accurate)

## Deliberately left alone

- `WHITE`, `DIMWHITE`, `BLACK`, `YELLOW`, `DIMYELLOW` — order-invariant (R and G bytes equal).
- `BLUE` `0x0000ff` — blue is the low byte in both orderings.
- `WARMWHITE` / `DIMWARMWHITE` — genuinely ambiguous; both readings give a plausible off-white, so the intended order cannot be recovered from the value.
- `M5.dis.drawpix(0, 0xf00000)` in `setup()` — renders green in GRB and was probably typed as RGB red, but it lights one pixel for ~50 ms and is then blanked by `drawNumber(icons[0], alloffcolor)` three lines later. No user-visible effect.

## Verification

Arduino firmware, so no local toolchain — this was verified by reading, not compiling. Worth a flash test on real hardware before release.

## Note

The constants are still *named* `RGB_COLOR_*` while holding GRB values, which is what invited the bug. Renaming to `GRB_COLOR_*` touches ~15 call sites so it was kept out of this minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
