### PR TITLE
feat: add a server-wide option to disable chat

### DIFF
--- a/UI/src/app/_components/producer/producer.component.html
+++ b/UI/src/app/_components/producer/producer.component.html
@@ -72,7 +72,7 @@
 			</div>
 			<hr class="my-3" />
 		</div>
-		<div class="col-md-6 col-xs-12 chat my-3">
+		<div class="col-md-6 col-xs-12 chat my-3" *ngIf="socketService.chatEnabled">
 			<h3>Chat</h3>
 			<app-chat type="producer" class="p-3"></app-chat>
 		</div>

--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -108,6 +108,27 @@
 			<a ngbNavLink>Listeners</a>
 			<ng-template ngbNavContent>
 				<div class="row">
+					<h3>Chat</h3>
+					<div>
+						<div class="form-check form-switch">
+							<input
+								class="form-check-input"
+								type="checkbox"
+								id="chkChatEnabled"
+								[(ngModel)]="socketService.chatEnabled"
+								(ngModelChange)="socketService.socket.emit('chat_enabled', $event)"
+							/>
+							<label class="form-check-label" for="chkChatEnabled">Enable Chat</label>
+						</div>
+						<span class="text-muted mt-3 d-block"
+							>Allows the Producer page and supported listener clients to exchange messages. When turned off, the chat
+							box is hidden and the server rejects any messages sent to it. Connect/disconnect and test mode notices are
+							still delivered.</span
+						>
+					</div>
+				</div>
+				<hr class="my-5" />
+				<div class="row">
 					<h3>Connected Listeners</h3>
 					<span class="text-muted mt-3" *ngIf="socketService.listenerClients.length == 0">No listeners connected.</span>
 					<div class="table-responsive">

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -1072,6 +1072,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 				{ id: '3011d34a', label: 'Aux 8', type: 'aux', color: '#0000FF', priority: 100, visible: false },
 			],
 			externalAddress: 'http://0.0.0.0:4455/#/tally',
