### PR TITLE
fix(ci): bump M5StickC-Plus library to 0.1.1 to unbreak the Plus build

### DIFF
--- a/.github/workflows/build-listener-clients.yaml
+++ b/.github/workflows/build-listener-clients.yaml
@@ -40,7 +40,7 @@ jobs:
             sketch: listener_clients/m5stickc-listener
             libraries: |
               - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
-              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
+              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.1.zip
               - name: WebSockets
               - name: WiFiManager
               - name: MultiButton
@@ -59,7 +59,7 @@ jobs:
             sketch: listener_clients/m5stickc-listener
             libraries: |
               - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
-              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
+              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.1.zip
               - name: WebSockets
               - name: WiFiManager
               - name: MultiButton
@@ -76,7 +76,7 @@ jobs:
             sketch: listener_clients/m5stickc-listener
             libraries: |
               - source-url: https://github.com/m5stack/M5StickC/archive/refs/tags/0.3.0.zip
-              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.0.zip
+              - source-url: https://github.com/m5stack/M5StickC-Plus/archive/refs/tags/0.1.1.zip
               - name: M5StickCPlus2
               - name: WebSockets
               - name: WiFiManager


### PR DESCRIPTION
The **M5StickC-Plus listener job has been failing on every run since #1113 merged.** My regression — adding the board to the matrix made the sketch include `M5StickCPlus.h` in CI for the first time, and the pinned `0.1.0` does not lex under the esp32 core the runner resolves (3.3.11).

```
M5StickCPlus.h:119:8: error: extended character “ is not valid in an identifier
  119 | #error “This library only supports boards with ESP32 processor.”
```

`0.1.0` wrote that line with **smart quotes**. It sits in an `#else` branch that is not taken on ESP32, but modern GCC still lexes skipped blocks and rejects the extended characters. `0.1.1` (Feb 2025) uses straight quotes. Verified by diffing the header between the two tags — that is the entire difference that matters here.

## Scope

Bumped in all three entries that pin the library, not just the failing one, so the plain M5StickC and Plus2 jobs cannot drift onto a different version of the same dependency. Neither of those ever includes the header, which is why only the Plus job went red.

## Current job status on main

| Job | Result |
|---|---|
| M5StickC | ✅ |
| **M5StickC-Plus** | ❌ **this PR** |
| M5StickC-Plus2 | ✅ |
| M5StickS3 | ✅ |

Worth noting the Plus2 job — the one #850 actually needed — has been passing throughout.

## Verification

Cannot be checked locally: no Arduino toolchain here, and the failure only reproduces against the core version the runner resolves. **CI on this PR is the test.** If `0.1.1` turns out to have its own incompatibility with core 3.3.11, the fallback is migrating the Plus path to M5Unified as the M5StickS3 listener already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)