### PR TITLE
fix: welcome workflow inputs, plus three latent device/listener defects (#1122, #1124, #1125)

### DIFF
--- a/.github/workflows/welcome-first-time-contributor.yml
+++ b/.github/workflows/welcome-first-time-contributor.yml
@@ -11,11 +11,19 @@ on:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    # The action comments on the new issue or PR, which the default token cannot do
+    # when the repository's workflow permissions are read-only.
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
+      # v3 renamed every input from hyphens to underscores. The hyphenated v1/v2
+      # spellings are not recognised, and the action then fails on the first one it
+      # needs with "Input required and not supplied: issue_message".
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Hello there ${{ github.actor }} 👋
 
             Welcome to TallyArbiter!
@@ -24,7 +32,7 @@ jobs:
 
             If you have more to contribute to this issue, please comment down below! We will try to get back to you as soon as we can.
 
-          pr-message: |
+          pr_message: |
             Hello there ${{ github.actor }} 👋
 
             Thank you for opening your first PR for the Tally Arbiter project!

--- a/src/index.ts
+++ b/src/index.ts
@@ -504,7 +504,9 @@ function initialSetup() {
 			let device = GetDeviceByDeviceId(deviceId)
 			let oldDeviceId = null
 
-			if (deviceId === 'null' || device.id === 'unassigned') {
+			//`!device` is the check that used to read `device.id === 'unassigned'`, back when a
+			//missing device came back as a stand-in carrying that id rather than as undefined.
+			if (deviceId === 'null' || !device) {
 				if (devices.length > 0) {
 					oldDeviceId = deviceId
 					deviceId = devices[0].id
@@ -521,7 +523,7 @@ function initialSetup() {
 			let supportsChat = obj.supportsChat ? obj.supportsChat : false
 
 			socket.join('device-' + deviceId)
-			let deviceName = GetDeviceByDeviceId(deviceId).name
+			let deviceName = GetDeviceNameByDeviceId(deviceId)
 			logger(`Listener Client Connected. Type: ${listenerType} Device: ${deviceName}`, 'info')
 
 			let ipAddress = socket.handshake.address
@@ -683,16 +685,23 @@ function initialSetup() {
 					socket.leave('device-' + oldDeviceId)
 					socket.join('device-' + deviceId)
 
+					// A socket can host more than one listener client -- the relay listener
+					// registers one entry per relay group, which is why the sibling
+					// listener_reassign_relay handler below also matches on internalId. So
+					// socketId alone does not say which client is being reassigned, and
+					// stopping at the first match would move whichever one happens to sit
+					// earliest in the array. oldDeviceId is the discriminator the caller
+					// already supplies: reassign every client on this socket that is
+					// actually pointing at it, and do not break early.
 					for (let i = 0; i < listener_clients.length; i++) {
-						if (listener_clients[i].socketId === socket.id) {
+						if (listener_clients[i].socketId === socket.id && listener_clients[i].deviceId === oldDeviceId) {
 							listener_clients[i].deviceId = deviceId
 							listener_clients[i].inactive = false
-							break
 						}
 					}
 
-					let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
-					let deviceName = GetDeviceByDeviceId(deviceId).name
+					let oldDeviceName = GetDeviceNameByDeviceId(oldDeviceId)
+					let deviceName = GetDeviceNameByDeviceId(deviceId)
 
 					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
 					UpdateSockets('listener_clients')
@@ -733,8 +742,8 @@ function initialSetup() {
 						}
 					}
 
-					let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
-					let deviceName = GetDeviceByDeviceId(deviceId).name
+					let oldDeviceName = GetDeviceNameByDeviceId(oldDeviceId)
+					let deviceName = GetDeviceNameByDeviceId(deviceId)
 
 					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
 					UpdateSockets('listener_clients')
@@ -775,8 +784,8 @@ function initialSetup() {
 						}
 					}
 
-					let oldDeviceName = GetDeviceByDeviceId(oldDeviceId).name
-					let deviceName = GetDeviceByDeviceId(deviceId).name
+					let oldDeviceName = GetDeviceNameByDeviceId(oldDeviceId)
+					let deviceName = GetDeviceNameByDeviceId(deviceId)
 
 					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
 					UpdateSockets('listener_clients')
@@ -801,8 +810,8 @@ function initialSetup() {
 						}
 					}
 
-					let oldDeviceName = GetDeviceByDeviceId(reassignObj.oldDeviceId).name
-					let deviceName = GetDeviceByDeviceId(reassignObj.newDeviceId).name
+					let oldDeviceName = GetDeviceNameByDeviceId(reassignObj.oldDeviceId)
+					let deviceName = GetDeviceNameByDeviceId(reassignObj.newDeviceId)
 
 					logger(`Listener Client reassigned from ${oldDeviceName} to ${deviceName}`, 'info')
 					UpdateSockets('listener_clients')
@@ -1359,8 +1368,9 @@ function getDeviceStates(deviceId?: string): DeviceState[] {
 				const deviceSources = device_sources.filter((s) => s.deviceId == d.id)
 
 				// Check if buss is linked, if linked all sources must be in this bus
-				const device = GetDeviceByDeviceId(d.id)
-				if ((device.linkedBusses || []).includes(b.id)) {
+				// d is already the device -- it comes from iterating `devices` just above, so
+				// looking it up again by its own id only ever returned d itself
+				if ((d.linkedBusses || []).includes(b.id)) {
 					// Check if all sources are in the buss, if not return [] for sources.
 					// Count number of sources in bus
 					// TODO: Check if this can be replaced with deviceSources.findIndex((s) and refactored to reduce duplicated code.
@@ -1851,6 +1861,14 @@ function RunAction(deviceId, busId, active) {
 	let actionObj: DeviceAction = null
 
 	let deviceObj = GetDeviceByDeviceId(deviceId)
+
+	if (!deviceObj) {
+		//previously this fell through to the disabled branch below and logged
+		//"Device: Unassigned is not enabled", because the missing device came back as a
+		//stand-in with no `enabled` field. Say what actually happened instead.
+		logger(`No device found for id ${deviceId}, so no actions will be run.`, 'error')
+		return
+	}
 
 	if (deviceObj.enabled === true) {
 		let filteredActions = device_actions.filter((obj) => obj.deviceId === deviceId)
@@ -2361,9 +2379,11 @@ function TallyArbiter_Edit_Device(obj: Manage): ManageResponse {
 	let deviceObj = obj.device
 
 	//capture the camera config before the loop below overwrites it, so we can tell whether it actually changed
+	//optional chaining because an edit for an id that is not present finds nothing; the loop below
+	//then matches nothing either, so treating the previous camera config as unset is correct
 	const existingDevice = GetDeviceByDeviceId(deviceObj.id)
-	const previousCameraIP = existingDevice.cameraIP
-	const previousCameraModel = existingDevice.cameraModel
+	const previousCameraIP = existingDevice?.cameraIP
+	const previousCameraModel = existingDevice?.cameraModel
 	const cameraChanged = previousCameraIP !== deviceObj.cameraIP || previousCameraModel !== deviceObj.cameraModel
 
 	for (let i = 0; i < devices.length; i++) {
@@ -2397,7 +2417,7 @@ function TallyArbiter_Edit_Device(obj: Manage): ManageResponse {
 
 function TallyArbiter_Delete_Device(obj: Manage): ManageResponse {
 	let deviceId = obj.deviceId
-	let deviceName = GetDeviceByDeviceId(deviceId).name
+	let deviceName = GetDeviceNameByDeviceId(deviceId)
 
 	//release any VISCA socket/keepalive timer held for this device
 	CleanupViscaCameraState(deviceId)
@@ -2486,10 +2506,17 @@ function TallyArbiter_Duplicate_Device(obj: Manage): ManageResponse {
 // or re-pointed while its address is already live has no cache entry until the next emission.
 // Several source types only emit on change (TSL 3.1/5.0, SimplyLive), so that gap can last
 // indefinitely. Seed the entry from the source's current tally instead, and drop any stale entry
-// when there is nothing to seed from. Stored as a defensive copy for the same reason
-// processSourceTallyData copies: source objects mutate their own bus arrays in place.
+// when there is nothing to seed from.
+//
+// Asks the source for its full state rather than reading tally.value, which is only the most
+// recent emission. The source types that emit through sendIndividualTallyData() -- the same
+// TSL and SimplyLive ones that emit on change -- publish just the address that changed, so
+// tally.value[address] was usually undefined for the address being seeded and this fell through
+// to the delete below even when the address was live. The spread below is kept even though
+// getCurrentTallyData() already returns per-address copies: the cache must not alias arrays a
+// source mutates in place, and that holds here regardless of what the accessor promises.
 function SeedSourceTallyDataForDeviceSource(deviceSource: DeviceSource) {
-	const busses = SourceClients[deviceSource.sourceId]?.tally?.value?.[deviceSource.address]
+	const busses = SourceClients[deviceSource.sourceId]?.getCurrentTallyData()?.[deviceSource.address]
 	if (Array.isArray(busses)) {
 		currentSourceTallyData[deviceSource.id] = [...busses]
 	} else {
@@ -2508,7 +2535,7 @@ function TallyArbiter_Add_Device_Source(obj: Manage): ManageResponse {
 
 	let deviceName = ''
 	try {
-		deviceName = GetDeviceByDeviceId(deviceSourceObj.deviceId).name
+		deviceName = GetDeviceNameByDeviceId(deviceSourceObj.deviceId)
 	} catch (error) {
 		//sometimes the device is already deleted, so we can't get the name
 		deviceName = 'Unknown'
@@ -2556,7 +2583,7 @@ function TallyArbiter_Edit_Device_Source(obj: Manage): ManageResponse {
 
 	let deviceName = ''
 	try {
-		deviceName = GetDeviceByDeviceId(deviceId).name
+		deviceName = GetDeviceNameByDeviceId(deviceId)
 	} catch (error) {
 		//sometimes the device is already deleted, so we can't get the name
 		deviceName = 'Unknown'
@@ -2604,7 +2631,7 @@ function TallyArbiter_Delete_Device_Source(obj: Manage): ManageResponse {
 
 	let deviceName = ''
 	try {
-		deviceName = GetDeviceByDeviceId(deviceId).name
+		deviceName = GetDeviceNameByDeviceId(deviceId)
 	} catch (error) {
 		//sometimes the device is already deleted, so we can't get the name
 		deviceName = 'Unknown'
@@ -2634,7 +2661,7 @@ function TallyArbiter_Add_Device_Action(obj: Manage): ManageResponse {
 	deviceActionObj.id = uuidv4()
 	device_actions.push(deviceActionObj)
 
-	let deviceName = GetDeviceByDeviceId(deviceActionObj.deviceId).name
+	let deviceName = GetDeviceNameByDeviceId(deviceActionObj.deviceId)
 
 	logger(`Device Action Added: ${deviceName}`, 'info')
 
@@ -2654,7 +2681,7 @@ function TallyArbiter_Edit_Device_Action(obj: Manage): ManageResponse {
 		}
 	}
 
-	let deviceName = GetDeviceByDeviceId(deviceActionObj.deviceId).name
+	let deviceName = GetDeviceNameByDeviceId(deviceActionObj.deviceId)
 
 	logger(`Device Action Edited: ${deviceName}`, 'info')
 
@@ -2675,7 +2702,7 @@ function TallyArbiter_Delete_Device_Action(obj: Manage): ManageResponse {
 		}
 	}
 
-	let deviceName = GetDeviceByDeviceId(deviceId).name
+	let deviceName = GetDeviceNameByDeviceId(deviceId)
 
 	logger(`Device Action Deleted: ${deviceName}`, 'info')
 
@@ -2694,7 +2721,7 @@ function TallyArbiter_Duplicate_Device_Action(obj: Manage): ManageResponse {
 
 	let deviceName = ''
 	try {
-		deviceName = GetDeviceByDeviceId(deviceActionObj.deviceId).name
+		deviceName = GetDeviceNameByDeviceId(deviceActionObj.deviceId)
 	} catch (error) {
 		//sometimes the device is already deleted, so we can't get the name
 		deviceName = 'Unknown'
@@ -2949,21 +2976,27 @@ export function GetBusByBusId(busId: string): BusOption {
 	return currentConfig.bus_options.find(({ id }) => id === busId)
 }
 
-function GetDeviceByDeviceId(deviceId: string): Device {
-	//gets the Device object by id
-	let device = undefined
+//gets the Device object by id, or undefined when no such device exists.
+//
+//This used to fabricate a { id: 'unassigned', name: 'Unassigned' } stand-in rather than
+//returning undefined, which made every `if (!device)` guard in this file unreachable and
+//let callers read fields the stand-in never had. It also meant the `Device` return
+//annotation was not enforced: the object only type-checked because it was inferred as any.
+//Callers that just need something printable should use GetDeviceNameByDeviceId below.
+//
+//'unassigned' is not a device id -- it is the sentinel a listener client carries when it is
+//not pointed at a device -- so it never resolves to a device.
+function GetDeviceByDeviceId(deviceId: string): Device | undefined {
+	if (deviceId === 'unassigned') return undefined
 
-	if (deviceId !== 'unassigned') {
-		device = devices.find(({ id }) => id === deviceId)
-	}
+	return devices.find(({ id }) => id === deviceId)
+}
 
-	if (!device) {
-		device = {}
-		device.id = 'unassigned'
-		device.name = 'Unassigned'
-	}
-
-	return device
+//Display counterpart to GetDeviceByDeviceId, for log lines and messages that only need a
+//label. Keeps the old 'Unassigned' fallback, which several callers below print for devices
+//that have already been deleted.
+function GetDeviceNameByDeviceId(deviceId: string): string {
+	return GetDeviceByDeviceId(deviceId)?.name ?? 'Unassigned'
 }
 
 function GetTSLClientById(tslClientId: string): TSLClient {
@@ -3058,9 +3091,11 @@ function AddListenerClient(
 }
 
 function UpdateListenerClients(deviceId: string) {
-	const device = GetDeviceByDeviceId(deviceId)
+	//name only, for the log line below -- clients can still be pointed at a device that has
+	//since been deleted, and that is what CheckListenerClients reassigns them away from
+	const deviceName = GetDeviceNameByDeviceId(deviceId)
 	for (const listenerClient of listener_clients.filter((l) => l.deviceId == deviceId && !l.inactive)) {
-		logger(`Sending device states to Listener Client: ${listenerClient.id} - ${device.name}`, 'info-quiet')
+		logger(`Sending device states to Listener Client: ${listenerClient.id} - ${deviceName}`, 'info-quiet')
 		io.to(`device-${deviceId}`).emit('device_states', getDeviceStates(deviceId))
 	}
 }
@@ -3479,7 +3514,7 @@ function UpdateSonyViscaTally(deviceId: string, cameraIP: string, inPgm: boolean
 function UpdateCamera(deviceId: string) {
 	const device = GetDeviceByDeviceId(deviceId)
 
-	if (!device.cameraIP || !device.cameraModel) {
+	if (!device?.cameraIP || !device.cameraModel) {
 		//only proceed if both camera IP and model are set
 		CleanupViscaCameraState(deviceId)
 		return
@@ -3642,7 +3677,11 @@ function CheckListenerClients() {
 	}
 
 	for (let i = 0; i < listener_clients.length; i++) {
-		if (GetDeviceByDeviceId(listener_clients[i].deviceId).id === 'unassigned') {
+		//`!GetDeviceByDeviceId(...)` is the check that used to read `.id === 'unassigned'`, back
+		//when a missing device came back as a stand-in carrying that id rather than as undefined.
+		//Clients already sitting on the 'unassigned' sentinel still match, since that never
+		//resolves to a device.
+		if (!GetDeviceByDeviceId(listener_clients[i].deviceId)) {
 			//this device has been removed, so reassign it to the first index
 			ReassignListenerClient(listener_clients[i].id, listener_clients[i].deviceId, newDeviceId)
 		}

--- a/src/sources/_Source.ts
+++ b/src/sources/_Source.ts
@@ -249,6 +249,31 @@ export class TallyInput extends EventEmitter {
 		}
 	}
 
+	/**
+	 * The source's full current address-to-busses map.
+	 *
+	 * `tally.value` is not a substitute. sendIndividualTallyData() publishes an
+	 * object holding only the address that just changed, so for the source types
+	 * that use it (TSL 3.1 UDP, TSL 5.0 UDP/TCP, SimplyLive) the last emission is
+	 * a partial snapshot and every other address reads as undefined -- even when
+	 * it is genuinely live. Those source types also only emit on change, so there
+	 * may be no later emission to correct the picture. This reads the map the
+	 * source actually maintains.
+	 *
+	 * Returns a copy, and copies each bus array rather than just the outer object:
+	 * addBusToAddress() pushes onto tallyData[address] in place, so a shallow
+	 * spread would hand out arrays that mutate underneath the caller. That is the
+	 * same no-aliasing invariant the currentSourceTallyData cache relies on.
+	 */
+	public getCurrentTallyData(): AddressTallyData {
+		const snapshot: AddressTallyData = {}
+		for (const address of Object.keys(this.tallyData)) {
+			const busses = this.tallyData[address]
+			snapshot[address] = Array.isArray(busses) ? [...busses] : []
+		}
+		return snapshot
+	}
+
 	protected sendTallyData() {
 		this.tally.next(this.tallyData)
 	}


### PR DESCRIPTION
Two commits, disjoint files.

## 1. `ci:` fix the welcome workflow — closes the failing check

The `welcome` job fails on **every** issue and PR:

```
Error: Input required and not supplied: issue_message
```

`actions/first-interaction@v3` names its inputs `issue_message` / `pr_message` / `repo_token`. The workflow still passed the v1/v2 hyphenated spellings, which v3 doesn't read.

Also adds an explicit `permissions` block — the action comments on the new issue/PR, which the default token can't do when the repo's workflow permissions are read-only. Without it the job would stop erroring on the input and then fail to post instead.

## 2. `fix:` three latent defects

All found by inspection, none changes behavior for a single-client, fully-configured setup.

### #1125 — `listener_reassign` reassigned the wrong client

Matched on `socketId` alone and `break`-ed at the first hit. A socket can host several listener clients (the relay listener registers one per relay group — which is exactly why the sibling `listener_reassign_relay` also matches on `internalId`), so it moved whichever entry sat earliest in the array and left the others on the old device.

Now matches on `socketId` **and** the caller's `oldDeviceId`, with no early break. `oldDeviceId` is already in the handler signature, so no client change is needed — the only caller, [tally.component.ts:31](UI/src/app/_components/tally/tally.component.ts), passes its real current device.

### #1124 — `TallyInput.getCurrentTallyData()`

`sendIndividualTallyData()` publishes an object holding only the address that changed, so for TSL 3.1/5.0 and SimplyLive `tally.value` is a partial snapshot and every other address reads `undefined` even when live. Those sources also only emit on change, so nothing later corrects it. `SeedSourceTallyDataForDeviceSource` read `tally.value` and therefore **deleted** the cache entry for addresses genuinely on program.

**One deliberate departure from the issue.** It suggests `return { ...this.tallyData }`. That is not sufficient: `addBusToAddress` does `tallyData[address].push(bus)`, mutating in place, so a shallow spread hands out arrays that change under the caller — breaking the very no-aliasing invariant the issue cites. This copies each bus array.

Verified directly against a probe subclass:

```
tally.value (last emission) : {"2":["busB"]}
getCurrentTallyData (full)  : {"1":["busA"],"2":["busB"]}
addr 1 via tally.value      : undefined      <- the bug
addr 1 via accessor         : ["busA"]
snapshot after source push  : ["busA"]       <- not aliased
source now                  : ["busA","busC"]
```

### #1122 — `GetDeviceByDeviceId` returns `Device | undefined`

It fabricated an `{ id: 'unassigned', name: 'Unassigned' }` stand-in, which made every `if (!device)` guard unreachable and left the `Device` annotation unenforced (the literal only type-checked because it was inferred `any`).

Now honest, with `GetDeviceNameByDeviceId` for display paths. **All 25 call sites audited:**

| Site | Change |
|---|---|
| 17 sites reading only `.name` | moved to the new helper |
| `listenerclient_connect`, `CheckListenerClients` | were detecting "no such device" via `.id === 'unassigned'`; now test the value |
| `RunAction` | real guard added — previously fell into the disabled branch and logged the misleading *"Device: Unassigned is not enabled"* |
| `Edit_Device`, `UpdateCamera`, `UpdateListenerClients` | tolerate a missing device instead of dereferencing the stand-in |
| `getDeviceStates` | lookup dropped — it was re-finding, by id, the device it was already iterating |
| `UpdateDeviceState` | its guard is now **live**, which was the point of the issue |

## ⚠️ Caveat worth knowing

`tsconfig.json` does not enable `strictNullChecks`, so the compiler does **not** enforce the new `| undefined` at call sites. A green `tsc` is not evidence that #1122 is complete — the audit above was done by reading, and a future caller assuming non-null won't be flagged. Enabling `strictNullChecks` would make this class of bug impossible, but it's a large separate change.

## Verification

- `npx tsc --noEmit` — exit 0
- `npm run format:check` — clean
- Server boots to `Tally Arbiter running on port 4477`
- `getCurrentTallyData` semantics verified functionally (output above)

Not exercised against live TSL/SimplyLive hardware or a multi-group relay listener — those are the two setups where #1124 and #1125 actually bite.

## Related

While auditing, [src/index.ts:1392](src/index.ts) and `:1412` in `getDeviceStates` read `SourceClients[...].tally.value` — the same partial-snapshot trap #1124 describes, and there's already a comment elsewhere in the file calling that read unsafe. Out of scope here; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)