### PR TITLE
fix: stop vMix duplicating addresses and parse its TCP stream by line

### DIFF
--- a/src/sources/VMix.ts
+++ b/src/sources/VMix.ts
@@ -10,12 +10,19 @@ import net from 'net'
 export class VMixSource extends TallyInput {
 	private client: any
 	private port = 8099 // Fixed vMix TCP port number
+	//TCP is a byte stream with no message boundaries, so a single vMix line can arrive split
+	//across several 'data' events and several lines can arrive coalesced in one event.
+	//Invariant: receiveBuffer only ever holds the trailing *incomplete* line; every complete
+	//(newline terminated) line is removed from it and processed exactly once.
+	private receiveBuffer = ''
 	constructor(source: Source) {
 		super(source)
 
 		this.client = new net.Socket()
 
 		this.client.on('connect', () => {
+			this.receiveBuffer = '' //a reconnect must not inherit a stale partial line
+
 			this.client.write('SUBSCRIBE TALLY\r\n')
 			this.client.write('SUBSCRIBE ACTS\r\n')
 
@@ -27,51 +34,21 @@ export class VMixSource extends TallyInput {
 
 		this.client.on('data', (data) => {
 			logger(`Source: ${source.name}  VMix data received.`, 'info-quiet')
-			data = data.toString().split(/\r?\n/)
 
-			const tallyData = data.filter((text) => text.startsWith('TALLY OK'))
+			this.receiveBuffer += data.toString()
 
-			// If received data contains TALLY information loop through the
-			// data and set preview and program based on received data.
-			if (tallyData.length > 0) {
-				logger(`Source: ${source.name}  VMix tally data received.`, 'info-quiet')
-				for (let j = 9; j < tallyData[0].length; j++) {
-					let address = j - 9 + 1
-					let value = tallyData[0].charAt(j)
+			//split off only the complete lines; the last element is either empty (the chunk
+			//ended on a newline) or the start of a line that will be continued by a later chunk
+			const lines = this.receiveBuffer.split(/\r?\n/)
+			this.receiveBuffer = lines.pop()
 
-					this.addAddress(`Input ${address}`, address.toString())
-					const busses = []
-					if (value === '2') {
-						busses.push('preview')
-					}
-					if (value === '1') {
-						busses.push('program')
-					}
-					this.setBussesForAddress(address.toString(), busses)
-				}
-				this.sendTallyData()
-			} else {
-				//we received some other command, so lets process it
-				if (data[0].indexOf('ACTS OK Recording ') > -1) {
-					this.setBussesForAddress('{{RECORDING}}', [])
-					if (data[0].indexOf('ACTS OK Recording 1') > -1) {
-						this.setBussesForAddress('{{RECORDING}}', ['program'])
-					}
-					this.sendTallyData()
-				}
-
-				if (data[0].indexOf('ACTS OK Streaming ') > -1) {
-					this.setBussesForAddress('{{STREAMING}}', [])
-					if (data[0].indexOf('ACTS OK Streaming 1') > -1) {
-						this.setBussesForAddress('{{STREAMING}}', ['program'])
-						this.sendTallyData()
-					}
-					this.sendTallyData()
-				}
+			for (const line of lines) {
+				this.processLine(line.trim())
 			}
 		})
 
 		this.client.on('close', () => {
+			this.receiveBuffer = ''
 			this.connected.next(false)
 		})
 
@@ -80,6 +57,48 @@ export class VMixSource extends TallyInput {
 		})
 
 		this.connect()
+	}
+
+	/** Processes a single complete line received from vMix. */
+	private processLine(line: string): void {
+		if (!line) {
+			return
+		}
+
+		// If received data contains TALLY information loop through the
+		// data and set preview and program based on received data.
+		if (line.startsWith('TALLY OK')) {
+			logger(`Source: ${this.source.name}  VMix tally data received.`, 'info-quiet')
+			//the character at index 9 onwards is the state of input 1 onwards (inputs are 1-based)
+			for (let j = 9; j < line.length; j++) {
+				let address = j - 9 + 1
+				let value = line.charAt(j)
+
+				this.addAddress(`Input ${address}`, address.toString())
+				const busses = []
+				if (value === '2') {
+					busses.push('preview')
+				}
+				if (value === '1') {
+					busses.push('program')
+				}
+				this.setBussesForAddress(address.toString(), busses)
+			}
+			this.sendTallyData()
+		} else if (line.startsWith('ACTS OK Recording ')) {
+			this.setBussesForAddress('{{RECORDING}}', [])
+			if (line.startsWith('ACTS OK Recording 1')) {
+				this.setBussesForAddress('{{RECORDING}}', ['program'])
+			}
+			this.sendTallyData()
+		} else if (line.startsWith('ACTS OK Streaming ')) {
+			this.setBussesForAddress('{{STREAMING}}', [])
+			if (line.startsWith('ACTS OK Streaming 1')) {
+				this.setBussesForAddress('{{STREAMING}}', ['program'])
+			}
+			this.sendTallyData()
+		}
+		//any other line (SUBSCRIBE OK, VERSION, other ACTS events, ...) is not tally data, so ignore it
 	}
 
 	private connect(): void {

--- a/src/sources/_Source.ts
+++ b/src/sources/_Source.ts
@@ -104,6 +104,19 @@ export class TallyInput extends EventEmitter {
 	public reconnect(): void {}
 
 	protected addAddress(label: string, address: string) {
+		//the address is the unique key, so never add it twice: some source types (like vMix) call this
+		//for every incoming tally message, and duplicated entries would grow the list without bound,
+		//fill the settings UI with repeats and re-broadcast an ever larger array on every emission.
+		//only update the label if it actually changed, and never emit when nothing changed at all,
+		//because a no-op emission is what triggers the re-broadcast storm.
+		let addressObj = this.addresses.value.find((a) => a.address === address)
+		if (addressObj) {
+			if (addressObj.label !== label) {
+				this.addresses.next(this.addresses.value.map((a) => (a.address === address ? { label, address } : a)))
+			}
+			return
+		}
+
 		this.addresses.next(this.addresses.value.concat({ label, address }))
 	}
 


### PR DESCRIPTION
Fixes #756.

## Defect 1 — unbounded duplicate addresses

`VMix.ts` called `this.addAddress()` for every input inside the `TALLY OK` parsing loop, on **every incoming TALLY message** — and vMix pushes those continuously. `TallyInput.addAddress()` had no de-duplication at all; it just `concat`ed.

So the `addresses` array grew without bound, the settings UI filled with duplicates, and every emission re-broadcast an ever-larger array. That matches the reporter's screenshot and the "works for a minute or two, then goes back to NONE" description.

The guard went into `addAddress()` in the base class rather than only in vMix, so it protects every source type. It updates the label in place only if the label actually changed, and **never emits when nothing changed** — a no-op emission is what caused the re-broadcast storm.

## Defect 2 — TCP stream treated as message-framed

The `data` handler split on newlines and then only inspected `tallyData[0]` and `data[0]`. TCP has no message boundaries, so:

- a `TALLY OK ...` line split across two `data` events was mis-parsed — each character position maps to an input, so a truncated line silently zeroes the trailing inputs
- any `ACTS` line that was not the first line in the chunk was dropped entirely

Now buffers on the instance, splits out only complete lines, keeps the trailing partial for the next event, and dispatches every line by prefix. Buffer resets on connect and close so a reconnect does not inherit a stale partial. Also removes a duplicated `sendTallyData()` in the Streaming branch.

TALLY parsing semantics preserved verbatim: `j = 9`, `'1'` program, `'2'` preview, else off, 1-based inputs.

## Verification

A harness (not committed) transpiled the real `_Source.ts` and `VMix.ts` in memory with a fake socket and fed synthetic traffic. **23 assertions pass; 15 of them fail against the pre-fix code**, confirming both defects:

- `TALLY OK 0120` split as `TALLY OK 01` + `20\r\n` → inputs 3 and 4 never set. Byte-at-a-time delivery left *every* input unset.
- TALLY + two `ACTS` lines coalesced in one chunk → both ACTS lines dropped.
- 500 identical TALLY messages → **2002 address entries, 2000 emissions**. After: 6 entries, 4 emissions, and runtime-added vMix inputs are still picked up.

`npx tsc --noEmit` clean.

## Other sources that were leaking the same way

Found while auditing callers, **not fixed here** (the base-class guard masks the symptoms; the broken guards themselves are addressed in the OBS/Tricaster PR):

- **OBS** — `saveSceneList4()` guards with `this.scenes4.includes(scene)` against fresh objects, so the identity check is always false and every scene is re-added on every call. `addAudioInput()` v5 calls `addAddress` *before* its own `includes` check. The four `{{...}}` pseudo-addresses are re-added on every reconnect in both protocol versions.
- **NewTek Tricaster** — guard requires a match on both `sourceId` and `address`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