+			chat_enabled: true,
 			remoteErrorReporting: false,
 			uuid: '',
 			mqtt: {

--- a/UI/src/app/_components/tally/tally.component.html
+++ b/UI/src/app/_components/tally/tally.component.html
@@ -17,7 +17,7 @@
 		</div>
 		<div class="row">
 			<div class="col-xs-12">
-				<div class="form-check" *ngIf="socketService.devices.length > 0">
+				<div class="form-check" *ngIf="socketService.devices.length > 0 && socketService.chatEnabled">
 					<input
 						class="form-check-input"
 						type="checkbox"
@@ -46,7 +46,7 @@
 		</div>
 		<div class="container flex-fill py-4" style="min-height: 50px">
 			<app-chat
-				*ngIf="route.snapshot.queryParams.chat !== 'false'"
+				*ngIf="socketService.chatEnabled && route.snapshot.queryParams.chat !== 'false'"
 				[type]="socketService.devices[currentDeviceIdx].name"
 			></app-chat>
 		</div>

--- a/UI/src/app/_services/socket.service.ts
+++ b/UI/src/app/_services/socket.service.ts
@@ -58,6 +58,9 @@ export class SocketService {
 	public testModeOn = false
 	public testModeInterval: number = 1000
 	public tslclients_1secupdate?: boolean
+	//server-wide chat switch. optimistic default of true so the chat UI isn't hidden
+	//for the moment between page load and the server telling us the real value
+	public chatEnabled = true
 	public deviceSources: DeviceSource[] = []
 	public addresses: Addresses = {}
 	public deviceActions: DeviceAction[] = []
@@ -357,6 +360,9 @@ export class SocketService {
 		})
 		this.socket.on('tslclients_1secupdate', (value: boolean) => {
 			this.tslclients_1secupdate = value
+		})
+		this.socket.on('chat_enabled', (value: boolean) => {
+			this.chatEnabled = value
 		})
 		this.socket.on('PortsInUse', (ports: Port[]) => {
 			this.portsInUse = ports

--- a/docs/docs/usage/sections/listener-clients.md
+++ b/docs/docs/usage/sections/listener-clients.md
@@ -14,7 +14,17 @@ Navigate to `/tally` on the Tally Arbiter server in your browser and select a De
 
 **You can also go to `/#/tally/9fe2efd9a` (replace `9fe2efd9a` with your actual DeviceId) and auto load the page to that Device without having to choose it from the list.**
 
-If you include `?chat=false` to the request, you can turn off the Messaging/Chat functions.
+If you include `?chat=false` to the request, you can turn off the Messaging/Chat functions for that page only.
+
+## Turning chat off for the whole server
+
+Chat is on by default. To turn it off for everyone, go to **Settings > Listeners** and switch off **Enable Chat**. This is stored in `config.json` as `chat_enabled` and survives a restart; a config file that predates this option has no such key and is treated as enabled, so nothing changes for existing installations.
+
+While chat is off, the chat box is hidden on the `/tally` and `/producer` pages, connected clients are told chat is unavailable, and the server rejects any messages sent to it — including messages sent straight to an individual listener client or relayed in from a cloud connection. Turning it back on takes effect immediately; clients do not need to reconnect.
+
+Connect/disconnect and test mode notices are not chat, so they are still delivered to the pages that show them.
+
+The per-page `?chat=false` described above still works as a local override: it hides chat on that one page even when chat is enabled server-wide. It cannot re-enable chat when the server has it switched off.
 
 ## Viewing all tally data
 

--- a/src/_helpers/chat.ts
+++ b/src/_helpers/chat.ts
@@ -1,0 +1,16 @@
+import { Config } from '../_models/Config'
+
+/**
+ * Server-wide chat switch.
+ *
+ * Chat is enabled by default: a config written before this option existed has no
+ * `chat_enabled` key at all, and those installs must keep working exactly as they
+ * did. Only an explicit `false` turns chat off, so a missing (or otherwise
+ * non-boolean) value always reads as enabled.
+ *
+ * Deliberately dependency-free so it can be used from anywhere without dragging
+ * the server entrypoint in.
+ */
+export function isChatEnabled(config: Pick<Config, 'chat_enabled'> | undefined | null): boolean {
+	return config?.chat_enabled !== false
+}

--- a/src/_helpers/config.ts
+++ b/src/_helpers/config.ts
@@ -47,6 +47,7 @@ export const ConfigDefaults: Config = {
 		{ id: '3011d34a', label: 'Aux 8', type: 'aux', color: '#0000FF', priority: 100, visible: false },
 	],
 	externalAddress: 'http://0.0.0.0:4455/#/tally',
+	chat_enabled: true,
 	remoteErrorReporting: false,
 	uuid: '',
 	mqtt: {

--- a/src/_helpers/configSchema.ts
+++ b/src/_helpers/configSchema.ts
@@ -276,6 +276,11 @@ export default {
 			description: 'Enable the TSL Clients 1secupdate option',
 			type: 'boolean',
 		},
+		chat_enabled: {
+			description: 'Enable the Producer/Listener chat (messaging) feature server-wide',
+			type: 'boolean',
+			default: true,
+		},
 		remoteErrorReporting: {
 			description: 'Enable remote error reporting',
 			type: 'boolean',

--- a/src/_models/Config.ts
+++ b/src/_models/Config.ts
@@ -23,6 +23,10 @@ export interface Config {
 	cloud_destinations: CloudDestination[]
 	cloud_keys: string[]
 	bus_options: BusOption[]
+	//server-wide chat on/off switch. absent in configs written before this option
+	//existed, which must keep behaving as "on", so treat only an explicit `false`
+	//as disabled (see isChatEnabled in _helpers/chat.ts)
+	chat_enabled?: boolean
 	remoteErrorReporting: boolean
 	mqtt?: ConfigMQTT
 }

--- a/src/_models/MessageListenerClientResponse.ts
+++ b/src/_models/MessageListenerClientResponse.ts
@@ -1,5 +1,5 @@
 export interface MessageListenerClientResponse {
 	result: 'message-sent-successfully' | 'message-not-sent'
 	listenerClientId: string | { relayGroupId?: string; gpoGroupId?: string }
-	error?: 'listener-client-not-supported' | 'listener-client-not-found'
+	error?: 'listener-client-not-supported' | 'listener-client-not-found' | 'chat-disabled'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import { UsePort } from './_decorators/UsesPort.decorator'
 import { secondsToHms } from './_helpers/time'
 import { currentConfig, getConfigRedacted, readConfig, SaveConfig, replaceConfig } from './_helpers/config'
 import { validateConfig } from './_helpers/configValidator'
+import { isChatEnabled } from './_helpers/chat'
 import {
 	deleteEveryErrorReport,
 	generateErrorReport,
@@ -305,6 +306,10 @@ function initialSetup() {
 	io.sockets.on('connection', (socket) => {
 		const ipAddr = socket.handshake.address
 
+		//tell every socket up front whether chat is available on this server, so the
+		//tally/producer pages can hide it and listener clients know not to offer it
+		socket.emit('chat_enabled', isChatEnabled(currentConfig))
+
 		const requireRole = (role: string) => {
 			return new Promise((resolve, reject) => {
 				if (typeof tmpSocketAccessTokens[socket.id] === 'undefined') {
@@ -525,11 +530,19 @@ function initialSetup() {
 				supportsChat,
 			)
 
+			//room membership tracks the client's own capability, not the server-wide
+			//switch: the room also carries operational notices, and keeping membership
+			//stable means flipping chat back on takes effect without a reconnect.
+			//Chat itself is blocked at the ingress points instead.
 			if (supportsChat) {
 				socket.join('messaging')
 			} else {
 				socket.leave('messaging')
 			}
+
+			//re-state the server-wide switch now that the client has declared it supports
+			//chat, so a listener client is never told chat is available when it isn't
+			socket.emit('chat_enabled', isChatEnabled(currentConfig))
 
 			socket.emit('bus_options', currentConfig.bus_options)
 			socket.emit('devices', devices)
@@ -574,6 +587,7 @@ function initialSetup() {
 					socket.emit('PortsInUse', PortsInUse.value)
 					socket.emit('networkDiscovery', RegisteredNetworkDiscoveryServices.value)
 					socket.emit('tslclients_1secupdate', currentConfig.tsl_clients_1secupdate)
+					socket.emit('chat_enabled', isChatEnabled(currentConfig))
 				})
 				.catch((e) => {
 					console.error(e)
@@ -1120,7 +1134,29 @@ function initialSetup() {
 				})
 		})
 
+		socket.on('chat_enabled', (value: boolean) => {
+			requireRole('settings:listeners')
+				.then((user) => {
+					currentConfig.chat_enabled = value === true
+					SaveConfig()
+					//everyone needs to know, not just the settings page that flipped it:
+					//tally/producer pages hide the chat UI off the back of this
+					io.emit('chat_enabled', isChatEnabled(currentConfig))
+					logger(`Chat has been ${isChatEnabled(currentConfig) ? 'enabled' : 'disabled'}.`, 'info')
+				})
+				.catch((err) => {
+					logger(err, 'error')
+				})
+		})
+
 		socket.on('messaging', (type: string, message: string) => {
+			//this handler is unauthenticated by design (any tally client can chat), so the
+			//server-wide switch has to be enforced here or the toggle would be cosmetic
+			if (!isChatEnabled(currentConfig)) {
+				logger(`Chat message from ${ipAddr} rejected: chat is disabled on this server.`, 'info-quiet')
+				socket.emit('error', 'Chat is disabled on this server.')
+				return
+			}
 			SendMessage(type, socket.id, message)
 		})
 
@@ -1242,7 +1278,11 @@ function initialSetup() {
 
 	const providers = [vMixEmulator, tslListenerProvider]
 	for (const provider of providers as ListenerProvider[]) {
-		provider.on('chatMessage', (type, socketId, message) => SendMessage(type, socketId, message))
+		//vMix/TSL listener providers can originate chat too, so they get the same gate
+		provider.on('chatMessage', (type, socketId, message) => {
+			if (!isChatEnabled(currentConfig)) return
+			SendMessage(type, socketId, message)
+		})
 		provider.on('updateSockets', (type) => {
 			UpdateSockets(type)
 			UpdateCloud(type)
@@ -2999,6 +3039,13 @@ function MessageListenerClient(
 	socketid: string,
 	message: string,
 ): MessageListenerClientResponse | void {
+	//single choke point for the direct-to-listener relay: both the producer's
+	//`messaging_client` handler and the inbound cloud relay funnel through here, so
+	//blocking the `messaging` room alone would have left this path wide open
+	if (!isChatEnabled(currentConfig)) {
+		return { result: 'message-not-sent', listenerClientId: listenerClientId, error: 'chat-disabled' }
+	}
+
 	let listenerClientObj = listener_clients.find(({ id }) => id === listenerClientId)
 
 	if (listenerClientObj) {
@@ -3501,6 +3548,13 @@ function CheckListenerClients() {
 }
 
 function SendMessage(type: string, socketid: string | null, message: string) {
+	//backstop for the outbound fan-out. `type === 'server'` is not chat: those are
+	//operational notices (test mode on/off, listener client connect/disconnect) that
+	//an operator still needs to see, so they are deliberately let through when chat is
+	//off. Anything else is a person talking and gets dropped.
+	if (type !== 'server' && !isChatEnabled(currentConfig)) {
+		return
+	}
 	io.to('messaging').emit('messaging', type, socketid, message)
 }
 


### PR DESCRIPTION
Closes #112.

Adds `chat_enabled` to the config, toggleable from Settings → Listeners. Default **enabled**, so existing installs are unchanged.

## Enforced on the server, not just hidden in the UI

This is the part that matters. `socket.on('messaging')` is unauthenticated by design, so a UI-only toggle would be bypassable by any socket. Five enforcement points:

| Path | Behaviour when off |
|---|---|
| `socket.on('messaging')` | rejected, sender told "Chat is disabled on this server." |
| `MessageListenerClient()` | early return `{result:'message-not-sent', error:'chat-disabled'}` |
| `provider.on('chatMessage')` | vMix/TSL listener providers gated |
| `SendMessage()` | backstop — drops anything where `type !== 'server'` |
| `socket.on('chat_enabled')` | behind `requireRole('settings:listeners')`, persists, broadcasts |

The `messaging_client` relay and the **cloud** inbound relay are closed at `MessageListenerClient()` rather than at each call site, so both are covered by one check and any future caller inherits it. Those are its only two callers, and there is no REST endpoint for it.

## Decisions

**`?chat=false` is kept as a per-page override, not replaced.** Effective visibility is `chatEnabled && queryParams.chat !== 'false'` — the param can still hide chat on one page while the server allows it, but cannot re-enable chat when the server has it off. The tally device picker's "Enable Chat" checkbox is hidden when chat is globally off, since it would be meaningless.

**System notices still get through.** `SendMessage('server', null, …)` also carries test-mode on/off and listener-client connect/disconnect — operational status an operator needs, not chat. The `type !== 'server'` condition is where that decision is written down.

**Clients are not kicked out of the `messaging` room mid-session.** Blocking at ingress is sufficient, and leaving membership alone is better: the room also carries those operational notices, and re-enabling then takes effect with no reconnect. Room membership keeps meaning "this client supports chat", not "chat is on".

`chat_enabled` is also emitted on connect, on `listenerclient_connect`, and in the settings `initialdata` burst, so a chat-capable listener is never told chat is available when it isn't.

## Backwards compatibility, proven

A config written before this change has no `chat_enabled` key. `readConfig()` spreads `ConfigDefaults` first so it picks up `true`, and `isChatEnabled` only treats an explicit `false` as off — so even a hand-mangled config can't read as disabled by accident. The key is deliberately **not** in the JSON schema's `required` list, so `validateConfig()` still accepts old configs.

## Verification

A scratch harness boots the **real** `src/index.ts` against a throwaway `HOME` seeded with a pre-change config, then drives it over real socket.io connections — including logging in as `admin` and toggling through the genuine authenticated path rather than mutating `currentConfig`. **21/21 checks pass**, covering: absent-key defaults, schema acceptance, persistence to disk, nothing emitted while off, the sender being told why, an already-joined client still blocked, operational notices still flowing, and re-enabling working without a reconnect.

`tsc --noEmit` clean, `format:check` clean, and a full `ng build` succeeds — worth running since `tsc` alone does not check Angular templates.

## Not verified

No test against real listener client hardware (M5Stick etc.) to confirm they handle being told `chat_enabled: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)