### PR TITLE
feat: add hex byte payload encoding to the Generic UDP action

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -1149,6 +1149,7 @@
 									{{ option.label }}
 								</option>
 							</select>
+							<small class="form-text" *ngIf="field.help">{{ field.help }}</small>
 						</div>
 						<div class="mb-3 form-check" *ngSwitchCase="'bool'">
 							<input

--- a/docs/docs/usage/sections/devices.md
+++ b/docs/docs/usage/sections/devices.md
@@ -41,4 +41,6 @@ Device Actions can only be run once when the device state enters or exits that b
 
 TSL 3.1 UDP/TCP supports Tally 1, 2, 3 and 4. The protocol specification does not specify what the tallies are used for, it is device/implementation specific. Some use Tally 1 for program some use it for preview. Connect the specfic bus to wanted tally.
 
+The Generic UDP action can send either text or raw bytes, selected with the "Payload Encoding" field. `Text` is the default and sends the UDP String as characters, optionally followed by the chosen End Character. `Hex bytes` reads the UDP String as a list of hex byte pairs, which is what you need for binary protocols such as VISCA over IP. For example, `81 01 7E 01 0A 00 02 FF` turns on tally lamp 1 on a Sony camera. Spaces, commas, colons, dashes and an optional `0x` prefix are all accepted (`0x81,0x01` and `8101` work too), and the End Character is ignored because a binary packet already carries its own terminator. If the value is not a valid sequence of hex byte pairs, nothing is sent and an error is logged.
+
 Ember+ device IP, port and Ember tree path must be specified in the action. Device path may be retrieved using Ember+ Viewer (freely available under BSL-1.0 license). More information on Ember+ may be found at github.com/Lawo/ember-plus. Ember+ vGPIO tally tested on Lawo MCX 6.4 and 10.8.

--- a/src/actions/UDP.ts
+++ b/src/actions/UDP.ts
@@ -8,6 +8,17 @@ import dgram from 'dgram'
 	{ fieldName: 'port', fieldLabel: 'Port', fieldType: 'port' },
 	{ fieldName: 'string', fieldLabel: 'UDP String', fieldType: 'text' },
 	{
+		fieldName: 'encoding',
+		fieldLabel: 'Payload Encoding',
+		fieldType: 'dropdown',
+		options: [
+			{ id: 'text', label: 'Text' },
+			{ id: 'hex', label: 'Hex bytes' },
+		],
+		optional: true,
+		help: 'Text (the default) sends the UDP String as latin1 characters. Hex bytes reads the UDP String as a list of hex byte pairs, e.g. "81 01 7E 01 0A 00 02 FF" for VISCA; spaces, commas, colons, dashes and an optional 0x prefix are allowed. The End Character is ignored for hex payloads.',
+	},
+	{
 		fieldName: 'end',
 		fieldLabel: 'End Character',
 		fieldType: 'dropdown',
@@ -18,6 +29,7 @@ import dgram from 'dgram'
 			{ id: '\r', label: 'CR - \\r' },
 			{ id: '\x00', label: 'NULL - \\x00' },
 		],
