### PR TITLE
fix: patch transitive vulnerabilities in the server lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -335,9 +335,9 @@
 			}
 		},
 		"node_modules/@electron/universal/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+			"integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1525,9 +1525,9 @@
 			}
 		},
 		"node_modules/app-builder-lib": {
-			"version": "26.15.3",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
-			"integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+			"version": "26.15.7",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.7.tgz",
+			"integrity": "sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1577,8 +1577,8 @@
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"dmg-builder": "26.15.3",
-				"electron-builder-squirrel-windows": "26.15.3"
+				"dmg-builder": "26.15.7",
+				"electron-builder-squirrel-windows": "26.15.7"
 			}
 		},
 		"node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -2448,16 +2448,16 @@
 			}
 		},
 		"node_modules/compression": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-			"integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+			"integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"compressible": "~2.0.18",
 				"debug": "2.6.9",
 				"negotiator": "~0.6.4",
-				"on-headers": "~1.0.2",
+				"on-headers": "~1.1.0",
 				"safe-buffer": "5.2.1",
 				"vary": "~1.1.2"
 			},
@@ -2479,15 +2479,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
-		},
-		"node_modules/compression/node_modules/on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -2770,9 +2761,9 @@
 			"license": "ISC"
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -2815,13 +2806,13 @@
 			}
 		},
 		"node_modules/dmg-builder": {
-			"version": "26.15.3",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
-			"integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+			"version": "26.15.7",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.7.tgz",
+			"integrity": "sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"app-builder-lib": "26.15.3",
+				"app-builder-lib": "26.15.7",
 				"builder-util": "26.15.3",
 				"fs-extra": "^10.1.0",
 				"js-yaml": "^4.1.0"
@@ -2985,18 +2976,18 @@
 			}
 		},
 		"node_modules/electron-builder": {
-			"version": "26.15.3",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
-			"integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+			"version": "26.15.7",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.7.tgz",
+			"integrity": "sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"app-builder-lib": "26.15.3",
+				"app-builder-lib": "26.15.7",
 				"builder-util": "26.15.3",
 				"builder-util-runtime": "9.7.0",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
-				"dmg-builder": "26.15.3",
+				"dmg-builder": "26.15.7",
 				"fs-extra": "^10.1.0",
 				"lazy-val": "^1.0.5",
 				"simple-update-notifier": "2.0.0",
@@ -3011,14 +3002,14 @@
 			}
 		},
 		"node_modules/electron-builder-squirrel-windows": {
-			"version": "26.15.3",
-			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
-			"integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+			"version": "26.15.7",
+			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.7.tgz",
+			"integrity": "sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"app-builder-lib": "26.15.3",
+				"app-builder-lib": "26.15.7",
 				"builder-util": "26.15.3",
 				"electron-winstaller": "5.4.0"
 			}
@@ -3599,9 +3590,9 @@
 			}
 		},
 		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+			"integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3920,9 +3911,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -4467,9 +4458,9 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -5038,9 +5029,9 @@
 			}
 		},
 		"node_modules/mqtt/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -5392,9 +5383,9 @@
 			}
 		},
 		"node_modules/obs-websocket-js-5/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -5420,6 +5411,15 @@
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/on-headers": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -6597,19 +6597,36 @@
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-			"integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+			"integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "~4.3.4",
-				"ws": "~8.17.1"
+				"debug": "~4.4.1",
+				"ws": "~8.21.0"
+			}
+		},
+		"node_modules/socket.io-adapter/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -7680,9 +7697,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.3.0"


### PR DESCRIPTION
`npm audit fix` **without `--force`**, so `package.json` is untouched — no direct dependency changes, no major bumps. Purely transitive resolutions in the lockfile.

## What moved

| Package | Before | After |
|---|---|---|
| `ws` | 7.5.10 | 7.5.13 |
| `ws` (socket.io-adapter) | 8.17.1 | 8.21.1 |
| `ws` (obs-websocket-js-5) | 8.18.0 | 8.21.1 |
| `ws` (mqtt) | 8.18.3 | 8.21.1 |
| `js-yaml` | 4.2.0 | 4.3.0 |
| `on-headers` | 1.0.2 | 1.1.0 (hoisted out of `compression`) |
| `brace-expansion` (glob) | 1.1.14 | 1.1.16 |

`npm audit` total: **27 → 22** (high 22 → 21, moderate 2 → 1, low 3 → 0).

## Two `ws` copies deliberately remain

Both are pinned by their parent's semver range and cannot move without `--force`:

| Copy | Version | Role |
|---|---|---|
| `engine.io-client` | 8.2.3 | cloud relay, **outbound** |
| `osc` | 8.18.0 | OSC control, **outbound** |

Both are outbound clients connecting to equipment on the operator's own network, not listeners accepting untrusted input. Exploiting them would require already controlling your switcher or cloud endpoint.

Worth stating plainly, because "5 open HIGH alerts on `ws`" reads much worse than the reality: **the copy that terminates inbound listener-client WebSockets is `engine.io`'s, and it was already at 8.21.1 before this change** — above every patched version. The inbound attack surface was never affected.

## What was noise

`brace-expansion` and `js-yaml` are build-chain only. `brace-expansion`'s vulnerable copies sit under `@electron/asar`, `dir-compare`, `glob` and `filelist` — packaging time. And nothing in `src/` parses YAML at all (config is JSON); the only YAML read at runtime is your own `dev-app-update.yml`. Bumped anyway since it was free.

## Verified

- `package.json` unchanged — confirmed, not assumed.
- A clean `npm ci` from the new lockfile succeeds.
- `tsc --noEmit` passes **against the freshly installed tree**, not the old one.

## Not verified — please read

**No smoke test against live hardware.** `ws`, `mqtt` and `obs-websocket-js-5` are all directly in the tally path, and `ws` moved by four minor versions under three different parents. I deliberately did not boot the server to test, because it writes to the shared app-data config folder and could have clobbered a real configuration.

This wants a run against a real source — ideally OBS and one other — before it goes into a release.
