### PR TITLE
fix: build M5StickC-Plus and Plus2 firmware, and repair board auto-detection

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -46,6 +46,43 @@ jobs:
               - name: MultiButton
               - name: Arduino_JSON
 
+          # Same sketch as M5StickC: it compiles for whichever of the three
+          # sticks the board defines say, so each variant needs its own build.
+          # Flashing the plain StickC binary to a Plus/Plus2 drives the wrong
+          # display and leaves the screen black.
+          - name: M5StickC-Plus
+            artifact: M5StickC-Plus
+            platform_name: esp32:esp32
+            platform_url: https://dl.espressif.com/dl/package_esp32_index.json
+            fqbn: esp32:esp32:m5stack_stickc_plus
+            options: ''
+            sketch: listener_clients/m5stickc-listener
+            libraries: |
+              - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
+              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
+              - name: WebSockets
+              - name: WiFiManager
+              - name: MultiButton
+              - name: Arduino_JSON
+
+          # The Plus2 build needs M5StickCPlus2 on top of the libraries the other
+          # two sticks use; it pulls in M5Unified/M5GFX itself.
+          - name: M5StickC-Plus2
+            artifact: M5StickC-Plus2
+            platform_name: esp32:esp32
+            platform_url: https://dl.espressif.com/dl/package_esp32_index.json
+            fqbn: esp32:esp32:m5stack_stickc_plus2
+            options: ''
+            sketch: listener_clients/m5stickc-listener
+            libraries: |
+              - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
+              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
+              - name: M5StickCPlus2
+              - name: WebSockets
+              - name: WiFiManager
+              - name: MultiButton
+              - name: Arduino_JSON
+
           # M5StickS3 is not in the espressif core; it only ships in the M5Stack
           # platform, from 3.3.8 onwards. The board has 8 MB of flash but its
           # default scheme is the 4 MB layout, leaving only 1.25 MB for the app.

