### PR TITLE
fix: repair broken address-registration guards in OBS and Tricaster

### DIFF
--- a/src/sources/NewtekTricaster.ts
+++ b/src/sources/NewtekTricaster.ts
@@ -68,7 +68,7 @@ export class NewtekTricasterSource extends TallyInput {
 			if (this.receiveBuffer.length > NewtekTricasterSource.MAX_BUFFER_SIZE) {
 				logger(
 					`Source: ${source.name}  Tricaster receive buffer exceeded ${NewtekTricasterSource.MAX_BUFFER_SIZE} bytes without a complete message; discarding buffered data.`,
-					'error'
+					'error',
 				)
 				this.receiveBuffer = ''
 			}
@@ -94,10 +94,7 @@ export class NewtekTricasterSource extends TallyInput {
 			parseString(wrapped, (error, result) => {
 				if (error) {
 					const preview = message.length > 500 ? message.slice(0, 500) + '...(truncated)' : message
-					logger(
-						`Source: ${source.name}  Tricaster XML failed to parse: ${error} - data: ${preview}`,
-						'error'
-					)
+					logger(`Source: ${source.name}  Tricaster XML failed to parse: ${error} - data: ${preview}`, 'error')
 				} else {
 					let shortcut_states = Object.entries(result['data']['shortcut_states'])
 
@@ -150,15 +147,12 @@ export class NewtekTricasterSource extends TallyInput {
 		}
 
 		for (let i = 0; i < sourceArray.length; i++) {
-			let tricasterSourceFound = false
-			for (let j = 0; j < this.tallydata_TC.length; j++) {
-				if (this.tallydata_TC[j].sourceId === sourceId) {
-					if (this.tallydata_TC[j].address === sourceArray[i]) {
-						tricasterSourceFound = true
-						break
-					}
-				}
-			}
+			// Key on the address alone: the address is the unique key of the addresses list, so the same
+			// Tricaster input must never be registered twice. Requiring a sourceId match as well would
+			// re-register (and duplicate) an address whenever the same input arrives with a different
+			// sourceId - and sourceId here is the TallyArbiter Source this data arrived on (see
+			// parseTricasterMessage), not a per-input Tricaster id, so it cannot distinguish inputs anyway.
+			let tricasterSourceFound = this.tallydata_TC.some((tallyObj) => tallyObj.address === sourceArray[i])
 
 			if (!tricasterSourceFound) {
 				//the source is not in the Tricaster array, we don't know anything about it, so add it to the array

--- a/src/sources/OBS.ts
+++ b/src/sources/OBS.ts
@@ -111,10 +111,7 @@ export class OBSSource extends TallyInput {
 
 					this.studioModeEnabled = studioModeStatus['studio-mode']
 
-					this.addAddress('{{STREAMING}}', '{{STREAMING}}')
-					this.addAddress('{{RECORDING}}', '{{RECORDING}}')
-					this.addAddress('{{VIRTUALCAM}}', '{{VIRTUALCAM}}')
-					this.addAddress('{{REPLAY}}', '{{REPLAY}}')
+					this.addStatusAddresses()
 					if (streamingAndRecordingStatus.streaming) this.setBussesForAddress('{{STREAMING}}', ['program'])
 					if (streamingAndRecordingStatus.recording) {
 						if (streamingAndRecordingStatus['recording-paused']) {
@@ -439,10 +436,7 @@ export class OBSSource extends TallyInput {
 					},
 				])
 				.then((results) => {
-					this.addAddress('{{STREAMING}}', '{{STREAMING}}')
-					this.addAddress('{{RECORDING}}', '{{RECORDING}}')
-					this.addAddress('{{VIRTUALCAM}}', '{{VIRTUALCAM}}')
-					this.addAddress('{{REPLAY}}', '{{REPLAY}}')
+					this.addStatusAddresses()
 
 					if ((results[0].responseData as OBSResponseTypes['GetStreamStatus']).outputActive) {
 						this.setBussesForAddress('{{STREAMING}}', ['program'])
@@ -676,11 +670,38 @@ export class OBSSource extends TallyInput {
 		this.connect()
 	}
 
+	/** True if an address string is already registered.
+	 * The address (not the label, and not any source-type-internal id) is the unique key of the
+	 * addresses list, so it is the only safe thing to key an "is this already registered?" check on.
+	 */
+	private hasAddress(address: string): boolean {
+		return this.addresses.value.some((a) => a.address === address)
+	}
+
+	/** Registers the four OBS status pseudo-addresses, skipping any that already exist.
+	 * The v4 'AuthenticationSuccess' and v5 'Identified' handlers that call this both fire again on
+	 * every reconnect, so registering these unconditionally would duplicate them once per reconnect.
+	 */
+	private addStatusAddresses(): void {
+		for (const address of ['{{STREAMING}}', '{{RECORDING}}', '{{VIRTUALCAM}}', '{{REPLAY}}']) {
+			if (!this.hasAddress(address)) {
+				this.addAddress(address, address)
+			}
+		}
+	}
+
 	/** Gets the Scene List, updates this.scenes4 and adds address if scene is not registered. */
 	private saveSceneList4(): void {
 		this.obsClient4.send('GetSceneList').then((data) => {
 			data.scenes.forEach((scene) => {
-				if (!this.scenes4.includes(scene)) {
+				//Key on the registered addresses, not on this.scenes4: this.scenes4 holds the scene
+				//OBJECTS from the previous GetSceneList response, so includes() (reference equality) never
+				//matched a freshly deserialized scene and every scene got re-added on every call.
+				//Comparing scene names against this.scenes4 wouldn't work either, because
+				//'SceneCollectionChanged' removes the old scenes' addresses *before* calling this while
+				//this.scenes4 still holds them - a scene name present in both collections would then be
+				//removed and never re-registered.
+				if (!this.hasAddress(scene.name)) {
 					this.addAddress(scene.name, scene.name)
 				}
 			})
@@ -695,7 +716,10 @@ export class OBSSource extends TallyInput {
 		this.obsClient5.call('GetSceneList').then((data) => {
 			let newScenes = data.scenes.flatMap((scene) => scene.sceneName as string)
 			newScenes.forEach((scene) => {
-				if (!this.scenes5.includes(scene)) {
+				//Key on the registered addresses rather than this.scenes5 for the same reason as in
+				//saveSceneList4(): 'CurrentSceneCollectionChanged' removes the old scenes' addresses before
+				//calling this, while this.scenes5 still lists them.
+				if (!this.hasAddress(scene)) {
 					this.addAddress(scene, scene)
 				}
 				if (scene === data.currentPreviewSceneName) {
@@ -838,9 +862,19 @@ export class OBSSource extends TallyInput {
 					})
 			}
 		} else if (this.obsProtocolVersion === 5) {
-			logger(`Source: ${this.source.name}  New audio input created (${input})`, 'info-quiet')
-			this.addAddress(input, input)
-			if (!this.audioInputs.includes(input)) this.audioInputs.push(input)
+			//Only register the address once. This must key on the registered addresses and not on
+			//this.audioInputs like the v4 branch above does: the 'Identified' handler assigns
+			//this.audioInputs wholesale *before* calling this for each entry, so on that path
+			//this.audioInputs already contains the input and cannot tell a first registration from a
+			//repeat. 'Identified' fires again on every reconnect, hence the duplicates.
+			if (!this.hasAddress(input)) {
+				logger(`Source: ${this.source.name}  New audio input created (${input})`, 'info-quiet')
+				this.addAddress(input, input)
+				if (!this.audioInputs.includes(input)) this.audioInputs.push(input)
+			}
+			//The mute state is queried even for an already-known input: a reconnect is exactly when the
+			//cached state may be stale (mute could have been toggled while we were disconnected, and no
+			//'InputMuteStateChanged' event was received for it), so it always has to be re-read.
 			this.obsClient5
 				.call('GetInputMute', {
 					inputName: input,


### PR DESCRIPTION
Repairs four broken address-registration guards in the OBS and Tricaster sources. No issue tracks these; they were found while auditing `addAddress` callers for #756.

Independent of #756's PR — different files, and the base-class de-dup there just becomes a no-op for these call sites. Either merge order works.

## Defect 1 — `saveSceneList4()` identity comparison

`this.scenes4.includes(scene)` compares scene **objects** from a previous `GetSceneList` response against freshly deserialized ones. `includes` uses SameValueZero, i.e. reference equality, so it never matched and every scene was re-added on every call — on connect and on every `SceneCollectionChanged`.

**Not fixed by mirroring `saveSceneList5()`'s name comparison**, which was the obvious move but would have regressed the collection-switch path: `SceneCollectionChanged` calls `removeAddress()` for the old scenes **before** calling `saveSceneList4()`, while `this.scenes4` still holds them (it is reassigned only at the end of the promise). A scene name present in both collections would be de-registered and then skipped as "already known" — the address silently vanishing. Master gets that case right only by accident of the always-false `includes`.

Keyed on the registered addresses instead, via a new `hasAddress()` helper.

## Defect 2 — v5 `addAudioInput()` registered before checking

`addAddress` ran unconditionally, before the `audioInputs.includes` check on the next line. `addAudioInput` is invoked for every input on every `Identified` event, so each reconnect re-registered them all.

**`audioInputs` cannot be the key here**, unlike the v4 branch: the `Identified` handler assigns `this.audioInputs = inputs.filter(...)` **before** the `forEach` that calls this, so on that path `audioInputs` already contains every input and nothing would ever register on first connect. Keys on `hasAddress()` instead.

`GetInputMute` is deliberately left **outside** the guard so it runs for already-known inputs too. `InputMuteStateChanged` is the only other thing that updates that tally and is not delivered while disconnected, so a mute toggled during an outage would otherwise stay wrong until the next user action. One cheap idempotent request per audio input per reconnect.

## Defect 3 — Tricaster over-specific guard

The guard required a match on both `sourceId` and `address`. Note the premise that `sourceId` is a Tricaster-internal id is **wrong**: `processTricasterTally(source, ...)` is passed the TallyArbiter `Source` object despite the parameter name, so it is the same reference on every call and the test was always true internally. The bug was only reachable through the `public` method, and the field is useless as a key either way since it is identical for every input. Now keys on address alone.

## Defect 4 — four pseudo-addresses re-added on every reconnect

`{{STREAMING}}`, `{{RECORDING}}`, `{{VIRTUALCAM}}`, `{{REPLAY}}` were added unconditionally in both the v4 `AuthenticationSuccess` and v5 `Identified` handlers, both of which fire on every reconnect. Replaced with a shared `addStatusAddresses()` helper.

## Also fixed

`saveSceneList5()` had the identical remove-then-skip hole on `CurrentSceneCollectionChanged` — it compares name strings against `this.scenes5`, which still lists the old scenes at that point. So a scene present in both collections was genuinely being dropped on every collection switch. One line plus a comment.

## Verification

A harness (not committed) transpiled the real `OBS.ts`, `NewtekTricaster.ts` and `_Source.ts` — real `addAddress`, real `BehaviorSubject` — with only `logger`, `currentConfig`, the decorator, models and network clients stubbed. `BASELINE=1` re-reads both sources via `git show master:<path>`.

Address counts over 2 connect cycles (2 scenes + 2 audio inputs + 4 pseudo = 8 expected):

| Scenario | pre-fix | post-fix |
|---|---|---|
| OBS v4, 2nd connect | **14** | **8** |
| OBS v5, 2nd `Identified` | **14** | **8** |
| Tricaster, same inputs, different `sourceId` | **5** | **3** |

Baseline: **6 of 12 assertions FAIL** on master, mapping 1:1 onto the four defects. Post-fix 12/12 pass. The baseline run also confirms v4 `addAudioInput` and v5's *reconnect* path were already correct.

`npx tsc --noEmit` clean; `prettier --check` clean on both files.

## Two disclosures

- `prettier -w` also reformatted two pre-existing non-conformant `logger()` calls in `NewtekTricaster.ts`. Formatting-only churn, easily reverted if preferred.
- **Separate pre-existing bug flagged, not fixed:** the second loop in `processTricasterTally` calls `addBusToAddress(sourceArray[i], ...)` while indexed over `tallydata_TC` — that looks like a genuine index mismatch affecting tally output, and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