+		help: 'Only applies when Payload Encoding is Text. Hex byte payloads are sent exactly as typed, with nothing appended.',
 	},
 	{
 		fieldName: 'type',
@@ -31,9 +43,67 @@ import dgram from 'dgram'
 	},
 ])
 export class UDP extends Action {
+	/**
+	 * Parses a user-typed hex byte string into a Buffer.
+	 *
+	 * Accepts the shapes people actually type when transcribing bytes out of a
+	 * protocol datasheet: `81 01 7E 01 0A 00 02 FF`, `8101 7E01`, `81,01,7E,FF`,
+	 * `0x81 0x01`, and any mix of upper/lower case. Whitespace and the common
+	 * byte separators (comma, colon, dash) are stripped, a leading `0x` is
+	 * dropped from each token, and the remaining digits must be valid hex and
+	 * even in number.
+	 *
+	 * Returns null for malformed input so the caller can log and bail out
+	 * instead of transmitting a truncated or wrong packet.
+	 */
+	private parseHexPayload(value: string): Buffer | null {
+		if (typeof value !== 'string') return null
+
+		const hexDigits = value
+			.split(/[\s,:\-]+/)
+			.filter((token) => token.length > 0)
+			.map((token) => token.replace(/^0x/i, ''))
+			.join('')
+
+		if (hexDigits.length === 0) return null
+		if (hexDigits.length % 2 !== 0) return null
+		if (!/^[0-9a-fA-F]+$/.test(hexDigits)) return null
+
+		return Buffer.from(hexDigits, 'hex')
+	}
+
 	public run(): void {
 		try {
-			let sendBuf = Buffer.from(unescape(this.action.data.string) + this.action.data.end, 'latin1')
+			// Two payload encodings exist so binary protocols (VISCA and friends) can
+			// be hand-crafted without changing how any existing config behaves:
+			//   - 'text' is the historical behaviour, byte for byte: unescape() the
+			//     UDP String (legacy %xx / %uXXXX decoding), append the End
+			//     Character, encode as latin1. There is no way to express a raw byte
+			//     such as 0x81 this way, which is why 'hex' was added.
+			//   - 'hex' reads the UDP String as raw bytes and sends them verbatim.
+			// Backwards compatibility: device actions saved before this field existed
+			// have no `encoding` key at all, so a missing (or empty) value must be
+			// treated as 'text'.
+			const encoding = this.action.data.encoding || 'text'
+
+			let sendBuf: Buffer
+			if (encoding === 'hex') {
+				const parsed = this.parseHexPayload(this.action.data.string)
+				if (parsed === null) {
+					logger(
+						`An error occured sending the Generic UDP: Payload Encoding is "Hex bytes" but the UDP String "${this.action.data.string}" is not a valid sequence of hex byte pairs. Use pairs of hex digits, e.g. 81 01 7E 01 0A 00 02 FF`,
+						'error',
+					)
+					return
+				}
+				// The End Character is deliberately ignored for hex payloads: a binary
+				// packet is fully described by its bytes, and silently appending a
+				// LF/CR/NULL would corrupt protocols like VISCA, which carry their own
+				// terminator (0xFF). Anyone who needs a trailing byte can just type it.
+				sendBuf = parsed
+			} else {
+				sendBuf = Buffer.from(unescape(this.action.data.string) + this.action.data.end, 'latin1')
+			}
 
 			if (!this.action.data.type) this.action.data.type = 'udp4'
 			let client = dgram.createSocket(this.action.data.type)


### PR DESCRIPTION
Unblocks #662, #303 and #967.

## Why these were blocked

`UDP.ts` built its payload as `Buffer.from(unescape(string) + end, 'latin1')`. `unescape()` is the legacy URL-unescaping function — it decodes `%xx` and `%uXXXX` and nothing else. There is no way to express a raw byte such as `0x81`: typing `\x81` produces four literal characters.

So VISCA over IP — which needs bytes like `81 01 7E 01 0A 00 02 FF` — was simply not expressible, which is what all three issues run into.

## Change

Adds an optional `encoding` dropdown ("Payload Encoding") to the Generic UDP action:

- **`text`** (default) — unchanged behaviour, byte for byte.
- **`hex`** — parses the UDP String as hex byte pairs and sends raw bytes. Tolerates whitespace, comma/colon/dash separators, an optional `0x` prefix per token, and mixed case.

Malformed input logs an actionable error naming the offending value and sends **nothing** — no partial packets. The validation (non-empty, even digit count, hex-only) deliberately runs *before* `Buffer.from(..., 'hex')`, which otherwise truncates invalid input silently.

The End Character is ignored in hex mode, documented in a code comment, the field help text and the docs: a binary packet is fully described by its bytes, and appending LF/CR/NULL would corrupt VISCA, which carries its own `0xFF` terminator.

## Backwards compatibility

`this.action.data.encoding || 'text'` routes any absent, empty or `null` value down the original untouched line. Verified byte-for-byte against configs with no `encoding` key:

- `{string:'TALLY ON', end:'\r\n'}` → `54 41 4C 4C 59 20 4F 4E 0D 0A`
- `{string:'%81%01', end:''}` → `81 01` (legacy `%xx` decoding intact)
- `{string:'caf%E9', end:'\n'}` → `63 61 66 E9 0A`

Identical output for `encoding: 'text'` and `encoding: ''`.

## Parser results

Accepted: `81 01 7E 01 0A 00 02 FF`, `8101 7E01`, `81,01,7E,FF`, `0x81 0x01`, lower case, `0X81,0x01:7E-FF`, `81:01:7E:FF`, `81-01-7E-FF`, `  81   01  `, `81017E010A0002FF`.

Rejected (nothing sent, error logged): `81 0`, `8`, `GG 01`, `81 ZZ`, `""`, `"   "`, `81 01 7`, `0x8`, `hello world`, `null`, `undefined`, numeric `12345`.

## Files

`src/actions/UDP.ts`, plus one line in `settings.component.html` to render per-field help under device-action dropdowns (there was no help output at all, so the End Character note would have been invisible), plus a docs paragraph with a VISCA example.

Checked and deliberately not changed: `TallyInputConfigField` already supports `help?`/`optional?`; `configSchema.ts` types `device_actions[].data` as a bare object so an unknown key is accepted; the UI schema is generated by `scripts/sync-ui-shared.js` at pre-build time.

## Verification

`npx tsc --noEmit` clean. Full Angular build succeeds, so the template addition type-checks under `strictTemplates`.

## Known cosmetic issue

Existing Generic UDP actions will show the new dropdown as `-- Select --` rather than "Text", because the key is genuinely absent. Behaviour is safe either way (saving without touching it writes `null`, still text), but it looks unset. Fixable by defaulting the dropdown in the UI if that is preferred.

## Scope

This only unblocks hand-crafted binary payloads. A first-class VISCA action — protocol implementation, camera addressing, inquiry handling — remains separate and considerably larger work, so #967 in particular may want to stay open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