--- a/listener_clients/m5stickc-listener/README.md
+++ b/listener_clients/m5stickc-listener/README.md
@@ -20,7 +20,7 @@ https://www.adafruit.com/product/4290 (Shipped from USA)
 1. Download an ESP flasher.
    You can use [esphome-flasher](https://github.com/esphome/esphome-flasher). If you want to use it, go to the [Github page](https://github.com/esphome/esphome-flasher) and download the latest release.
 2. Go to https://github.com/josephdadams/TallyArbiter/actions/workflows/build-listener-clients.yaml and click on the first element in the list.
-   From here, scroll down to the _"Artifacts"_ section and click on _"TallyArbiter-Listener-M5StickC"_.
+   From here, scroll down to the _"Artifacts"_ section and click on the artifact for your board: _"TallyArbiter-Listener-M5StickC"_, _"TallyArbiter-Listener-M5StickC-Plus"_ or _"TallyArbiter-Listener-M5StickC-Plus2"_.
    Un-zip the downloaded archive.
 3. Plug your board into the computer.
 4. Open the ESP flashed that you downloaded.
@@ -28,7 +28,7 @@ https://www.adafruit.com/product/4290 (Shipped from USA)
    You should select the file that ends in **.ino.bin**, not the file that ends in _.ino.elf_ or _.ino.partitions.bin_.
 5. Flash the firmware on your board _(clicking "Flash ESP" in esphome-flasher)_.
 
-**NB:** The built version onf GitHub is only for **M5StickC**.
+**NB:** The built versions on GitHub are published separately for **M5StickC**, **M5StickC-Plus** and **M5StickC-Plus2**. Each binary only works on the board it was built for, so make sure you flash the one that matches your device — a binary built for another variant drives the wrong display and leaves the screen black.
 
 Done! Now your board is running the latest listener client firmware version. Go to the _"Setup your device"_ sections to connect the board to the Tally Arbiter server.
 

--- a/listener_clients/m5stickc-listener/m5stickc-listener.ino
+++ b/listener_clients/m5stickc-listener/m5stickc-listener.ino
@@ -3,19 +3,21 @@
 //
 // Board defines used by Arduino IDE as preprocessor flags when selecting boards
 // Boards > M5Stack Arduino > M5StickC / M5StickCPlus / M5StickCPlus2
-// M5StickC        ARDUINO_m5stack_stickc
-// M5StickC-Plus   ARDUINO_m5stack_stickc_plus
-// M5StickC-Plus2  ARDUINO_m5stack_stickc_plus2
+// The cores define ARDUINO_<build.board>, which is upper case in the current
+// esp32/M5Stack cores; the lower case spellings are kept for older cores.
+// M5StickC        ARDUINO_M5STACK_STICKC       / ARDUINO_m5stack_stickc
+// M5StickC-Plus   ARDUINO_M5STACK_STICKC_PLUS  / ARDUINO_m5stack_stickc_plus
+// M5StickC-Plus2  ARDUINO_M5STACK_STICKC_PLUS2 / ARDUINO_m5stack_stickc_plus2
 //
-#if defined(ARDUINO_m5stack_stickc)
+#if defined(ARDUINO_M5STACK_STICKC) || defined(ARDUINO_m5stack_stickc)
 #define STICK_C
 #endif
 
-#if defined(ARDUINO_m5stack_stickc_plus)
+#if defined(ARDUINO_M5STACK_STICKC_PLUS) || defined(ARDUINO_m5stack_stickc_plus)
 #define STICK_C_PLUS
 #endif
 
-#if defined(ARDUINO_m5stack_stickc_plus2)
+#if defined(ARDUINO_M5STACK_STICKC_PLUS2) || defined(ARDUINO_m5stack_stickc_plus2)
 #define STICK_C_PLUS2
 #endif
 
@@ -31,8 +33,8 @@
 //#define STICK_C_PLUS
 //#define STICK_C_PLUS2
 
-// The default is M5StickC if nothing is specified. This is also the only
-// supported board type in the github builds.
+// The default is M5StickC if nothing is specified. The github builds publish a
+// separate binary for each of the three board types.
 #if !defined(STICK_C) && !defined(STICK_C_PLUS) && !defined(STICK_C_PLUS2)
 #define STICK_C
 #endif


### PR DESCRIPTION
Fixes #850.

## Root cause — two separate problems

**1. CI only ever built one variant.** The matrix had a single `M5StickC` entry (`esp32:esp32:m5stack_stickc`). A user who downloaded the prebuilt artifact and flashed it to a Plus2 got the plain StickC build, which drives the wrong display and backlight — hence the black screen.

**2. The sketch's board auto-detection never worked at all.** This is the part that makes the first problem worse than it looks. `m5stickc-listener.ino` tested for `ARDUINO_m5stack_stickc_plus2` (lower case), but both the espressif and M5Stack cores emit `-DARDUINO_{build.board}` from `platform.txt`, and `boards.txt` sets `build.board=M5STACK_STICKC_PLUS2` — **upper case**. Macro names are case-sensitive, so detection always fell through to the `#if !defined(...)` StickC default.

That means anyone who selected M5StickC-Plus2 in the Arduino IDE and built **from source** also got StickC code, unless they manually uncommented `#define STICK_C_PLUS2`. Adding matrix entries alone would have produced three byte-identical StickC binaries.

## Changes

- Two new matrix entries: `M5StickC-Plus` (`esp32:esp32:m5stack_stickc_plus`) and `M5StickC-Plus2` (`esp32:esp32:m5stack_stickc_plus2`), mirroring the existing StickC entry. Plus2 also pulls in the `M5StickCPlus2` library.
- Board detection now accepts both the upper- and lower-case macro spellings, so it works regardless of core convention.
- README updated to name all three artifacts and explain that a mismatched binary is what causes the black screen; also fixes the `onf` typo.
- Removed the now-false "only supported board type in the github builds" comment in the `.ino`.

## FQBN verification

Confirmed rather than assumed. The workflow's pinned `platform_url` is a stale index listing only esp32 1.0.0–1.0.6, but the core actually installed comes from arduino-cli's default index, which carries esp32 up to 3.3.9 — which is why the existing `m5stack_stickc` (a 3.x-only board id) compiles today. In esp32 3.3.9 `boards.txt` all three ids exist. No M5Stack platform index needed.

Partition defaults are adequate: Plus is `huge_app` (3 MB app vs a ~1.35 MB sketch), Plus2 is `default_8MB` (3.19 MB app, retains the second OTA partition this sketch's ArduinoOTA needs).

## Verification

YAML parses; all 11 matrix entries load and every `artifact` value is unique, so artifacts and release zips will not collide. No Arduino build was attempted locally — **the CI run on this PR is the real test**, and the three binaries should differ in size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
