### PR TITLE
chore: drop master from workflow triggers now the rename is done

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,12 +1,10 @@
 name: CodeQL & Container Security
 
 on:
-  # Both names are listed so this keeps running either side of the master -> main
-  # rename. Drop `master` once the rename is done and verified.
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
   schedule:
     - cron: '0 6 * * 1' # Weekly scan
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,8 @@
 name: Docs
 
 on:
-  # Both names are listed so docs keep deploying either side of the master -> main
-  # rename. Drop `master` once the rename is done and verified.
   push:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ name: Format
 on:
   pull_request:
   push:
-    branches: [master, main]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Step 2 of the `master` → `main` rename, and the last of it.

The dual-branch triggers added in #1130 existed only to bridge the rename. `master` no longer exists, so listing it is dead config — carrying a comment that explicitly tells the next reader to remove it.

## Verified on `main` before removing

All three workflows have had a successful run on the renamed branch, so nothing being removed here is load-bearing:

| Workflow | Run on `main` |
|---|---|
| CodeQL & Container Security | ✅ success |
| Docs | ✅ success |
| Format | ✅ success |

That was the check the two-step approach existed to make possible — CodeQL and Docs both fail silently rather than erroring, so confirming they actually fire was the only way to know the rename had worked.

## Changes

| File | Change |
|---|---|
| `codeql-analysis.yml` | `push` and `pull_request` → `branches: [main]` |
| `docs.yml` | `push` → `branches: [main]` |
| `format.yml` | `push` → `branches: [main]` |

Plus the two bridging comments, which no longer apply. `format.yml`'s `pull_request` trigger has no branch filter and is untouched.

## Verified

- All three parse via `yaml.safe_load`, and each trigger block resolves to `main` only.
- **No `master` reference remains anywhere under `.github/`.**
- `npm run format:check` clean — this PR is gated by the Format workflow it modifies.

The three `master` references left in the repo are deliberate and point at other repositories: `obsproject/obs-websocket` in `src/sources/OBS.ts`, `Clashsoft/ng-bootstrap-darkmode` in the theme-selector template, and `josephdadams/USBRelay` in the relay listener readme.
