### PR TITLE
fix(tricaster): address the matched input and remove rather than add on the off path

### DIFF
--- a/src/sources/NewtekTricaster.ts
+++ b/src/sources/NewtekTricaster.ts
@@ -180,16 +180,20 @@ export class NewtekTricasterSource extends TallyInput {
 					if (this.tallydata_TC[i].address === sourceArray[j]) {
 						tricasterSourceFound = true
 						//update the tally state because Tricaster is saying this source is in the current bus
+						//address the entry we actually matched: the match above is on sourceArray[j], and
+						//this.tallydata_TC[i].address is equal to it. Using sourceArray[i] indexed into the
+						//wrong array (i walks tallydata_TC, j walks sourceArray), so the bus landed on an
+						//unrelated input - or on undefined once tallydata_TC grew past the current bus list.
 						switch (tallyType) {
 							case 'preview_tally':
 								this.tallydata_TC[i].tally1 = 1
 								this.tallydata_TC[i].preview = 1
-								this.addBusToAddress(sourceArray[i], 'preview')
+								this.addBusToAddress(this.tallydata_TC[i].address, 'preview')
 								break
 							case 'program_tally':
 								this.tallydata_TC[i].tally2 = 1
 								this.tallydata_TC[i].program = 1
-								this.addBusToAddress(sourceArray[i], 'program')
+								this.addBusToAddress(this.tallydata_TC[i].address, 'program')
 								break
 							default:
 								break
@@ -202,16 +206,20 @@ export class NewtekTricasterSource extends TallyInput {
 			// Remove preview or program for each not used Tricaster input, in case it was earlier used.
 			if (!tricasterSourceFound) {
 				//it is no longer in the bus, mark it as such
+				//this branch is the "not on this bus" case, so it must REMOVE the bus, not add it. It
+				//previously called addBusToAddress, which lit the tally for an input Tricaster had just
+				//reported as absent. removeBusFromAllAddresses() at the top of this function has already
+				//cleared the bus, so this is belt-and-braces, but it keeps the branch honest.
 				switch (tallyType) {
 					case 'preview_tally':
 						this.tallydata_TC[i].tally1 = 0
 						this.tallydata_TC[i].preview = 0
-						this.addBusToAddress(sourceArray[i], 'preview')
+						this.removeBusFromAddress(this.tallydata_TC[i].address, 'preview')
 						break
 					case 'program_tally':
 						this.tallydata_TC[i].tally2 = 0
 						this.tallydata_TC[i].program = 0
-						this.addBusToAddress(sourceArray[i], 'program')
+						this.removeBusFromAddress(this.tallydata_TC[i].address, 'program')
 						break
 					default:
 						break


### PR DESCRIPTION
Fixes #1121 — but **please read the severity correction below**, because my original report of that issue overstated the impact.

## The two defects

In `processTricasterTally()` (`src/sources/NewtekTricaster.ts`), the outer loop indexes `i` over `this.tallydata_TC` while the inner indexes `j` over `sourceArray`:

1. **Both branches called `addBusToAddress(sourceArray[i])`** — indexing the wrong array. The match is established on `sourceArray[j]`.
2. **The unmatched branch called `addBusToAddress` at all.** That branch is the "this input is NOT on the bus" case; it zeroes the bookkeeping flags and then, on master, *adds* the bus.

## Severity correction

I originally reported this as "tally applied to the wrong input." **That does not actually happen**, and I was wrong to claim it.

Because `tallydata_TC` always contains every member of `sourceArray` (the registration loop directly above guarantees it), indices `0..sourceArray.length-1` are covered by one branch or the other — so every real bus member does get lit correctly. The two bugs cancel out on the visible outcome.

What genuinely goes wrong is everything past that index: `sourceArray[i]` resolves to `undefined`, and bus state accumulates against the literal address `"undefined"`, which then rides along in every tally emission and in the tally data log.

A sweep of all 65 bus-membership shapes over four inputs, run against the real `processTricasterTally` and the real `TallyInput` base class:

| | real inputs lit incorrectly | shapes polluting `"undefined"` |
|---|---|---|
| master | **0** / 65 | **50** / 65 |
| this PR | 0 / 65 | 0 / 65 |

So this is noise and dead state, not a tally correctness bug. Still worth fixing: the phantom address pollutes tally output, and an "off" branch that calls "add" is a landmine for anyone who later touches the `removeBusFromAllAddresses()` call at the top of the function that is currently masking it.

## The change

- Matched branch addresses `this.tallydata_TC[i].address`, which the enclosing condition has already proven equal to `sourceArray[j]`. Using the field rather than either loop variable removes the ambiguity that caused this.
- Unmatched branch switches to `removeBusFromAddress`. `removeBusFromAllAddresses()` at the top already clears the bus, so this is belt-and-braces — but it stops the branch from doing the opposite of what its comment says.

Four call sites, no other logic touched.

## Verification

`npx tsc --noEmit` clean; `prettier --check` clean. No hardware test — this was verified with a harness (not committed) that transpiles the real `NewtekTricaster.ts` and `_Source.ts` in memory, constructs the source without running its socket-opening constructor, and drives `processTricasterTally` directly with the real base-class bus methods and a stubbed `bus_options`. Worth a confirmation against a real Tricaster with more than two inputs before release.
