### PR TITLE
fix: npm start crashes at import with "Cannot access 'io' before initialization"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,16 @@ const listenPort: number = parseInt(process.env.PORT) || 4455
 const app = express()
 const httpServer = new http.Server(app)
 
+//Set to true immediately after `io` is constructed below. `var` rather than `let` so it is hoisted
+//and readable (as undefined) from logger() during module evaluation, before this line is reached.
+var ioReady = false
+
 const io = new socketio.Server(httpServer, { allowEIO3: true })
+//logger() can run during module evaluation, before the line above has executed. It cannot test
+//`io` directly to find out: `io` is a const, so it is in the temporal dead zone until then and
+//even `typeof io` throws a ReferenceError rather than returning 'undefined'. This flag is a
+//plain assignment after initialisation, which is safe to read at any point.
+ioReady = true
 const socketupdates_Settings: string[] = [
 	'sources',
 	'devices',
@@ -1583,7 +1592,7 @@ export function logger(log, type: 'info-quiet' | 'info' | 'error' | 'console_act
 	logObj.log = log
 	logObj.type = type
 	Logs.push(logObj)
-	if (typeof io !== 'undefined') io.to('settings').emit('log_item', logObj)
+	if (ioReady) io.to('settings').emit('log_item', logObj)
 }
 
 function writeTallyDataFile(log) {


### PR DESCRIPTION
`npm start` — `ts-node-dev src/index.ts --dev`, the documented dev workflow — has been dying before the server boots:

```
ReferenceError: Cannot access 'io' before initialization
    at logger (src/index.ts:1586)
    at Object.<anonymous> (src/index.ts:95)
```

Found while building #112; unrelated to that work, so it is here on its own.

## Root cause

`logger()` guarded its socket emit with:

```ts
if (typeof io !== 'undefined') io.to('settings').emit('log_item', logObj)
```

That idiom is only safe for a variable that was **never declared**. `io` *is* declared — as a `const` further down the module — so at line 95 it is in the temporal dead zone, and `typeof` on a TDZ binding **throws a ReferenceError** instead of returning `'undefined'`.

So the guard caused the exact failure it was written to prevent, for any `logger()` call during module evaluation. Line 95 (`if (devmode) logger('TallyArbiter running in Development Mode.', 'info')`) is one such call, which is why this only bites in dev mode.

## Fix

An explicit `ioReady` flag, declared with `var` so it is hoisted and readable as `undefined` before its initialiser runs, and set to `true` immediately after `io` is constructed. The guard's intent — "only emit if the socket server exists yet" — is preserved, without depending on `typeof` semantics.

I fixed the guard rather than moving the line 95 call, because the guard exists precisely because `logger()` can run before `io` is constructed; moving one call would leave the trap set for the next one.

## Verified

Ran `ts-node-dev` against a throwaway `HOME` so no real config was touched:

- **on `main`** — reproduces, dies at import
- **with this change** — boots through OSC setup, config load, uuid/JWT generation and user migration

`tsc --noEmit` clean, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)