### PR TITLE
ensure tally start even if IMU does not

### DIFF
--- a/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
+++ b/listener_clients/M5AtomMatrix-listener/tallyarbiter-m5atom/tallyarbiter-m5atom.ino
@@ -795,7 +795,6 @@ void setup() {
   // Initialize IMU (MPU6886) The rotation sensor
   if (M5.IMU.Init() != 0) {
     Serial.println("MPU6886 initialization failed!");
-    while (1) delay(100);
   } else {
     Serial.println("MPU6886 initialization successful!");
   }


### PR DESCRIPTION

## What does this change do?

Remove the endless loop that is triggered when the IMU fails initialization. 

## Why?

Fixing issue 1175 where the tally does not start when the IMU fails initialization. 

## How did you test it?

Ran it on my own M5 Matrix using the Arduino IDE with the newest libaries. 

## Issue fixed by this:
https://github.com/josephdadams/TallyArbiter/issues/1175

## Checklist

- [x ] The description above matches what the diff actually does
- [x ] The diff contains only changes relevant to this PR — no unrelated
      reformatting, style rewrites, or drive-by edits
- [x ] Any claim I make in this description (tests pass, scan is clean, build is
      green) is something I actually ran and can point to

