### PR TITLE
chore(dependabot): stop opening updates that cannot build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'electron-builder'
         update-types: ['version-update:semver-major']
+      # TypeScript 7 removed moduleResolution=node10 and downlevelIteration and now
+      # requires an explicit rootDir -- all three are in tsconfig.json, so the bump
+      # cannot compile without a config migration first (see #1145).
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   # Angular front end. Most of this tree is build tooling that never reaches a
   # browser, so it is grouped tightly to keep the noise down.
@@ -40,11 +45,23 @@ updates:
     groups:
       ui-all:
         patterns: ['*']
+        exclude-patterns: ['@angular*', '@angular-devkit*']
         update-types: ['minor', 'patch']
-    # Angular majors need a coordinated `ng update` across the whole framework,
-    # which Dependabot cannot do correctly on its own.
+    # Angular is excluded from version updates entirely, not just majors. The first
+    # run produced #1139, which failed to install: the group moved @angular/core to
+    # 21.2.18 while @angular/animations only had 21.2.17 published, and npm refused
+    # the peer mismatch. Grouping cannot fix that -- it is upstream publishing lag,
+    # and it would recur on any release where the packages land unevenly. Angular is
+    # meant to be updated with `ng update`, which resolves the whole framework
+    # together. Security advisories still come through as Dependabot security
+    # updates, which this ignore list does not suppress.
     ignore:
       - dependency-name: '@angular*'
+      - dependency-name: '@angular-devkit*'
+      # ang-jsoneditor 6 dropped NgJsonEditorModule in favour of standalone
+      # components, so a version bump alone cannot build (see #1140). Needs a code
+      # migration in settings.component.ts and app.module.ts first.
+      - dependency-name: 'ang-jsoneditor'
         update-types: ['version-update:semver-major']
 
   # Docusaurus site. Build-time only: the output is static HTML deployed to


### PR DESCRIPTION
The config's first run produced three PRs that fail CI for reasons **no rebase can fix**. Each is a real incompatibility needing code or config work first, so without this they get reopened and re-fail on every schedule.

| Ignored | Why | PR |
|---|---|---|
| `typescript` major | TS 7 removed `moduleResolution=node10` and `downlevelIteration`, and now requires explicit `rootDir` — all three are in `tsconfig.json` | #1145 |
| `@angular*`, `@angular-devkit*` (all updates) | peer mismatch, see below | #1139 |
| `ang-jsoneditor` major | v6 dropped `NgJsonEditorModule` for standalone components | #1140 |

## Angular is ignored entirely, not just at major

The `ui-all` group moved `@angular/core` to 21.2.18 while `@angular/animations` only had 21.2.17 published, and npm refused the peer mismatch:

```
npm error While resolving: @angular/animations@21.2.17
npm error Found: @angular/core@21.2.18
```

Grouping cannot fix this — it is upstream publishing lag, and it recurs on any release where the packages land unevenly. Angular is meant to be updated with `ng update`, which resolves the framework as a unit. So it is both excluded from the group and ignored outright.

**Security advisories are unaffected.** Dependabot security updates are a separate mechanism that this ignore list does not suppress.

## The other two are one migration each, not merges

Both are worth doing eventually, just not as a dependency bump:

- **TypeScript 7** — migrate `tsconfig.json` off the three removed options.
- **ang-jsoneditor 6** — replace the `NgJsonEditorModule` import with the standalone `JsonEditorComponent` in `settings.component.ts` and `app.module.ts`. Worth pairing with a visual check of the config editor, since it is three majors of behaviour change.

Ignored at major only for `ang-jsoneditor`, so minor and patch still flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)