### PR TITLE
fix: carry tally state across when an address is renamed

### DIFF
--- a/src/sources/_Source.ts
+++ b/src/sources/_Source.ts
@@ -127,11 +127,29 @@ export class TallyInput extends EventEmitter {
 	protected renameAddress(address: string, newAddress: string, newLabel: string) {
 		this.emit('renameAddress', address, newAddress) //this is for source types where the address is used as a key and is not a fixed number, like OBS
 
+		//tallyData is keyed by address, so the busses have to move across with it. Without this the state
+		//stays stranded under the old key and the renamed address reads as having no tally until the source
+		//next emits for it - which, for a source that only emits on change, can be the rest of the shot.
+		//Several source types (TSL, SimplyLive, ContributionTally) call this with the same address on both
+		//sides purely to update the label, so there is nothing to move in that case.
+		if (address !== newAddress && Object.prototype.hasOwnProperty.call(this.tallyData, address)) {
+			//addBusToAddress/removeBusFromAddress lazily create tallyData[newAddress], so an event for the
+			//new name may already have landed before this rename was processed. That entry is newer than
+			//what we would carry over, so leave it alone and just drop the stale key.
+			if (!Object.prototype.hasOwnProperty.call(this.tallyData, newAddress)) {
+				this.tallyData[newAddress] = this.tallyData[address]
+			}
+			delete this.tallyData[address]
+		}
+
 		//first check to see if the address current label is the same as the new label
 		//if it is, don't update the label
 		let addressObj = this.addresses.value.find((a) => a.address === address)
 		if (addressObj) {
-			if (addressObj.label !== newLabel) {
+			//rewrite the entry if EITHER the address or the label changed. Gating on the label alone would
+			//leave the entry filed under the old address whenever a rename kept the same label, which would
+			//then disagree with the tallyData re-key above.
+			if (address !== newAddress || addressObj.label !== newLabel) {
 				this.addresses.next(
 					this.addresses.value.filter((a) => a.address !== address).concat({ address: newAddress, label: newLabel }),
 				)


### PR DESCRIPTION
Fixes #1123. Severity was verified before fixing — see [the analysis on the issue](https://github.com/josephdadams/TallyArbiter/issues/1123#issuecomment-5111090166).

## The defect

`TallyInput.renameAddress()` updated the `addresses` list and emitted the `renameAddress` event so `index.ts` could re-point device sources — but never touched `tallyData`, which is keyed by address. The busses stayed stranded under the old key and the renamed address had no state.

```
before rename: {"Scene A":["PGM"]}
after rename : {"Scene A":["PGM"]}
addresses    : ["Scene B"]
```

Impact is bounded: it self-corrects at the next transition on that address, and the stale key gets bus-cleared by the next `removeBusFromAllAddresses`. But rename a scene while it is parked on program and nothing else changes, and the gap lasts the length of the shot. Only OBS (3 call sites) actually changes an address — TSL, SimplyLive and ContributionTally all pass the same address on both sides to set a label.

## A second defect, fixed in the same change

The guard on the addresses list fired only when the **label** changed:

```ts
if (addressObj.label !== newLabel) {
```

A rename that kept the same label left the entry filed under the **old address**. No shipped caller does that today (OBS always passes the new name as the label), so it is unreachable — but the re-key above is gated on `address !== newAddress`, so leaving this would have let the two disagree and produce a state worse than the bug being fixed. Now fires when either the address or the label changes.

## Collision handling

`addBusToAddress`/`removeBusFromAddress` create `tallyData[address]` lazily, so an event for the new name can land before the rename is processed. When an entry already exists under the new name it is treated as newer, left alone, and only the stale key is dropped — rather than being overwritten with carried-over state or merged into a union that never existed on the wire.

## Verification

No test suite, so this was checked with a harness (not committed) that transpiles the real `_Source.ts` and drives the real `renameAddress` through a minimal `TallyInput` subclass, stubbing only `logger` and `bus_options`. `BASELINE=1` runs the same assertions against `origin/master`.

| scenario | master | this PR |
|---|---|---|
| rename while live on program | FAIL | PASS |
| stale key removed | FAIL | PASS |
| collision: newer entry under new name preserved | PASS | PASS |
| collision: stale key still removed | FAIL | PASS |
| label-only rename leaves tally alone | PASS | PASS |
| address changes, label unchanged | FAIL ×2 | PASS |
| renaming an address with no tally creates nothing | PASS | PASS |
| still self-corrects on the next transition | FAIL | PASS |

**master: 6 passed, 6 failed. This PR: 12 passed, 0 failed.**

`npx tsc --noEmit` clean, `prettier --check` clean. `_Source.ts` is the base class for every source type, so worth a smoke test on a real OBS setup — rename a scene while it is on program, in both the `rename: true` and `rename: false` device-source states.
