### PR TITLE
feat: duplicate a device (with its sources and actions) or a single action

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -700,6 +700,13 @@
 						<button class="btn btn-sm btn-secondary mx-1 my-1" (click)="editDeviceActions(device, deviceActionsModal)">
 							<i class="fas fa-play"></i> Edit Actions ({{ getDeviceActionsByDeviceId(device.id).length }})
 						</button>
+						<button
+							class="btn btn-sm btn-secondary mx-1 my-1"
+							title="Create a copy of this device, along with its sources and actions. The copy is created disabled and without a TSL address."
+							(click)="duplicateDevice(device)"
+						>
+							<i class="fas fa-copy"></i> Duplicate
+						</button>
 						<button class="btn btn-sm btn-danger mx-1 my-1" (click)="deleteDevice(device)">
 							<i class="fas fa-trash"></i> Delete
 						</button>
@@ -1066,6 +1073,13 @@
 							<td>
 								<button class="btn btn-sm btn-secondary mx-1 my-1" (click)="editDeviceAction(deviceAction)">
 									<i class="fas fa-pen"></i> Edit
+								</button>
+								<button
+									class="btn btn-sm btn-secondary mx-1 my-1"
+									title="Create a copy of this action on this device."
+									(click)="duplicateDeviceAction(deviceAction)"
+								>
+									<i class="fas fa-copy"></i> Duplicate
 								</button>
 								<button class="btn btn-sm btn-danger mx-1 my-1" (click)="deleteDeviceAction(deviceAction)">
 									<i class="fas fa-trash"></i> Delete

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -205,6 +205,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 				this.scrollToBottom(this.logsContainer)
 			}),
 		)
+		this.subscriptions.push(this.socketService.deviceDuplicated.subscribe(() => this.onDeviceDuplicated()))
 		if (this.authService.requireRole('admin')) {
 			this.socketService.socket.on('server_error', this.handleServerError)
 			this.socketService.socket.on('unread_error_reports', this.handleUnreadErrorReports)
@@ -428,6 +429,46 @@ export class SettingsComponent implements OnInit, OnDestroy {
 			action: 'delete',
 			type: 'device',
 			deviceId: device.id,
+		}
+		this.socketService.socket.emit('manage', arbiterObj)
+	}
+
+	// Creates the copy straight away rather than opening a pre-filled Add Device modal. The user's
+	// flow is "duplicate this camera five times, then tweak each one": a modal would force them
+	// through a save dialog before they even have the copy, and it could only ever cover the device's
+	// own fields - the device sources and device actions that make the duplicate worth having are
+	// edited from two entirely different modals anyway. Creating immediately also means five clicks
+	// gets five copies, and they can edit them in any order afterwards.
+	public duplicateDevice(device: Device) {
+		const arbiterObj = {
+			action: 'duplicate',
+			type: 'device',
+			deviceId: device.id,
+		}
+		this.socketService.socket.emit('manage', arbiterObj)
+	}
+
+	private onDeviceDuplicated() {
+		Swal.fire({
+			icon: 'success',
+			title: 'Device duplicated',
+			text: 'Its sources and actions were copied too. The copy is disabled and has no TSL address until you edit it.',
+			toast: true,
+			position: 'top-end',
+			showConfirmButton: false,
+			timer: 6000,
+			timerProgressBar: true,
+			...globalSwalOptions,
+		})
+	}
+
+	public duplicateDeviceAction(deviceAction: DeviceAction) {
+		const arbiterObj = {
+			action: 'duplicate',
+			type: 'device_action',
+			device_action: {
+				id: deviceAction.id,
+			},
 		}
 		this.socketService.socket.emit('manage', arbiterObj)
 	}

