### PR TITLE
fix: main is broken — unresolved merge conflict markers in src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,20 +139,7 @@ const listenPort: number = parseInt(process.env.PORT) || 4455
 const app = express()
 const httpServer = new http.Server(app)
 
-<<<<<<< HEAD
 io = new socketio.Server(httpServer, { allowEIO3: true })
-=======
-//Set to true immediately after `io` is constructed below. `var` rather than `let` so it is hoisted
-//and readable (as undefined) from logger() during module evaluation, before this line is reached.
-var ioReady = false
-
-const io = new socketio.Server(httpServer, { allowEIO3: true })
-//logger() can run during module evaluation, before the line above has executed. It cannot test
-//`io` directly to find out: `io` is a const, so it is in the temporal dead zone until then and
-//even `typeof io` throws a ReferenceError rather than returning 'undefined'. This flag is a
-//plain assignment after initialisation, which is safe to read at any point.
-ioReady = true
->>>>>>> origin/main
 const socketupdates_Settings: string[] = [
 	'sources',
 	'devices',
@@ -1644,11 +1631,7 @@ export function logger(log, type: 'info-quiet' | 'info' | 'error' | 'console_act
 	logObj.log = log
 	logObj.type = type
 	Logs.push(logObj)
-<<<<<<< HEAD
 	if (io) io.to('settings').emit('log_item', logObj)
-=======
-	if (ioReady) io.to('settings').emit('log_item', logObj)
->>>>>>> origin/main
 }
 
 function writeTallyDataFile(log) {


### PR DESCRIPTION
## 🚨 `main` does not compile

`src/index.ts` on `main` contains four literal conflict markers. Every build, `tsc`, and `npm start` fail at parse time:

```
src/index.ts(142,1): error TS1185: Merge conflict marker encountered.
src/index.ts(144,1): error TS1185: Merge conflict marker encountered.
src/index.ts(155,1): error TS1185: Merge conflict marker encountered.
src/index.ts(1647,1): error TS1185: Merge conflict marker encountered.
```

## How it happened

Two PRs fixed the *same* logger temporal-dead-zone crash independently:

- **#1147** — hoisted `var ioReady` flag, guard `if (ioReady)`
- **#1160** — hoisted `let io`, guard `if (io)`

Both were merged. The #1160 branch tip (`34f0ceb`) was clean — 0 markers, `tsc` passing. Its parent on main (`6282853`) already carried #1147's `ioReady`. The squash-merge `f620e4c` then resolved one against the other **and committed the conflict unresolved**, which is where the markers entered:

| commit | markers |
|---|---|
| `34f0ceb` (#1160 branch tip) | 0 |
| `6282853` (main, pre-#1160) | 0 |
| `f620e4c` (#1160 squash-merge) | **4** |

Worth flagging for process: #1160 duplicated a fix that was already on main. Checking `main` for an existing fix before opening it would have avoided the collision entirely.

## Resolution

Resolved to the single-binding form:

```ts
let io: socketio.Server          // hoisted, initialized to undefined
...
io = new socketio.Server(httpServer, { allowEIO3: true })
...
if (io) io.to('settings').emit('log_item', logObj)
```

`let io` is in scope and initialized to `undefined` before any `logger()` call, so `if (io)` is a real guard by itself — which makes the separate `ioReady` flag redundant. One binding rather than two with an invariant between them.

**#1147's approach is equally correct.** If keeping `io` as `const` is preferred, the swap is to drop the `let io` declaration and restore the flag — happy to flip it.

Only the TDZ half of #1160 conflicted. Its other changes came through the squash intact and are untouched here:
- `loadConfig()` logging and skipping a source that fails to initialize
- `TallyArbiter_Add_Source()` validating the source type before adding

Net diff is 17 deletions, no additions.

## Verification

- No conflict markers or `ioReady` references remain
- `npx tsc --noEmit` — exit 0
- `npm run format:check` — clean
- Server boots to `Tally Arbiter running on port 4488`, with the dev-mode banner logging *before* `io` exists (the original TDZ trigger)

Recommend merging this ahead of anything else queued against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)