### PR TITLE
feat: add Sony VISCA over IP camera tally support (experimental)

### DIFF
--- a/docs/docs/usage/sections/devices.md
+++ b/docs/docs/usage/sections/devices.md
@@ -22,6 +22,38 @@ Device Sources can be "linked" on either the Preview Bus, the Program Bus, or bo
 
 The source address is typically the actual input number on the switcher. So, if your camera on your ATEM comes in on Input 5, just enter `5`. However, if you're using a source like OBS Studio, your address might be a string, like `Scene 2` or `Image 1`. Some Source Types also support selecting the Device Address via a list.
 
+## Camera Tally
+
+Some cameras have a tally lamp built in that can be driven over the network. If yours does, you can have Tally Arbiter talk to it directly, without a listener client or a Device Action.
+
+Two fields on a Device control this:
+
+- **Camera IP** — the network address of the camera itself.
+- **Camera Model** — which protocol Tally Arbiter should speak to it.
+
+Both must be filled in before anything is sent. Whenever the Device changes state, Tally Arbiter works out whether it is in Program or Preview and sends the matching command to the camera.
+
+The following camera models are implemented:
+
+### Canon PTZ Camera (XC Protocol)
+
+Canon PTZ cameras that expose the XC control CGI. Program and Preview each light the corresponding tally mode on the camera.
+
+### Sony VISCA over IP (experimental)
+
+:::warning
+Both Sony VISCA entries are **experimental and have not been tested against real hardware**. The commands are transcribed from Sony's published VISCA command lists. If you have a Sony camera to try them on, please report what you see — the outgoing packets are logged as hex at the `info-quiet` log level so you can confirm exactly what went on the wire.
+:::
+
+Commands are sent as VISCA over IP on UDP port 52381, which is fixed and not currently configurable. Two variants are available:
+
+- **Single Tally Lamp** — for BRC and SRG series bodies that have one tally lamp. Program _or_ Preview lights it.
+- **Red/Green Tally Lamps** — for newer bodies with two lamps, such as the ILME-FR7. Program lights the red lamp and Preview lights the green lamp. Note that the green lamp command is documented for the FR7 series; it is not listed in the SRG-A40/A12 command list and may do nothing on those cameras.
+
+Most Sony cameras require tally control to be handed over to an external controller before VISCA tally commands have any effect. On the ILME-FR7 this is **[Technical] > [Tally] > [Tally Control] > [External]** in the camera or web menu; other models have an equivalent "external tally" setting.
+
+Sony cameras also extinguish the lamp automatically if they do not receive another "on" command within 15 seconds, so Tally Arbiter re-sends the current state every few seconds for as long as a lamp is lit.
+
 ## Device Actions
 
 Once a device is assigned to a source(s), if a matching condition is met, an action can be performed. You can specify whether the action should be run when the device is entering a bus or leaving a bus, which is helpful for bus-specific actions like operating a relay. Multiple actions are supported per device and per bus (preview and program).

