### PR TITLE
fix: OSC action crashed when the Path field was left blank

### DIFF
--- a/src/actions/OSC.ts
+++ b/src/actions/OSC.ts
@@ -38,68 +38,95 @@ oscUDP.on('ready', function () {
 ])
 export class OSC extends Action {
 	public run(): void {
-		let data = []
+		try {
+			let data = []
 
-		const isNumeric = (string) => /^[+-]?\d+(\.\d+)?$/.test(string)
+			const isNumeric = (string) => /^[+-]?\d+(\.\d+)?$/.test(string)
 
-		if (this.action.data.args !== '') {
-			// Quote-aware tokenizer: a double-quoted span (which may contain
-			// spaces) is treated as a single argument; everything else is
-			// split on whitespace, matching the documented behavior that
-			// "Strings must be encapsulated by double quotes."
-			const tokens: { value: string; quoted: boolean }[] = []
-			const tokenRegex = /"([^"]*)"|(\S+)/g
-			let match: RegExpExecArray | null
+			// IP and Port are required; bail with something actionable rather than
+			// handing undefined to the osc library.
+			if (!(this.action.data.ip && this.action.data.port)) {
+				logger('Error in OSC Action. IP and Port must be given.', 'error')
+				return
+			}
 
-			while ((match = tokenRegex.exec(this.action.data.args)) !== null) {
-				if (match[1] !== undefined) {
-					tokens.push({ value: match[1], quoted: true })
-				} else {
-					tokens.push({ value: match[2], quoted: false })
+			// Truthiness check, not `!== ''`. The UI omits fields the user never
+			// filled in from `data` entirely, so a blank Arguments box arrives as
+			// `undefined` rather than `''`. With `!== ''` that was true, and the
+			// tokenizer then coerced `undefined` into the literal string
+			// "undefined" and sent it as a bogus OSC string argument.
+			if (this.action.data.args) {
+				// Quote-aware tokenizer: a double-quoted span (which may contain
+				// spaces) is treated as a single argument; everything else is
+				// split on whitespace, matching the documented behavior that
+				// "Strings must be encapsulated by double quotes."
+				const tokens: { value: string; quoted: boolean }[] = []
+				const tokenRegex = /"([^"]*)"|(\S+)/g
+				let match: RegExpExecArray | null
+
+				while ((match = tokenRegex.exec(this.action.data.args)) !== null) {
+					if (match[1] !== undefined) {
+						tokens.push({ value: match[1], quoted: true })
+					} else {
+						tokens.push({ value: match[2], quoted: false })
+					}
+				}
+
+				let arg: any
+
+				for (let i = 0; i < tokens.length; i++) {
+					const { value, quoted } = tokens[i]
+					// Check if OSC-string. A quoted argument is always treated as a
+					// string, even if its contents look numeric, since quoting is
+					// how the user explicitly opts into string type.
+					if (quoted || !isNumeric(value)) {
+						arg = {
+							type: 's',
+							value: value.replace(/"/g, '').replace(/'/g, ''),
+						}
+						data.push(arg)
+					}
+					// Check if float32
+					else if (value.toString().indexOf('.') > -1) {
+						arg = {
+							type: 'f',
+							value: parseFloat(value),
+						}
+						data.push(arg)
+					}
+					// No check, assume int32
+					else {
+						arg = {
+							type: 'i',
+							value: parseInt(value),
+						}
+						data.push(arg)
+					}
 				}
 			}
 
-			let arg: any
+			// Truthiness check, not `== ''`, for the same reason: a blank Path box
+			// arrives as `undefined`, and `undefined == ''` is `false`, so the
+			// fallback never ran and an undefined OSC address was passed to the
+			// encoder, which threw inside the osc library (issue #633).
+			// Defaulted into a local so the user's saved config is left untouched.
+			let address = this.action.data.path || '/'
 
-			for (let i = 0; i < tokens.length; i++) {
-				const { value, quoted } = tokens[i]
-				// Check if OSC-string. A quoted argument is always treated as a
-				// string, even if its contents look numeric, since quoting is
-				// how the user explicitly opts into string type.
-				if (quoted || !isNumeric(value)) {
-					arg = {
-						type: 's',
-						value: value.replace(/"/g, '').replace(/'/g, ''),
-					}
-					data.push(arg)
-				}
-				// Check if float32
-				else if (value.toString().indexOf('.') > -1) {
-					arg = {
-						type: 'f',
-						value: parseFloat(value),
-					}
-					data.push(arg)
-				}
-				// No check, assume int32
-				else {
-					arg = {
-						type: 'i',
-						value: parseInt(value),
-					}
-					data.push(arg)
-				}
+			// An OSC address must begin with '/'. The Path field has no validation
+			// in the UI, so a forgotten leading slash is added here rather than
+			// letting it fail to encode exactly like a missing path did.
+			if (!address.startsWith('/')) {
+				logger(`OSC Action path "${address}" is missing a leading slash. Sending "/${address}" instead.`, 'info-quiet')
+				address = `/${address}`
 			}
-		}
 
-		if (this.action.data.path == '') {
-			this.action.data.path = '/'
+			logger(
+				`Sending OSC Message: ${this.action.data.ip}:${this.action.data.port} ${address} ${this.action.data.args || ''}`,
+				'info',
+			)
+			oscUDP.send({ address, args: data }, this.action.data.ip, this.action.data.port)
+		} catch (error) {
+			logger(`An error occured sending the OSC Message: ${error}`, 'error')
 		}
-
-		logger(
-			`Sending OSC Message: ${this.action.data.ip}:${this.action.data.port} ${this.action.data.path} ${this.action.data.args}`,
-			'info',
-		)
-		oscUDP.send({ address: this.action.data.path, args: data }, this.action.data.ip, this.action.data.port)
 	}
 }


### PR DESCRIPTION
Fixes #633.

## Root cause

The reported trace:

```
TypeError: Cannot read properties of undefined (reading 'buffer')
    at osc.nativeBuffer (node_modules/osc/src/osc.js:126:33)
    at p.send (node_modules/osc/src/osc-transports.js:57:23)
    at OSC.run (dist/actions/OSC.js:88:16)
    at RunAction -> UpdateDeviceState -> processSourceTallyData -> rxjs Subscriber
```

`OSC.ts` guarded with `if (this.action.data.path == '')`. In JavaScript `undefined == ''` is **`false`**, so a *missing* Path field never hit the `'/'` fallback. The UI is what makes it missing rather than empty: `settings.component.ts` initializes a new action with `data: {}`, and the Path input has no `required`, pattern or any other validation, so an untouched box never creates the key.

`oscUDP.send({ address: undefined, ... })` then reached the osc library, `encodeOSC` rejected the address-less packet and returned `undefined`, and `osc-transports.js:57` passed that straight into `nativeBuffer`.

The same class of bug affected `args`: `undefined !== ''` is true, so the tokenizer ran `tokenRegex.exec(undefined)`, the regex coerced it to the literal string `"undefined"`, and a bogus string argument was sent.

## Reproduced before fixing

A scratch harness loaded the real `OSC.ts` and wrapped `UDPPort.prototype.send`:

```
data = {"ip":"127.0.0.1","port":"9000","args":"1"}
-> oscUDP.send({"args":[{"type":"i","value":1}]}, "127.0.0.1", "9000")
RESULT: THREW -> TypeError: Cannot read properties of undefined (reading 'buffer')
```

That is the reported error verbatim. It also surfaced **a second route to the same crash**: a path *without a leading slash* (`tally` instead of `/tally`) fails `encodeOSC` identically.

## Changes

- Truthiness guards on both `path` and `args`, with comments naming the `undefined == ''` trap.
- `'/'` defaulted into a **local** variable — the old code assigned back into `this.action.data`, writing a value the user never entered into the in-memory device action.
- `ip`/`port` validated up front in the `if (!(ip && port))` → `logger` → `return` style already used by `TSL.ts`.
- Whole body wrapped in try/catch like `UDP.ts`. This matters: the trace shows the throw escaping through `RunAction` → `UpdateDeviceState` → the RxJS subscriber, so one malformed action could disrupt tally processing for unrelated devices.
- A path missing its leading slash gets one prepended rather than being rejected — since the UI applies no validation, rejecting server-side would leave a saved config silently dead with only a log line. Logged at `info-quiet` because it fires on every tally change.

The quote-aware tokenizer is untouched.

## Port readiness — checked, no guard needed

`run()` can fire before the `'ready'` event, but that is not a route to this failure: `UDPPort.open()` assigns `this.socket` synchronously before `bind()` resolves, and the crash happens in `encodeOSC` before `sendRaw` is entered.

## Verification

Five cases pass with no throw: missing path → `address: "/"`; missing args → `args: []`; missing ip/port → logs and returns; `"tally"` → `"/tally"`; and the fully-populated control case produces a **byte-identical packet to before** (`[i 1, f 2.5, s "hello world"]`), confirming the tokenizer did not regress.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