--- a/UI/src/app/_services/socket.service.ts
+++ b/UI/src/app/_services/socket.service.ts
@@ -88,6 +88,7 @@ export class SocketService {
 	public scrollChatSubject = new Subject<void>()
 	public closeModals = new Subject<void>()
 	public deviceStateChanged = new Subject<DeviceState[]>()
+	public deviceDuplicated = new Subject<void>()
 
 	constructor(private connLostSnackbar: connLostSnackbarService) {
 		this.socket = io()
@@ -291,6 +292,16 @@ export class SocketService {
 					this.socket.emit('device_states')
 					this.socket.emit('listener_clients')
 					break
+				//deliberately not grouped with device-added: duplicating happens from the devices table
+				//with no modal open, and the copy is created disabled, which the user needs telling about
+				case 'device-duplicated-successfully':
+					this.socket.emit('devices')
+					this.socket.emit('device_sources')
+					this.socket.emit('device_actions')
+					this.socket.emit('device_states')
+					this.socket.emit('listener_clients')
+					this.deviceDuplicated.next()
+					break
 				case 'device-source-added-successfully':
 				case 'device-source-edited-successfully':
 					this.socket.emit('device_sources')
@@ -303,6 +314,12 @@ export class SocketService {
 				case 'device-action-edited-successfully':
 				case 'device-action-deleted-successfully':
 					this.closeModals.next()
+					this.socket.emit('devices')
+					this.socket.emit('device_actions')
+					break
+				//no closeModals here: duplicating is done from inside the still-open device actions
+				//modal, and closing it would fight the "duplicate, tweak, duplicate again" flow
+				case 'device-action-duplicated-successfully':
 					this.socket.emit('devices')
 					this.socket.emit('device_actions')
 					break

--- a/src/_helpers/duplicate.ts
+++ b/src/_helpers/duplicate.ts
@@ -1,0 +1,101 @@
+import { Device } from '../_models/Device'
+import { DeviceAction } from '../_models/DeviceAction'
+import { DeviceSource } from '../_models/DeviceSource'
+import { clone } from './clone'
+import { uuidv4 } from './uuid'
+
+export interface DuplicatedDevice {
+	device: Device
+	device_sources: DeviceSource[]
+	device_actions: DeviceAction[]
+}
+
+// "Camera 1" -> "Camera 1 (copy)" -> "Camera 1 (copy 2)" -> ...
+// An existing copy suffix is stripped first, so duplicating a duplicate gives "Camera 1 (copy 2)"
+// rather than "Camera 1 (copy) (copy)". Names are not a key anywhere (ids are), but a list of six
+// identically named devices is exactly the thing this feature is supposed to save the user from.
+export function generateDuplicateName(name: string, existingNames: string[]): string {
+	const base = (name || '').replace(/\s*\(copy(?:\s+\d+)?\)\s*$/i, '').trim() || 'Untitled'
+
+	let candidate = `${base} (copy)`
+	let counter = 2
+
+	while (existingNames.includes(candidate)) {
+		candidate = `${base} (copy ${counter})`
+		counter++
+	}
+
+	return candidate
+}
+
+// Every field is listed explicitly rather than spread, for two reasons: volatile fields
+// (outputTypeIdx here, listenerCount/modePreview/modeProgram/cloudClientId on Device) describe the
+// original's live state and must not ride along, and `data` is an arbitrary nested object that has
+// to be deep copied. Spreading would alias it, so editing the copy's action data would silently
+// rewrite the original's.
+export function buildDuplicateDeviceAction(sourceAction: DeviceAction, deviceId: string): DeviceAction {
+	return {
+		id: uuidv4(),
+		deviceId: deviceId,
+		busId: sourceAction.busId,
+		active: sourceAction.active,
+		outputTypeId: sourceAction.outputTypeId,
+		data: clone(sourceAction.data ?? {}),
+	}
+}
+
+export function buildDuplicateDeviceSource(sourceDeviceSource: DeviceSource, deviceId: string): DeviceSource {
+	return {
+		id: uuidv4(),
+		deviceId: deviceId,
+		sourceId: sourceDeviceSource.sourceId,
+		address: sourceDeviceSource.address,
+		bus: sourceDeviceSource.bus,
+		rename: sourceDeviceSource.rename,
+		reconnect_interval: sourceDeviceSource.reconnect_interval,
+		max_reconnects: sourceDeviceSource.max_reconnects,
+	}
+}
+
+// Builds the whole cascade a device duplicate implies - the device plus its device sources and
+// device actions - as the mirror image of the cascade TallyArbiter_Delete_Device tears down.
+// Returns new objects only; the caller is responsible for committing them to the live arrays.
+export function buildDuplicateDevice(
+	sourceDevice: Device,
+	allDeviceSources: DeviceSource[],
+	allDeviceActions: DeviceAction[],
+	existingDeviceNames: string[],
+): DuplicatedDevice {
+	const device: Device = {
+		id: uuidv4(),
+		name: generateDuplicateName(sourceDevice.name, existingDeviceNames),
+		description: sourceDevice.description,
+		// A TSL address identifies the device to every connected TSL client. Two devices sharing one
+		// address would both drive the same physical display, with whichever updated last winning, so
+		// the copy starts with no address and the user assigns a free one when they edit it.
+		tslAddress: '',
+		// The copy points at the original's sources until the user re-points it. Leaving it enabled
+		// would mean creating it immediately fires a second set of actions off the original camera's
+		// tally - real relays and lights, on a live system. It is created disabled and the user
+		// enables it once it is configured.
+		enabled: false,
+		// new array: sharing the reference would make editing either device's linked busses edit both
+		linkedBusses: [...(sourceDevice.linkedBusses || [])],
+		cameraIP: sourceDevice.cameraIP,
+		cameraModel: sourceDevice.cameraModel,
+		// cloud ownership and the volatile live-state fields (listenerCount, modePreview, modeProgram)
+		// describe the original and are deliberately not carried over
+		cloudConnection: false,
+		cloudClientId: undefined,
+	}
+
+	const device_sources = allDeviceSources
+		.filter((deviceSource) => deviceSource.deviceId === sourceDevice.id)
+		.map((deviceSource) => buildDuplicateDeviceSource(deviceSource, device.id))
+
+	const device_actions = allDeviceActions
+		.filter((deviceAction) => deviceAction.deviceId === sourceDevice.id)
+		.map((deviceAction) => buildDuplicateDeviceAction(deviceAction, device.id))
+
+	return { device, device_sources, device_actions }
+}

--- a/src/_models/Manage.ts
+++ b/src/_models/Manage.ts
@@ -19,7 +19,7 @@ export interface Manage {
 		| 'cloud_key'
 		| 'cloud_client'
 		| 'user'
-	action: 'add' | 'edit' | 'delete' | 'remove'
+	action: 'add' | 'edit' | 'delete' | 'duplicate' | 'remove'
 
 	source?: Source
 	sourceId?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { Actions } from './_globals/Actions'
 
 // Helpers
 import { uuidv4 } from './_helpers/uuid'
+import { buildDuplicateDevice, buildDuplicateDeviceAction } from './_helpers/duplicate'
 import { logFilePath, Logs, serverLogger, tallyLogger } from './_helpers/logger'
 import { getNetworkInterfaces } from './_helpers/networkInterfaces'
 import { loadClassesFromFolder } from './_helpers/fileLoader'
@@ -1851,6 +1852,8 @@ function TallyArbiter_Manage(obj: Manage, access_token: string = ''): Promise<Ma
 						result = TallyArbiter_Edit_Device(obj)
 					} else if (obj.action === 'delete') {
 						result = TallyArbiter_Delete_Device(obj)
+					} else if (obj.action === 'duplicate') {
+						result = TallyArbiter_Duplicate_Device(obj)
 					}
 					break
 				case 'device_source':
@@ -1871,6 +1874,8 @@ function TallyArbiter_Manage(obj: Manage, access_token: string = ''): Promise<Ma
 						result = TallyArbiter_Edit_Device_Action(obj)
 					} else if (obj.action === 'delete') {
 						result = TallyArbiter_Delete_Device_Action(obj)
+					} else if (obj.action === 'duplicate') {
+						result = TallyArbiter_Duplicate_Device_Action(obj)
 					}
 					break
 				case 'tsl_client':
@@ -2362,6 +2367,57 @@ function TallyArbiter_Delete_Device(obj: Manage): ManageResponse {
 	return { result: 'device-deleted-successfully' }
 }
 
+// The mirror image of TallyArbiter_Delete_Device's cascade: a device on its own is not worth
+// duplicating, so the copy takes the device's device sources and device actions with it, each with
+// a fresh id and re-pointed at the new device. (github issue #724)
+function TallyArbiter_Duplicate_Device(obj: Manage): ManageResponse {
+	const sourceDevice = devices.find(({ id }) => id === obj.deviceId)
+
+	if (!sourceDevice) {
+		return { result: 'error', error: 'Device not found.' }
+	}
+
+	const duplicate = buildDuplicateDevice(
+		sourceDevice,
+		device_sources,
+		device_actions,
+		devices.map((device) => device.name),
+	)
+
+	devices.push(duplicate.device)
+
+	UpdateCloud('devices')
+
+	device_sources.push(...duplicate.device_sources)
+
+	// same reason TallyArbiter_Add_Device_Source seeds: without an entry the new device source
+	// reports nothing until its source next emits, which for change-only sources can be never
+	for (const deviceSource of duplicate.device_sources) {
+		SeedSourceTallyDataForDeviceSource(deviceSource)
+	}
+
+	UpdateCloud('device_sources')
+
+	device_actions.push(...duplicate.device_actions)
+
+	UpdateSockets('devices')
+	UpdateSockets('device_sources')
+
+	// as in TallyArbiter_Add_Device, so the copy's state is correct immediately rather than at the
+	// next tally emission. No actions will actually fire: RunAction skips disabled devices, and the
+	// duplicate is created disabled.
+	UpdateDeviceState(duplicate.device.id)
+
+	tslListenerProvider.updateListenerClientsForDevice(currentDeviceTallyData, duplicate.device)
+
+	logger(
+		`Device Duplicated: ${sourceDevice.name} -> ${duplicate.device.name} (${duplicate.device_sources.length} source(s), ${duplicate.device_actions.length} action(s))`,
+		'info',
+	)
+
+	return { result: 'device-duplicated-successfully', deviceId: duplicate.device.id }
+}
+
 // currentSourceTallyData is only ever refreshed when a source emits, and initializeSource()
 // resolves addresses to device source ids at emission time, so a device source that is created
 // or re-pointed while its address is already live has no cache entry until the next emission.
@@ -2561,6 +2617,29 @@ function TallyArbiter_Delete_Device_Action(obj: Manage): ManageResponse {
 	logger(`Device Action Deleted: ${deviceName}`, 'info')
 
 	return { result: 'device-action-deleted-successfully', deviceId: deviceId }
+}
+
+function TallyArbiter_Duplicate_Device_Action(obj: Manage): ManageResponse {
+	const sourceAction = device_actions.find(({ id }) => id === obj.device_action?.id)
+
+	if (!sourceAction) {
+		return { result: 'error', error: 'Device action not found.' }
+	}
+
+	const deviceActionObj = buildDuplicateDeviceAction(sourceAction, sourceAction.deviceId)
+	device_actions.push(deviceActionObj)
+
+	let deviceName = ''
+	try {
+		deviceName = GetDeviceByDeviceId(deviceActionObj.deviceId).name
+	} catch (error) {
+		//sometimes the device is already deleted, so we can't get the name
+		deviceName = 'Unknown'
+	}
+
+	logger(`Device Action Duplicated: ${deviceName}`, 'info')
+
+	return { result: 'device-action-duplicated-successfully', deviceId: deviceActionObj.deviceId }
 }
 
 function TallyArbiter_Add_TSL_Client(obj: Manage): ManageResponse {


### PR DESCRIPTION
Closes #724.

The reporter's use case: *"I have camera one set up, I need to add 4 actions, Then I need to duplicate the camera and actions for 5 other cameras."* So this duplicates a Device **together with its device sources and device actions**, not an empty shell. Duplicating a single action on its own is also supported, as asked.

New `action: 'duplicate'` on the existing `manage` socket dispatch — no new socket event, so it inherits `requireRole('settings')`, the `settings:sources_devices` role check, and the `SaveConfig()` that runs after the switch. The device duplicate mirrors `TallyArbiter_Delete_Device`'s cascade in reverse, including `SeedSourceTallyDataForDeviceSource` per source (change-only sources would otherwise never populate the cache) and a final `UpdateDeviceState`.

## Three decisions worth your eye

**The copy is created disabled.** This is the one I'd argue hardest for. The copy points at the *same* device sources as the original until you re-point them, so an enabled copy would start driving a second full set of actions off camera 1's tally the instant you click — real relays, real lights, on a live rig, from what feels like a clipboard operation. `RunAction` gates on `deviceObj.enabled`, so state still computes correctly without firing anything, and the devices table already greys disabled rows.

**`tslAddress` is cleared, not copied.** Two devices claiming one address means `TSL.ts` drives the same physical display from both with last-write-wins — an intermittent fault that is worse than an obviously-missing setting. `''` is already the well-handled "no TSL" value. The tooltip and success toast both say so.

**Creates immediately; no pre-filled modal.** A device modal can only cover the device's own fields — the sources and actions that make the duplicate worth having live in two *other* modals. A pre-filled modal would either not carry them (useless) or carry them invisibly and lose them on Cancel (surprising). The action button likewise creates in place without closing the still-open actions modal.

Naming: `Camera 1` → `Camera 1 (copy)` → `Camera 1 (copy 2)`. An existing suffix is stripped from the base first, so duplicating a duplicate does not give `(copy) (copy)`.

## Verification

Duplication logic lives in a new `src/_helpers/duplicate.ts` as pure builders, which is what made it testable without importing the side-effecting server module. **27/27 scratch assertions pass** — fresh v4 uuids, `deviceId` re-pointing, only-this-device filtering, volatile fields dropped (`listenerCount`/`modePreview`/`modeProgram`/`cloudClientId`), and the input arrays left unmutated.

**The aliasing check was confirmed non-vacuous.** It asserts `notStrictEqual` down through `data.nested.list`, then mutates the copy and asserts the original is untouched. Negative control: patching the helper to use a shallow `Object.assign({}, sourceAction.data)` — the spread a person would naturally write — makes it fail with `nested object is aliased!`. Restored, 27/27.

`tsc --noEmit` clean, `format:check` clean, and a full `ng build` succeeds — which matters here because `UI/tsconfig.json` sets `strictTemplates` and `noFallthroughCasesInSwitch`, so it checked both the new bindings and the new switch cases.

## Not done

No docs change — `docs/` has no page describing these table buttons. And not smoke-tested against a live source: **the thing worth checking by hand is that a duplicated device stays dark until you enable it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)