--- a/src/_models/CameraModels.ts
+++ b/src/_models/CameraModels.ts
@@ -1,10 +1,20 @@
 export interface CameraModel {
-    id: string
-    label: string
-    visible: boolean
+	id: string
+	label: string
+	visible: boolean
 }
 
 export const CameraModels: CameraModel[] = [
-    { id: 'canon_xc', label: 'Canon PTZ Camera (XC Protocol)', visible: true },
-    // Add more camera models as needed and support for them in 
+	{ id: 'canon_xc', label: 'Canon PTZ Camera (XC Protocol)', visible: true },
+	{
+		id: 'sony_visca',
+		label: 'Sony VISCA over IP - Single Tally Lamp (EXPERIMENTAL, untested on hardware)',
+		visible: true,
+	},
+	{
+		id: 'sony_visca_rg',
+		label: 'Sony VISCA over IP - Red/Green Tally Lamps (EXPERIMENTAL, untested on hardware)',
+		visible: true,
+	},
+	// Add more camera models as needed and support for them in
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -2271,6 +2271,13 @@ function TallyArbiter_Add_Device(obj: Manage): ManageResponse {
 
 function TallyArbiter_Edit_Device(obj: Manage): ManageResponse {
 	let deviceObj = obj.device
+
+	//capture the camera config before the loop below overwrites it, so we can tell whether it actually changed
+	const existingDevice = GetDeviceByDeviceId(deviceObj.id)
+	const previousCameraIP = existingDevice.cameraIP
+	const previousCameraModel = existingDevice.cameraModel
+	const cameraChanged = previousCameraIP !== deviceObj.cameraIP || previousCameraModel !== deviceObj.cameraModel
+
 	for (let i = 0; i < devices.length; i++) {
 		if (devices[i].id === deviceObj.id) {
 			devices[i].name = deviceObj.name
@@ -2285,6 +2292,15 @@ function TallyArbiter_Edit_Device(obj: Manage): ManageResponse {
 	tslListenerProvider.updateListenerClientsForDevice(currentDeviceTallyData, deviceObj)
 
 	UpdateCloud('devices')
+
+	//UpdateCamera only runs on a device state change, so a camera edit would otherwise not reach the camera
+	//until the next tally transition. Release any state held against the old camera and push the current
+	//tally to the new one immediately. Skipped when the camera config is untouched, so editing a device's
+	//name does not blink the tally lamp of a camera that is currently live.
+	if (cameraChanged) {
+		CleanupViscaCameraState(deviceObj.id)
+		UpdateCamera(deviceObj.id)
+	}
 
 	logger(`Device Edited: ${deviceObj.name}`, 'info')
 
@@ -3037,6 +3053,12 @@ const VISCA_TALLY_REFRESH_MS = 5000
 interface ViscaCameraState {
 	socket: dgram.Socket
 	sequence: number
+	// IP and variant this state was last driven with. Held here rather than
+	// captured in the keepalive closure so that a config edit can never leave a
+	// timer firing at a stale address, and so teardown knows which camera and
+	// which lamps to extinguish.
+	cameraIP: string
+	redGreen: boolean
 	// last state we pushed, re-sent by the keepalive timer
 	lastCommands: number[][]
 	refreshTimer?: ReturnType<typeof setInterval>
@@ -3062,7 +3084,7 @@ function GetViscaCameraState(deviceId: string, cameraIP: string): ViscaCameraSta
 			logger(`VISCA socket error for device ${deviceId}: ${err.message}`, 'error')
 		})
 
-		state = { socket: socket, sequence: 0, lastCommands: [] }
+		state = { socket: socket, sequence: 0, cameraIP: cameraIP, redGreen: false, lastCommands: [] }
 		viscaCameraStates.set(deviceId, state)
 
 		// First contact with this camera: reset the sequence number so the
@@ -3086,7 +3108,17 @@ function SendViscaPacket(
 	payloadType: number[],
 	payload: number[],
 	isControl = false,
+	onComplete?: () => void,
 ): void {
+	let completed = false
+	const complete = () => {
+		if (completed) {
+			return
+		}
+		completed = true
+		onComplete?.()
+	}
+
 	try {
 		// The sequence number of a RESET control packet is ignored by the
 		// camera, but the field still has to be present.
@@ -3109,17 +3141,28 @@ function SendViscaPacket(
 			if (err) {
 				logger(`Error sending VISCA packet to ${cameraIP}: ${err.message}`, 'error')
 			}
+			complete()
 		})
 	} catch (error) {
 		logger(`Error building/sending VISCA packet for device ${deviceId}: ${error}`, 'error')
+		// the send callback will never fire, so release the waiter here
+		complete()
 	}
 }
 
-// Tears down the socket and keepalive timer for a device that is no longer a
-// VISCA camera (deleted, camera fields cleared, or model changed). Without this
-// the refresh timer would keep re-lighting the lamp forever. We deliberately do
-// not send an explicit OFF here: dropping the keepalive lets the camera's own
-// 15 second expiry extinguish the lamp, which also works if the camera is gone.
+// Tears down the socket and keepalive timer for a device that is no longer this
+// VISCA camera (deleted, camera fields cleared, model changed, or IP changed).
+// Without this the refresh timer would keep re-lighting the lamp forever.
+//
+// If a lamp was lit we explicitly extinguish it first, addressed to the IP and
+// variant the state was last driven with -- i.e. the OLD camera. Relying on the
+// camera's own 15 second expiry instead would leave the old camera lit for up
+// to 15 seconds while the newly configured one also lights, which on an IP edit
+// means two cameras showing tally at once. An OFF is two UDP datagrams at most
+// and costs nothing if the camera is already unreachable.
+//
+// The socket is closed only once those datagrams have been handed to the OS;
+// closing immediately after send() can discard them.
 function CleanupViscaCameraState(deviceId: string) {
 	const state = viscaCameraStates.get(deviceId)
 
@@ -3127,16 +3170,47 @@ function CleanupViscaCameraState(deviceId: string) {
 		return
 	}
 
+	// drop it from the map up front so nothing can pick up a dying state
+	viscaCameraStates.delete(deviceId)
+
 	try {
+		// the keepalive only runs while something is lit, so its presence tells
+		// us whether there is anything to extinguish
+		const wasLit = !!state.refreshTimer
+
 		if (state.refreshTimer) {
 			clearInterval(state.refreshTimer)
+			state.refreshTimer = undefined
 		}
-		state.socket.close()
+
+		const closeSocket = () => {
+			try {
+				state.socket.close()
+			} catch (error) {
+				logger(`Error closing VISCA socket for device ${deviceId}: ${error}`, 'error')
+			}
+		}
+
+		if (!wasLit) {
+			closeSocket()
+			return
+		}
+
+		const offCommands = state.redGreen ? [VISCA_CMD_TALLY_OFF, VISCA_CMD_GREEN_TALLY_OFF] : [VISCA_CMD_TALLY_OFF]
+
+		let pending = offCommands.length
+
+		for (const command of offCommands) {
+			SendViscaPacket(state, deviceId, state.cameraIP, VISCA_PAYLOAD_TYPE_COMMAND, command, false, () => {
+				pending--
+				if (pending === 0) {
+					closeSocket()
+				}
+			})
+		}
 	} catch (error) {
 		logger(`Error cleaning up VISCA state for device ${deviceId}: ${error}`, 'error')
 	}
-
-	viscaCameraStates.delete(deviceId)
 }
 
 // Sends the absolute desired lamp state and keeps it refreshed.
@@ -3156,6 +3230,11 @@ function UpdateSonyViscaTally(deviceId: string, cameraIP: string, inPgm: boolean
 	if (!state) {
 		return
 	}
+
+	// keep the state pointed at the live config; the keepalive and teardown both
+	// read these rather than closing over the values passed in on one call
+	state.cameraIP = cameraIP
+	state.redGreen = redGreen
 
 	const commands: number[][] = []
 
@@ -3186,7 +3265,7 @@ function UpdateSonyViscaTally(deviceId: string, cameraIP: string, inPgm: boolean
 	if (anythingLit) {
 		state.refreshTimer = setInterval(() => {
 			for (const command of state.lastCommands) {
-				SendViscaPacket(state, deviceId, cameraIP, VISCA_PAYLOAD_TYPE_COMMAND, command)
+				SendViscaPacket(state, deviceId, state.cameraIP, VISCA_PAYLOAD_TYPE_COMMAND, command)
 			}
 		}, VISCA_TALLY_REFRESH_MS)
 		// Do not hold the process open just for a tally refresh.
@@ -3224,18 +3303,27 @@ function UpdateCamera(deviceId: string) {
 	switch (device.cameraModel) {
 		case 'canon_xc':
 			//clear all tallies first
-			axios.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=off`)
+			//a bare axios.get() with no .catch() is an unhandled rejection if the camera is unreachable,
+			//which terminates the process on modern Node. UpdateCamera is now also reachable from the
+			//device edit handler, so a mistyped camera IP must not be fatal.
+			axios
+				.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=off`)
+				.catch((error) => logger(`Error sending Canon XC command to ${device.cameraIP}: ${error}`, 'error'))
 			
 			if (inPgm) {
 				logger(`Sending Canon XC command to set camera ON AIR`, 'info-quiet')
 				//send command to camera IP to set tally program
-				axios.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=on&f.tally.mode=program`)
+				axios
+					.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=on&f.tally.mode=program`)
+					.catch((error) => logger(`Error sending Canon XC command to ${device.cameraIP}: ${error}`, 'error'))
 			}
 			
 			if (inPvw) {
 				logger(`Sending Canon XC command to set camera PREVIEW`, 'info-quiet')
 				//send command to camera IP to set tally preview
-				axios.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=on&f.tally.mode=preview`)
+				axios
+					.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=on&f.tally.mode=preview`)
+					.catch((error) => logger(`Error sending Canon XC command to ${device.cameraIP}: ${error}`, 'error'))
 			}
 			break
 		case 'sony_visca':

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import compression from 'compression'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
 import bodyParser from 'body-parser'
 import http from 'http'
+import dgram from 'dgram'
 import socketio from 'socket.io'
 import ioClient from 'socket.io-client'
 import { BehaviorSubject } from 'rxjs'
@@ -2294,6 +2295,9 @@ function TallyArbiter_Delete_Device(obj: Manage): ManageResponse {
 	let deviceId = obj.deviceId
 	let deviceName = GetDeviceByDeviceId(deviceId).name
 
+	//release any VISCA socket/keepalive timer held for this device
+	CleanupViscaCameraState(deviceId)
+
 	for (let i = 0; i < devices.length; i++) {
 		if (devices[i].id === deviceId) {
 			devices.splice(i, 1)
@@ -2959,12 +2963,244 @@ function MessageListenerClient(
 	}
 }
 
+// ============================================================================
+// Sony VISCA over IP tally support
+// ----------------------------------------------------------------------------
+// EXPERIMENTAL: none of this has been verified against real hardware. Every
+// byte sequence below is transcribed from Sony's published command lists and
+// is cited with its source. If your camera behaves differently, correct the
+// constants in this one block -- no VISCA bytes are constructed anywhere else.
+//
+// PRIMARY SOURCE (framing + single-lamp tally), read directly from the PDF:
+//   Sony "VISCA Command List", Software Version 2.00, doc E-042-100-12 (1),
+//   covering BRC-X400/X401, SRG-X400/X402/201M2, SRG-X120/HD1M2, pp. 9-11 and
+//   the TALLY row of the command list.
+//   https://shop.ccisolutions.com/StoreFront/jsp/pdf/SON-SRGX400_visca_commandList.pdf
+//   (dealer-hosted copy of Sony's document; pro.sony blocks automated fetches)
+//
+// SOURCE (red/green two-lamp tally):
+//   Sony "VISCA Command List", Software Version 1.00, doc 5-042-055-11 (1),
+//   covering ILME-FR7 / ILME-FR7K, "Command List (6/6)" -- the TALLY category
+//   has two rows, RED and GREEN.
+//   https://www.manualslib.com/manual/2854210/Sony-Ilme-Fr7.html?page=17
+//
+// SOURCE (SRG-A40/A12 has the single-lamp TALLY command but NO green row):
+//   Sony SRG-A40/A12 VISCA/CGI Command List
+//   https://www.manualslib.com/manual/3106426/Sony-Srg-A40.html?page=19
+//
+// SOURCE (camera-side prerequisite):
+//   Sony ILME-FR7 Help Guide, "Connecting a Tally Signal" -- the camera menu
+//   item [Technical] > [Tally] > [Tally Control] must be set to [External]
+//   before VISCA tally commands have any effect.
+//   https://helpguide.sony.net/ilc/2240/v1/en/contents/TP1000673481.html
+// ============================================================================
+
+// UDP port for VISCA over IP. Per the BRC-X400 command list p. 9 this is fixed
+// at 52381 and the Device model currently has no field to override it.
+const VISCA_PORT = 52381
+
+// Message header, 8 bytes (BRC-X400 command list pp. 10-11):
+//   bytes 0-1  payload type
+//   bytes 2-3  payload length, big-endian
+//   bytes 4-7  sequence number, big-endian
+const VISCA_PAYLOAD_TYPE_COMMAND = [0x01, 0x00] // "VISCA command"
+const VISCA_PAYLOAD_TYPE_CONTROL = [0x02, 0x00] // "Control command"
+
+// Control-command payload 0x01 = RESET: "Resets the sequence number to 0. The
+// value that was set as the sequence number is ignored." (p. 11)
+const VISCA_CONTROL_RESET = [0x01]
+
+// Peripheral device address. "VISCA over IP cannot reflect each address to the
+// address of the VISCA message" -- the address is locked to 1, so the first
+// byte of every payload is 0x81. (BRC-X400 command list pp. 10, 13)
+const VISCA_ADDRESS = 0x81
+
+// TALLY ON/OFF -- "8x 01 7E 01 0A 00 0p FF", p: 2=On, 3=Off.
+// This is the single lamp on BRC/SRG bodies and the RED lamp on the FR7.
+const VISCA_CMD_TALLY_ON = [VISCA_ADDRESS, 0x01, 0x7e, 0x01, 0x0a, 0x00, 0x02, 0xff]
+const VISCA_CMD_TALLY_OFF = [VISCA_ADDRESS, 0x01, 0x7e, 0x01, 0x0a, 0x00, 0x03, 0xff]
+
+// GREEN TALLY ON/OFF -- "8x 01 7E 04 1A 00 0p FF", p: 2=On, 3=Off.
+// Documented for ILME-FR7/FR7K. NOTE: the SRG-A40/A12 command list does NOT
+// list a green row, so this may be a no-op on SRG-A bodies.
+const VISCA_CMD_GREEN_TALLY_ON = [VISCA_ADDRESS, 0x01, 0x7e, 0x04, 0x1a, 0x00, 0x02, 0xff]
+const VISCA_CMD_GREEN_TALLY_OFF = [VISCA_ADDRESS, 0x01, 0x7e, 0x04, 0x1a, 0x00, 0x03, 0xff]
+
+// "Expiration time for an on status of the tally lamp: The tally lamp is turned
+// off if not receiving an ON command from any controller for 15 seconds after
+// receiving an ON command of TALLY ON/OFF." (BRC-X400 command list p. 12)
+// So a lit lamp has to be refreshed or the camera drops it mid-shot. We re-send
+// the current state well inside that window while any lamp is lit.
+const VISCA_TALLY_EXPIRY_MS = 15000
+const VISCA_TALLY_REFRESH_MS = 5000
+
+interface ViscaCameraState {
+	socket: dgram.Socket
+	sequence: number
+	// last state we pushed, re-sent by the keepalive timer
+	lastCommands: number[][]
+	refreshTimer?: ReturnType<typeof setInterval>
+}
+
+// Per-device VISCA state, keyed by device id. VISCA over IP needs an
+// incrementing sequence number per camera plus a socket to send from, and
+// UpdateCamera's switch has nowhere to keep that.
+const viscaCameraStates = new Map<string, ViscaCameraState>()
+
+function GetViscaCameraState(deviceId: string, cameraIP: string): ViscaCameraState | undefined {
+	let state = viscaCameraStates.get(deviceId)
+
+	if (state) {
+		return state
+	}
+
+	try {
+		const socket = dgram.createSocket('udp4')
+		// A socket-level error (ICMP port unreachable, etc.) is emitted
+		// asynchronously and would be an uncaught exception if unhandled.
+		socket.on('error', (err) => {
+			logger(`VISCA socket error for device ${deviceId}: ${err.message}`, 'error')
+		})
+
+		state = { socket: socket, sequence: 0, lastCommands: [] }
+		viscaCameraStates.set(deviceId, state)
+
+		// First contact with this camera: reset the sequence number so the
+		// camera and Tally Arbiter agree on where the count starts.
+		SendViscaPacket(state, deviceId, cameraIP, VISCA_PAYLOAD_TYPE_CONTROL, VISCA_CONTROL_RESET, true)
+
+		return state
+	} catch (error) {
+		logger(`Unable to create VISCA socket for device ${deviceId}: ${error}`, 'error')
+		return undefined
+	}
+}
+
+// Builds the 8-byte header + payload, logs it as hex, and fires it off.
+// Never throws: UpdateCamera runs inside an RxJS subscriber via
+// UpdateDeviceState, and a throw here would disrupt tally for other devices.
+function SendViscaPacket(
+	state: ViscaCameraState,
+	deviceId: string,
+	cameraIP: string,
+	payloadType: number[],
+	payload: number[],
+	isControl = false,
+): void {
+	try {
+		// The sequence number of a RESET control packet is ignored by the
+		// camera, but the field still has to be present.
+		if (!isControl) {
+			state.sequence = (state.sequence + 1) >>> 0
+		}
+
+		const packet = Buffer.alloc(8 + payload.length)
+		packet[0] = payloadType[0]
+		packet[1] = payloadType[1]
+		packet.writeUInt16BE(payload.length, 2)
+		packet.writeUInt32BE(isControl ? 1 : state.sequence, 4)
+		Buffer.from(payload).copy(packet, 8)
+
+		const hex = packet.toString('hex').toUpperCase().replace(/(..)/g, '$1 ').trim()
+
+		logger(`Sending Sony VISCA packet to ${cameraIP}:${VISCA_PORT} -> ${hex}`, 'info-quiet')
+
+		state.socket.send(packet, VISCA_PORT, cameraIP, (err) => {
+			if (err) {
+				logger(`Error sending VISCA packet to ${cameraIP}: ${err.message}`, 'error')
+			}
+		})
+	} catch (error) {
+		logger(`Error building/sending VISCA packet for device ${deviceId}: ${error}`, 'error')
+	}
+}
+
+// Tears down the socket and keepalive timer for a device that is no longer a
+// VISCA camera (deleted, camera fields cleared, or model changed). Without this
+// the refresh timer would keep re-lighting the lamp forever. We deliberately do
+// not send an explicit OFF here: dropping the keepalive lets the camera's own
+// 15 second expiry extinguish the lamp, which also works if the camera is gone.
+function CleanupViscaCameraState(deviceId: string) {
+	const state = viscaCameraStates.get(deviceId)
+
+	if (!state) {
+		return
+	}
+
+	try {
+		if (state.refreshTimer) {
+			clearInterval(state.refreshTimer)
+		}
+		state.socket.close()
+	} catch (error) {
+		logger(`Error cleaning up VISCA state for device ${deviceId}: ${error}`, 'error')
+	}
+
+	viscaCameraStates.delete(deviceId)
+}
+
+// Sends the absolute desired lamp state and keeps it refreshed.
+//
+// CLEAR-vs-SET: the Canon branch sends an unconditional tally=off and then
+// turns on whichever lamp applies. We do NOT mirror that here. Blanking a VISCA
+// lamp and immediately re-lighting it is a visible blink on the physical lamp
+// and doubles the packet count. Instead we send the absolute state of every
+// lamp we control on every call -- red = program, green = preview -- which is
+// idempotent, produces no intermediate off state, and is still unconditional
+// (not send-on-change), so a dropped UDP packet self-corrects on the next tally
+// transition. Cost is 1 packet per transition for sony_visca and 2 for
+// sony_visca_rg, plus the keepalive below.
+function UpdateSonyViscaTally(deviceId: string, cameraIP: string, inPgm: boolean, inPvw: boolean, redGreen: boolean) {
+	const state = GetViscaCameraState(deviceId, cameraIP)
+
+	if (!state) {
+		return
+	}
+
+	const commands: number[][] = []
+
+	if (redGreen) {
+		// Program lights the red lamp, preview lights the green lamp.
+		commands.push(inPgm ? VISCA_CMD_TALLY_ON : VISCA_CMD_TALLY_OFF)
+		commands.push(inPvw ? VISCA_CMD_GREEN_TALLY_ON : VISCA_CMD_GREEN_TALLY_OFF)
+	} else {
+		// Single lamp: program or preview both light it.
+		commands.push(inPgm || inPvw ? VISCA_CMD_TALLY_ON : VISCA_CMD_TALLY_OFF)
+	}
+
+	state.lastCommands = commands
+
+	for (const command of commands) {
+		SendViscaPacket(state, deviceId, cameraIP, VISCA_PAYLOAD_TYPE_COMMAND, command)
+	}
+
+	// Keepalive: without this the camera drops the lamp after
+	// VISCA_TALLY_EXPIRY_MS. Only runs while something is lit.
+	const anythingLit = inPgm || inPvw
+
+	if (state.refreshTimer) {
+		clearInterval(state.refreshTimer)
+		state.refreshTimer = undefined
+	}
+
+	if (anythingLit) {
+		state.refreshTimer = setInterval(() => {
+			for (const command of state.lastCommands) {
+				SendViscaPacket(state, deviceId, cameraIP, VISCA_PAYLOAD_TYPE_COMMAND, command)
+			}
+		}, VISCA_TALLY_REFRESH_MS)
+		// Do not hold the process open just for a tally refresh.
+		state.refreshTimer.unref?.()
+	}
+}
+
 function UpdateCamera(deviceId: string) {
 	const device = GetDeviceByDeviceId(deviceId)
 
 	if (!device.cameraIP || !device.cameraModel) {
 		//only proceed if both camera IP and model are set
-		return	
+		CleanupViscaCameraState(deviceId)
+		return
 	}
 
 	logger(`Updating camera for device: ${device.name} (Camera: ${device.cameraModel})`, 'info-quiet')
@@ -2979,6 +3215,11 @@ function UpdateCamera(deviceId: string) {
 
 	const inPgm = pgmBus && pgmBus.sources.length > 0
 	const inPvw = pvwBus && pvwBus.sources.length > 0
+
+	//if this device was previously a VISCA camera and no longer is, release its socket and keepalive
+	if (device.cameraModel !== 'sony_visca' && device.cameraModel !== 'sony_visca_rg') {
+		CleanupViscaCameraState(deviceId)
+	}
 
 	switch (device.cameraModel) {
 		case 'canon_xc':
@@ -2996,6 +3237,14 @@ function UpdateCamera(deviceId: string) {
 				//send command to camera IP to set tally preview
 				axios.get(`http://${device.cameraIP}/-wvhttp-01-/control.cgi?f.tally=on&f.tally.mode=preview`)
 			}
+			break
+		case 'sony_visca':
+			//single tally lamp: program or preview both light it
+			UpdateSonyViscaTally(deviceId, device.cameraIP, !!inPgm, !!inPvw, false)
+			break
+		case 'sony_visca_rg':
+			//separate lamps: program lights red, preview lights green
+			UpdateSonyViscaTally(deviceId, device.cameraIP, !!inPgm, !!inPvw, true)
 			break
 		default:
 			console.log(`Camera model ${device.cameraModel} not supported for tally updates.`)


### PR DESCRIPTION
Addresses #967 and #303. Implemented to mirror the existing Canon PTZ (XC protocol) camera tally feature — same `CameraModels` registry, same `cameraIP`/`cameraModel` device fields, same `UpdateCamera()` switch.

⚠️ **Untested on hardware.** Both models are labelled EXPERIMENTAL in the UI dropdown. Everything below is transcription from Sony documentation plus synthetic packet verification.

## What's added

| id | Behaviour |
|---|---|
| `sony_visca` | Single tally lamp — lit when the device is in program **or** preview |
| `sony_visca_rg` | Red lamp = program, green lamp = preview |

No change to `Device` (`cameraIP`/`cameraModel` already exist). Only `src/_models/CameraModels.ts` is edited — the `UI/` copy is generated by `scripts/sync-ui-shared.js`.

## Protocol, with sources

Read from Sony's own PDF rather than recalled. Primary source: *VISCA Command List, Software Version 2.00*, doc E-042-100-12(1), covering BRC-X400/X401, SRG-X400/X402/201M2, SRG-X120/HD1M2 — [dealer-hosted copy](https://shop.ccisolutions.com/StoreFront/jsp/pdf/SON-SRGX400_visca_commandList.pdf) (pro.sony blocks automated fetches).

Framing (pp. 9–13): UDP **52381**; 8-byte header + 1–16 byte payload; payload type `0x01 0x00` for a VISCA command and `0x02 0x00` for control; payload length 2 bytes big-endian; sequence number 4 bytes big-endian. Sequence reset is a control packet with payload `0x01`. Address is locked to `0x81` over IP — Sony notes the address nibble *"cannot be reflected"*.

| Command | Bytes | Source |
|---|---|---|
| TALLY ON | `81 01 7E 01 0A 00 02 FF` | BRC-X400 list p. 25 |
| TALLY OFF | `81 01 7E 01 0A 00 03 FF` | same |
| GREEN TALLY ON | `81 01 7E 04 1A 00 02 FF` | [ILME-FR7 VISCA Command List](https://www.manualslib.com/manual/2854210/Sony-Ilme-Fr7.html?page=17), doc 5-042-055-11(1) |
| GREEN TALLY OFF | `81 01 7E 04 1A 00 03 FF` | same |

`p: 2 = On, 3 = Off`, matching Sony's convention elsewhere (Power, IR Receive, etc.).

All byte sequences live in one commented constant block so values can be corrected from a camera manual without touching logic.

## ⚠️ What could not be verified

1. **Green tally on SRG-A bodies.** `7E 04 1A` is confirmed only for ILME-FR7/FR7K. The SRG-A40/A12 command list has the single-lamp `7E 01 0A` row but **no green row at all**, so `sony_visca_rg` may silently do nothing on SRG-A. Flagged in code and docs — use `sony_visca` there.
2. **No hardware test of any kind.**
3. The FR7 green command came from a ManualsLib render of Sony's PDF rather than the PDF itself. The raw text was unambiguous and the red value on the same page cross-checks against the PDF that was read directly, but it is one step removed.

Worth knowing: a scraped copy of the SRG-A40 manual reports TALLY as `7E 01 03`. That is **wrong** — the HTML table's category column is offset by one row from the byte column, and `7E 01 03` is actually HDMI COLOR SPACE. Verified against raw HTML.

## The 15-second expiry — why there is a keepalive

BRC-X400 list p. 12: *"The tally lamp is turned off if not receiving an ON command from any controller for 15 seconds after receiving an ON command."*

`UpdateCamera` only fires on state change, so a single ON is not enough — **any shot held longer than 15 seconds would drop its own tally**, and the feature would have looked broken. A 5-second keepalive re-sends current state while any lamp is lit, `unref()`'d so it never holds the process open, cleared and rebuilt on every state change. `VISCA_TALLY_EXPIRY_MS` / `VISCA_TALLY_REFRESH_MS` are isolated if you want to strip it.

**Camera-side prerequisite, also documented:** `[Technical] > [Tally] > [Tally Control]` must be set to `[External]` or VISCA tally does nothing.

## Design decisions that differ from Canon

**Absolute state, not clear-then-set.** Canon sends an unconditional `tally=off` then lights what applies. Over HTTP each request is a full state set, but for VISCA an OFF-then-ON on the same physical lamp is a visible blink and doubles packet count. This sends the absolute state of every lamp on every call instead — idempotent, no intermediate off, still unconditional so a dropped datagram self-corrects at the next transition.

**Edit-path reconciliation (second commit).** `TallyArbiter_Edit_Device` overwrote `cameraIP`/`cameraModel` without reconciling VISCA state, so a running keepalive would keep transmitting to the **old IP** — indefinitely, if that device's tally never changed again. Now tears down conditionally (only when those fields actually changed, so renaming a live device does not blink its lamp) and calls `UpdateCamera` so the new camera picks up current state immediately. `cameraIP`/`redGreen` also moved onto the state object rather than being closure-captured, so a timer cannot outlive its configuration.

**Teardown sends an explicit OFF** to the old camera and old variant before dropping the socket. Relying on the 15s expiry is fine on delete but wrong on an IP change — two cameras would show tally simultaneously for up to 15 seconds. Applied to all three teardown paths.

## Scope note — this PR also touches the Canon branch

The three Canon `axios.get()` calls had no `.catch()`, so an unreachable camera is an unhandled rejection, which terminates the process on modern Node. That was previously only reachable on a tally transition; routing `UpdateCamera` through the interactive edit handler means **a mistyped Canon IP and a click on Save could kill the server**. So `.catch()` was added to all three. Canon request logic is otherwise unchanged.

## Verification

Commit 1: the committed VISCA block was extracted and run against a live UDP listener on 127.0.0.1:52381. Sony's own documented example frame (Preset 1 recall) reproduces byte-for-byte. Confirmed the reset consumes no sequence number, the sequence increments per command packet, and the length field tracks payload (`0007` vs `0008`).

Commit 2: lifecycle exercised with a `dgram` shim recording destination IPs — IP change extinguishes the old camera before lighting the new one, keepalive follows the new IP, model change `rg`→single extinguishes the orphan green, cleared fields tear down with no late sends, no double-close, no send-after-close.

`npx tsc --noEmit` clean.

## Known behaviour and open questions

- Changing **only the model** on a live camera (same IP, `rg` → single) produces a brief RED OFF → RED ON blink. Unavoidable if the green lamp must be extinguished during teardown, and only on a deliberate model change.
- **Port is not configurable** — fixed at 52381 per Sony's spec. Making it configurable means extending `Device`, the settings form and config migration; `VISCA_PORT` is a named constant if that day comes. Possibly relevant for the third-party clone in #967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
