### PR TITLE
chore: make stale bot exemptions opt-in via a keep label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,11 +13,17 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had recent activity. 
+            This issue has been automatically marked as stale because it has not had recent activity.
             It will be closed in 7 days if no further activity occurs.
+            Add the `keep` label if this should stay open.
           close-issue-message: >
-            Closing this issue due to inactivity. Feel free to reopen if it's still relevant.
+            Closing this issue due to inactivity. Feel free to reopen if it's still relevant,
+            and add the `keep` label so it doesn't go stale again.
           days-before-stale: 180
           days-before-close: 7
-          exempt-issue-labels: 'bug,enhancement,feature'
+          # Only issues are handled; -1 disables staleness for pull requests.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: 'keep'
+          exempt-all-milestones: true
           remove-stale-when-updated: true


### PR DESCRIPTION
Housekeeping for the issue backlog. No issue tracks this.

## Problem

`stale.yml` set `exempt-issue-labels: 'bug,enhancement,feature'` — but those are effectively the **only** labels used on issues in this repo, so every issue was exempt and the stale bot has never closed anything. The backlog currently runs to ~66 open issues, the oldest from December 2020.

## Changes

| Option | Change |
|---|---|
| `exempt-issue-labels` | `'bug,enhancement,feature'` → `'keep'` |
| `exempt-all-milestones` | added, `true` — anything actually scheduled is protected |
| `days-before-pr-stale` | added, `-1` |
| `days-before-pr-close` | added, `-1` |

`days-before-stale: 180` / `days-before-close: 7` unchanged. `stale-issue-label` deliberately not set — v9 already defaults it to `Stale`, so adding it would only restate the default.

Every option name was verified against `action.yml` on the `v9` tag rather than from memory.

## Why PR staleness is now disabled

PR staleness was previously unconfigured, so PRs silently **inherited the issue timings** (180/7). And since no `stale-pr-message` or `close-pr-message` was set, a dormant contributor PR would have been marked and closed with **no explanatory comment at all**. Auto-closing contributor PRs is usually undesirable anyway — a dormant PR normally means it has not been reviewed yet, not that it was abandoned.

The stale/close messages now name the `keep` label as the opt-out.

## ⚠️ Two things before merging

1. **The `keep` label does not exist in this repo yet.** Until it is created and applied, `exempt-issue-labels: 'keep'` matches nothing and only milestoned issues are protected. Create it and label what should stay open **first**.

2. **This flips the bot from a no-op to actively closing the backlog.** On the next scheduled run (daily 03:00 UTC) it starts marking dormant issues stale and closing them 7 days later. `operations-per-run` defaults to 30, so it works through them over several days rather than all at once.

Suggested sequence: create `keep` → label the keepers → one `workflow_dispatch` run with `debug-only: true` to see the blast radius without it commenting or closing → then let the schedule take over.

## Verification

`yaml.safe_load` parses cleanly; the folded scalars join correctly and `days-before-pr-stale` parses as integer `-1`. The workflow was **not** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
