### PR TITLE
fix: correct device tally arbitration and stale source tally cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1321,7 +1321,9 @@ function getDeviceStates(deviceId?: string): DeviceState[] {
 							num++
 						}
 					}
-					if (num === deviceSources.length) {
+					// same guard as UpdateDeviceState: no device sources means not active,
+					// otherwise num === deviceSources.length is trivially true at 0
+					if (deviceSources.length > 0 && num === deviceSources.length) {
 						return {
 							busId: b.id,
 							deviceId: d.id,
@@ -1514,7 +1516,10 @@ function UpdateDeviceState(deviceId: string) {
 				}
 			}
 
-			if (num === deviceSources.length) {
+			// deviceSources.length must be checked explicitly: with no device sources at all
+			// num and deviceSources.length are both 0, which would otherwise report the device
+			// as active on every linked bus. A device with no sources is inactive everywhere.
+			if (deviceSources.length > 0 && num === deviceSources.length) {
 				//
 				currentDeviceTallyData[device.id].push(bus.id)
 				if (!previousBusses.includes(bus.id)) {
@@ -1527,10 +1532,15 @@ function UpdateDeviceState(deviceId: string) {
 			}
 		} else {
 			// bus is unlinked – active if ANY device source is on this bus (OR logic)
-			const anySourceInBus = deviceSources.some((deviceSource) => {
-				const data = SourceClients[deviceSource.sourceId]?.tally?.value || []
-				return !!data?.[deviceSource.address]?.includes(bus.id)
-			})
+			// Both branches must read currentSourceTallyData (keyed by device source id) so they
+			// share one source of truth. Reading SourceClients[...].tally.value instead is unsafe:
+			// sources that publish via sendIndividualTallyData() (TSL 3.1/5.0, SimplyLive) emit an
+			// object containing only the address that just changed, so every other address on that
+			// source reads as undefined and its devices would spuriously go inactive.
+			// An empty deviceSources array makes .some() false, which is the correct result here.
+			const anySourceInBus = deviceSources.some((deviceSource) =>
+				currentSourceTallyData?.[deviceSource.id]?.includes(bus.id),
+			)
 
 			if (anySourceInBus) {
 				currentDeviceTallyData[device.id].push(bus.id)
@@ -1760,9 +1770,15 @@ function processSourceTallyData(sourceId: string, tallyData: SourceTallyData) {
 		}
 	}
 
+	// Cache defensive copies of the bus arrays, never the arrays themselves. The incoming
+	// arrays are owned by the source object (TallyInput.addBusToAddress() pushes into them
+	// in place), so storing them directly would make the cached "previous" value the same
+	// array as the next "current" value. The areBussesEqual comparison above would then see
+	// identical arrays and silently drop the tally_data update for any pure-add transition.
+	// Also note the comparison must stay above this assignment.
 	currentSourceTallyData = {
 		...currentSourceTallyData,
-		...tallyData,
+		...Object.fromEntries(Object.entries(tallyData).map(([deviceSourceId, busses]) => [deviceSourceId, [...busses]])),
 	}
 
 	for (const device of devices) {
@@ -2410,7 +2426,10 @@ function TallyArbiter_Delete_Device_Source(obj: Manage): ManageResponse {
 		}
 	}
 
-	delete currentDeviceTallyData[deviceSourceId]
+	// currentSourceTallyData is keyed by device source id, so this is the cache the deleted
+	// device source has an entry in. (currentDeviceTallyData is keyed by device id and is
+	// rebuilt from scratch by UpdateDeviceState, so it needs no cleanup here.)
+	delete currentSourceTallyData[deviceSourceId]
 
 	let deviceName = ''
 	try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1737,6 +1737,10 @@ function initializeSource(source: Source): TallyInput {
 		)) {
 			deviceSource.address = newAddress
 		}
+		//no currentSourceTallyData work to do here: it is keyed by device source id, not address,
+		//and a rename doesn't change which physical input the device source points at. Re-seeding
+		//would in fact be wrong, since TallyInput.renameAddress() doesn't re-key its own tallyData,
+		//so the source has nothing under newAddress until it next emits.
 		UpdateSockets('device_sources')
 		SaveConfig()
 	})
@@ -2338,11 +2342,30 @@ function TallyArbiter_Delete_Device(obj: Manage): ManageResponse {
 	return { result: 'device-deleted-successfully' }
 }
 
+// currentSourceTallyData is only ever refreshed when a source emits, and initializeSource()
+// resolves addresses to device source ids at emission time, so a device source that is created
+// or re-pointed while its address is already live has no cache entry until the next emission.
+// Several source types only emit on change (TSL 3.1/5.0, SimplyLive), so that gap can last
+// indefinitely. Seed the entry from the source's current tally instead, and drop any stale entry
+// when there is nothing to seed from. Stored as a defensive copy for the same reason
+// processSourceTallyData copies: source objects mutate their own bus arrays in place.
+function SeedSourceTallyDataForDeviceSource(deviceSource: DeviceSource) {
+	const busses = SourceClients[deviceSource.sourceId]?.tally?.value?.[deviceSource.address]
+	if (Array.isArray(busses)) {
+		currentSourceTallyData[deviceSource.id] = [...busses]
+	} else {
+		//source isn't connected, or hasn't reported this address yet, so we know nothing about it
+		delete currentSourceTallyData[deviceSource.id]
+	}
+}
+
 function TallyArbiter_Add_Device_Source(obj: Manage): ManageResponse {
 	let deviceSourceObj = obj.device_source
 	let deviceId = deviceSourceObj.deviceId
 	deviceSourceObj.id = uuidv4()
 	device_sources.push(deviceSourceObj)
+
+	SeedSourceTallyDataForDeviceSource(deviceSourceObj)
 
 	let deviceName = ''
 	try {
@@ -2361,6 +2384,9 @@ function TallyArbiter_Add_Device_Source(obj: Manage): ManageResponse {
 	}
 
 	UpdateCloud('device_sources')
+
+	//recompute now so the device reflects the new source immediately instead of at the next emission
+	if (deviceId) UpdateDeviceState(deviceId)
 
 	logger(`Device Source Added: ${deviceName} - ${sourceName}`, 'info')
 
@@ -2383,6 +2409,9 @@ function TallyArbiter_Edit_Device_Source(obj: Manage): ManageResponse {
 			device_sources[i].rename = deviceSourceObj.rename
 			device_sources[i].reconnect_interval = deviceSourceObj.reconnect_interval
 			device_sources[i].max_reconnects = deviceSourceObj.max_reconnects
+			//the cached entry describes the OLD sourceId/address, so re-seed it from wherever
+			//this device source now points rather than leaving it reporting the previous input
+			SeedSourceTallyDataForDeviceSource(device_sources[i])
 		}
 	}
 
@@ -2403,6 +2432,9 @@ function TallyArbiter_Edit_Device_Source(obj: Manage): ManageResponse {
 	}
 
 	UpdateCloud('device_sources')
+
+	//recompute now so the device stops reporting the old address's state
+	if (deviceId) UpdateDeviceState(deviceId)
 
 	logger(`Device Source Edited: ${deviceName} - ${sourceName}`, 'info')
 
@@ -2448,6 +2480,9 @@ function TallyArbiter_Delete_Device_Source(obj: Manage): ManageResponse {
 	}
 
 	UpdateCloud('device_sources')
+
+	//recompute now so any action tied to the removed source is turned back off
+	if (deviceId) UpdateDeviceState(deviceId)
 
 	logger(`Device Source Deleted: ${deviceName} - ${sourceName}`, 'info')
 


### PR DESCRIPTION
Fixes three defects in device tally arbitration, plus a stale-cache regression the first pass introduced. No single issue tracks these — they were found while investigating #794 and #970 and may improve both, though neither is confirmed fixed.

## Defect 1 — a device with zero device sources reported every linked bus as ACTIVE

`UpdateDeviceState()` ended its linked-bus branch with `if (num === deviceSources.length)`. With no device sources both sides are `0`, so the condition was trivially true: the device was marked active on every linked bus and `RunAction(deviceId, bus.id, true)` fired. Now requires `deviceSources.length > 0`.

The structurally identical check in `getDeviceStates()` got the same guard. That one was behaviourally inert (both branches emit the same `DeviceState` when there are no sources) but is fixed so the two copies do not drift.

## Defect 2 — the two branches read different, sometimes-partial, data stores

- linked branch: `currentSourceTallyData[deviceSource.id]` — the cumulative cache.
- unlinked branch: `SourceClients[...].tally.value[deviceSource.address]` — a live read off the subject.

The live read is unsafe. TSL 3.1 UDP, TSL 5.0 UDP/TCP and SimplyLive publish via `sendIndividualTallyData()`, which emits an object containing **only the address that just changed**. Every other address on those sources reads `undefined`, so any device on them — for any bus not in `linkedBusses` — collapsed to inactive whenever some unrelated address updated, firing a spurious `RunAction(..., false)`.

Both branches now read `currentSourceTallyData`.

## Defect 3 — change detection defeated by object aliasing

`processSourceTallyData()` cached the bus arrays **by reference**, and `addBusToAddress()` mutates in place (`.push()`). So the cached "previous" value *was* the incoming "current" value, `areBussesEqual` hit its `if (a === b) return true` fast path, and the `tally_data` update to the settings UI was silently dropped for any pure-add transition (e.g. OBS `SceneItemEnableStateChanged`).

The cache now stores defensive copies. Fixed at the cache assignment — the single point where data is retained across updates — rather than patching each consumer, since `writeTallyDataFile` and `SendCloudSourceTallyData` serialize immediately and retain nothing.

## Second commit — regression fix

Defect 2 moved a correctness dependency from a live read onto cache population, and nothing populated the cache when a device source was created or re-pointed: `initializeSource()` resolves addresses to device source ids *at emission time*. So a device source added for an input already live on program read as inactive until that source next emitted — indefinitely, for the emit-on-change sources this fix is about.

- New `SeedSourceTallyDataForDeviceSource()` seeds (or clears) the cache entry from the source's current tally, called on add and edit. Seed-or-delete makes one helper correct for both: on add the delete is a no-op, on edit it removes the stale entry.
- `delete currentDeviceTallyData[deviceSourceId]` in the delete path was using a device **source** id against the device-keyed map, so it never matched. Now deletes from `currentSourceTallyData`.
- `UpdateDeviceState()` added to the add/edit/delete paths, which previously never recomputed. Verified no re-entrancy (`RunAction` only constructs and runs an output action) and no double-invocation; `TallyArbiter_Add_Device` already does this at the same point in the same flow.

**Known limitation:** for TSL/SimplyLive the seed usually cannot help, because `tally.value` is that partial object. No worse than before, but `TallyInput.tallyData` is `private` with no full-state accessor — adding one would close this properly.

**`renameAddress` deliberately not touched.** The cache is keyed by device source id, which a rename does not change. Re-seeding there would actively break it: `TallyInput.renameAddress()` never re-keys its own `tallyData`, so the source has nothing under the new address until it next emits. A comment records this.

## Verification

`npx tsc --noEmit` clean. No test suite exists. Reasoning was checked against every call site; **this is core arbitration logic and deserves a live smoke test before release** — particularly the add/edit/delete device-source flows, since those now fire actions where they previously did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
