### PR TITLE
fix(relay-listener): clean install fails, reconnect goes inert, and mDNS discovery is broken

### DIFF
--- a/listener_clients/relay-listener/index.js
+++ b/listener_clients/relay-listener/index.js
@@ -8,7 +8,9 @@ const path = require('path')
 const { v4: uuidv4 } = require('uuid')
 const config_file = './config_relays.json' //local storage JSON file
 const USBRelay = require('@josephdadams/usbrelay')
-const bonjour = require('bonjour')()
+const { Bonjour } = require('bonjour-service')
+const bonjour = new Bonjour()
+const mdns_discovery_timeout = 10000 //how long each MDNS browse waits before starting over
 
 //var relay = 		null;
 var detectedRelays = []
@@ -263,7 +265,23 @@ function openSocket() {
 	}
 
 	if (server_config.useMDNS) {
-		bonjour.findOne({ type: 'tally-arbiter' }, function (service) {
+		findServerUsingMDNS()
+	} else if (ip) {
+		logger(`Reading TallyArbiter server connection info from config: ${ip}:${port}`, 'info')
+		connectToServer(ip, port)
+	}
+
+	function findServerUsingMDNS() {
+		//findOne gives up after the timeout and calls back with null, where the old bonjour
+		//package waited indefinitely. Keep browsing rather than giving up: the listener and
+		//the server are often started together, so the server may not be advertising yet.
+		bonjour.findOne({ type: 'tally-arbiter' }, mdns_discovery_timeout, function (service) {
+			if (!service) {
+				logger(`No Tally Arbiter server found using MDNS yet. Still looking.`, 'info')
+				findServerUsingMDNS()
+				return
+			}
+
 			ip = service.host
 			port = service.port
 			const advertisedVersion = service.txt ? service.txt.version : undefined
@@ -279,9 +297,6 @@ function openSocket() {
 			logger(`Found TallyArbiter server using MDNS: ${ip}:${port}`, 'info')
 			connectToServer(ip, port)
 		})
-	} else if (ip) {
-		logger(`Reading TallyArbiter server connection info from config: ${ip}:${port}`, 'info')
-		connectToServer(ip, port)
 	}
 }
 

--- a/listener_clients/relay-listener/index.js
+++ b/listener_clients/relay-listener/index.js
@@ -193,6 +193,7 @@ function connectToServer(ip, port) {
 
 	socket.on('connect', function () {
 		logger('Connected to Tally Arbiter server.', 'info')
+		registerListenerClients()
 	})
 
 	socket.on('disconnect', function () {
@@ -234,7 +235,10 @@ function connectToServer(ip, port) {
 			}
 		}
 	})
+}
 
+function registerListenerClients() {
+	//(re)register every relay group with the server; runs on each connect, including reconnects
 	for (let i = 0; i < relay_groups.length; i++) {
 		socket.emit('listenerclient_connect', {
 			deviceId: relay_groups[i].deviceId,

--- a/listener_clients/relay-listener/index.js
+++ b/listener_clients/relay-listener/index.js
@@ -266,9 +266,12 @@ function openSocket() {
 		bonjour.findOne({ type: 'tally-arbiter' }, function (service) {
 			ip = service.host
 			port = service.port
-			if (service.txt.version.startsWith('2.')) {
+			const advertisedVersion = service.txt ? service.txt.version : undefined
+			if (typeof advertisedVersion !== 'string') {
+				logger(`Could not read a version from the server advertisement, continuing anyway.`, 'error')
+			} else if (advertisedVersion.startsWith('2.')) {
 				logger(
-					`Error connecting to Tally Arbiter: Tally Arbiter server version ${service.txt.version} is not supported.`,
+					`Error connecting to Tally Arbiter: Tally Arbiter server version ${advertisedVersion} is not supported.`,
 					'error',
 				)
 				process.exit(3)

--- a/listener_clients/relay-listener/package-lock.json
+++ b/listener_clients/relay-listener/package-lock.json
@@ -12,7 +12,7 @@
 				"@josephdadams/usbrelay": "^1.0.3",
 				"bonjour": "^3.5.1",
 				"cli-color": "^2.0.4",
-				"socket.io": "4.8.3",
+				"socket.io-client": "4.8.3",
 				"uuid": "^14.0.1"
 			}
 		},
@@ -33,42 +33,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
 			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
-		},
-		"node_modules/@types/cors": {
-			"version": "2.8.17",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
-			"integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/node": {
-			"version": "22.7.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-			"integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-			"dependencies": {
-				"undici-types": "~6.19.2"
-			}
-		},
-		"node_modules/@types/ws": {
-			"version": "8.18.1",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-			"dependencies": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/array-flatten": {
 			"version": "2.1.2",
@@ -93,14 +57,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"engines": {
-				"node": "^4.5.0 || >= 5.9"
-			}
 		},
 		"node_modules/bindings": {
 			"version": "1.5.0",
@@ -191,26 +147,6 @@
 			},
 			"engines": {
 				"node": ">=0.10"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/d": {
@@ -327,24 +263,17 @@
 				"once": "^1.4.0"
 			}
 		},
-		"node_modules/engine.io": {
-			"version": "6.6.9",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
-			"integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+		"node_modules/engine.io-client": {
+			"version": "6.6.6",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+			"integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+			"license": "MIT",
 			"dependencies": {
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"@types/ws": "^8.5.12",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.7.2",
-				"cors": "~2.8.5",
+				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.4.1",
 				"engine.io-parser": "~5.2.1",
-				"ws": "~8.21.0"
-			},
-			"engines": {
-				"node": ">=10.2.0"
+				"ws": "~8.21.0",
+				"xmlhttprequest-ssl": "~2.1.1"
 			}
 		},
 		"node_modules/engine.io-parser": {
@@ -630,25 +559,6 @@
 				"timers-ext": "^0.1.7"
 			}
 		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/mimic-response": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -700,14 +610,6 @@
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
 			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
 		},
-		"node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/next-tick": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
@@ -744,14 +646,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-is": {
@@ -937,30 +831,19 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
-		"node_modules/socket.io": {
+		"node_modules/socket.io-client": {
 			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
-			"integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+			"integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
+				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.4.1",
-				"engine.io": "~6.6.0",
-				"socket.io-adapter": "~2.5.2",
+				"engine.io-client": "~6.6.1",
 				"socket.io-parser": "~4.2.4"
 			},
 			"engines": {
-				"node": ">=10.2.0"
-			}
-		},
-		"node_modules/socket.io-adapter": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
-			"integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
-			"dependencies": {
-				"debug": "~4.4.1",
-				"ws": "~8.21.0"
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/socket.io-parser": {
@@ -1047,11 +930,6 @@
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
 			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
-		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1067,14 +945,6 @@
 			],
 			"bin": {
 				"uuid": "dist-node/bin/uuid"
-			}
-		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/wrappy": {
@@ -1102,6 +972,14 @@
 				}
 			}
 		},
+		"node_modules/xmlhttprequest-ssl": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+			"integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -1127,39 +1005,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
 			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
 		},
-		"@types/cors": {
-			"version": "2.8.17",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
-			"integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/node": {
-			"version": "22.7.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-			"integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-			"requires": {
-				"undici-types": "~6.19.2"
-			}
-		},
-		"@types/ws": {
-			"version": "8.18.1",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-			"requires": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
-			}
-		},
 		"array-flatten": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -1169,11 +1014,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
-		"base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -1244,20 +1084,6 @@
 				"es6-iterator": "^2.0.3",
 				"memoizee": "^0.4.15",
 				"timers-ext": "^0.1.7"
-			}
-		},
-		"cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-		},
-		"cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"requires": {
-				"object-assign": "^4",
-				"vary": "^1"
 			}
 		},
 		"d": {
@@ -1345,21 +1171,16 @@
 				"once": "^1.4.0"
 			}
 		},
-		"engine.io": {
-			"version": "6.6.9",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
-			"integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+		"engine.io-client": {
+			"version": "6.6.6",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+			"integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
 			"requires": {
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
-				"@types/ws": "^8.5.12",
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "~0.7.2",
-				"cors": "~2.8.5",
+				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.4.1",
 				"engine.io-parser": "~5.2.1",
-				"ws": "~8.21.0"
+				"ws": "~8.21.0",
+				"xmlhttprequest-ssl": "~2.1.1"
 			}
 		},
 		"engine.io-parser": {
@@ -1583,19 +1404,6 @@
 				"timers-ext": "^0.1.7"
 			}
 		},
-		"mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-		},
-		"mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"requires": {
-				"mime-db": "1.52.0"
-			}
-		},
 		"mimic-response": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -1635,11 +1443,6 @@
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
 			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
 		},
-		"negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-		},
 		"next-tick": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
@@ -1667,11 +1470,6 @@
 				"node-addon-api": "^3.0.2",
 				"prebuild-install": "^7.1.1"
 			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-is": {
 			"version": "1.1.5",
@@ -1781,27 +1579,15 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
-		"socket.io": {
+		"socket.io-client": {
 			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
-			"integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+			"integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
 			"requires": {
-				"accepts": "~1.3.4",
-				"base64id": "~2.0.0",
-				"cors": "~2.8.5",
+				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.4.1",
-				"engine.io": "~6.6.0",
-				"socket.io-adapter": "~2.5.2",
+				"engine.io-client": "~6.6.1",
 				"socket.io-parser": "~4.2.4"
-			}
-		},
-		"socket.io-adapter": {
-			"version": "2.5.8",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
-			"integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
-			"requires": {
-				"debug": "~4.4.1",
-				"ws": "~8.21.0"
 			}
 		},
 		"socket.io-parser": {
@@ -1876,11 +1662,6 @@
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
 			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
-		"undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1890,11 +1671,6 @@
 			"version": "14.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
 			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -1906,6 +1682,11 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
 			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"requires": {}
+		},
+		"xmlhttprequest-ssl": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+			"integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/listener_clients/relay-listener/package-lock.json
+++ b/listener_clients/relay-listener/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@josephdadams/usbrelay": "^1.0.3",
-				"bonjour": "^3.5.1",
+				"bonjour-service": "^1.4.4",
 				"cli-color": "^2.0.4",
 				"socket.io-client": "4.8.3",
 				"uuid": "^14.0.1"
@@ -27,17 +27,13 @@
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+			"license": "MIT"
 		},
 		"node_modules/@socket.io/component-emitter": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
 			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
-		},
-		"node_modules/array-flatten": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -76,17 +72,14 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
-		"node_modules/bonjour": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.1.tgz",
-			"integrity": "sha512-xONzj4PfpPJw6xSqCcT2SmQkBOXpUINUz3o3qXcWJwYlXbkZNcNaUae0o5lle7tKt4HHV6dTgkIRhAXZ3nBMsQ==",
+		"node_modules/bonjour-service": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+			"integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
+			"license": "MIT",
 			"dependencies": {
-				"array-flatten": "^2.1.0",
-				"deep-equal": "^1.0.1",
-				"dns-equal": "^1.0.0",
-				"dns-txt": "^2.0.2",
-				"multicast-dns": "^7.2.3",
-				"multicast-dns-service-types": "^1.1.0"
+				"fast-deep-equal": "^3.1.3",
+				"multicast-dns": "^7.2.5"
 			}
 		},
 		"node_modules/buffer": {
@@ -110,23 +103,6 @@
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/buffer-indexof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
-		},
-		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/chownr": {
@@ -188,39 +164,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/deep-equal": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-			"dependencies": {
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.1",
-				"is-regex": "^1.0.4",
-				"object-is": "^1.0.1",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 			"engines": {
 				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dependencies": {
-				"object-keys": "^1.0.12"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -231,28 +180,16 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/dns-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
-		},
 		"node_modules/dns-packet": {
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
 			"integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+			"license": "MIT",
 			"dependencies": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/dns-txt": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-			"dependencies": {
-				"buffer-indexof": "^1.0.0"
 			}
 		},
 		"node_modules/end-of-stream": {
@@ -378,6 +315,12 @@
 			"resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
 			"integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
 		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -388,64 +331,10 @@
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
-		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/github-from-package": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
 			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
-		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"dependencies": {
-				"has-symbols": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
@@ -476,54 +365,10 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-date-object": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-promise": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
 			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
-		},
-		"node_modules/is-regex": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -592,6 +437,7 @@
 			"version": "7.2.5",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
 			"integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+			"license": "MIT",
 			"dependencies": {
 				"dns-packet": "^5.2.2",
 				"thunky": "^1.0.2"
@@ -599,11 +445,6 @@
 			"bin": {
 				"multicast-dns": "cli.js"
 			}
-		},
-		"node_modules/multicast-dns-service-types": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
 		},
 		"node_modules/napi-build-utils": {
 			"version": "1.0.2",
@@ -646,29 +487,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/once": {
@@ -738,21 +556,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-			"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -903,7 +706,8 @@
 		"node_modules/thunky": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+			"license": "MIT"
 		},
 		"node_modules/timers-ext": {
 			"version": "0.1.7",
@@ -1005,11 +809,6 @@
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
 			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
 		},
-		"array-flatten": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
-		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1033,17 +832,13 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
-		"bonjour": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.1.tgz",
-			"integrity": "sha512-xONzj4PfpPJw6xSqCcT2SmQkBOXpUINUz3o3qXcWJwYlXbkZNcNaUae0o5lle7tKt4HHV6dTgkIRhAXZ3nBMsQ==",
+		"bonjour-service": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+			"integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
 			"requires": {
-				"array-flatten": "^2.1.0",
-				"deep-equal": "^1.0.1",
-				"dns-equal": "^1.0.0",
-				"dns-txt": "^2.0.2",
-				"multicast-dns": "^7.2.3",
-				"multicast-dns-service-types": "^1.1.0"
+				"fast-deep-equal": "^3.1.3",
+				"multicast-dns": "^7.2.5"
 			}
 		},
 		"buffer": {
@@ -1053,20 +848,6 @@
 			"requires": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
-			}
-		},
-		"buffer-indexof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
-		},
-		"call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"chownr": {
@@ -1111,41 +892,15 @@
 				"mimic-response": "^3.1.0"
 			}
 		},
-		"deep-equal": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-			"requires": {
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.1",
-				"is-regex": "^1.0.4",
-				"object-is": "^1.0.1",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.2.0"
-			}
-		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
-		},
 		"detect-libc": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
 			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
-		},
-		"dns-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
 		},
 		"dns-packet": {
 			"version": "5.6.1",
@@ -1153,14 +908,6 @@
 			"integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
 			"requires": {
 				"@leichtgewicht/ip-codec": "^2.0.1"
-			}
-		},
-		"dns-txt": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-			"requires": {
-				"buffer-indexof": "^1.0.0"
 			}
 		},
 		"end-of-stream": {
@@ -1276,6 +1023,11 @@
 				}
 			}
 		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1286,46 +1038,10 @@
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"get-intrinsic": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
-			}
-		},
 		"github-from-package": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
 			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-		},
-		"has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"requires": {
-				"has-symbols": "^1.0.2"
-			}
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -1342,36 +1058,10 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
-		"is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			}
-		},
-		"is-date-object": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"requires": {
-				"has-tostringtag": "^1.0.0"
-			}
-		},
 		"is-promise": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
 			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
-		},
-		"is-regex": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			}
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -1433,11 +1123,6 @@
 				"thunky": "^1.0.2"
 			}
 		},
-		"multicast-dns-service-types": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
-		},
 		"napi-build-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -1470,20 +1155,6 @@
 				"node-addon-api": "^3.0.2",
 				"prebuild-install": "^7.1.1"
 			}
-		},
-		"object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			}
-		},
-		"object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -1540,15 +1211,6 @@
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
 				"util-deprecate": "^1.0.1"
-			}
-		},
-		"regexp.prototype.flags": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-			"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
 			}
 		},
 		"safe-buffer": {

--- a/listener_clients/relay-listener/package.json
+++ b/listener_clients/relay-listener/package.json
@@ -26,7 +26,7 @@
 		"@josephdadams/usbrelay": "^1.0.3",
 		"bonjour": "^3.5.1",
 		"cli-color": "^2.0.4",
-		"socket.io": "4.8.3",
+		"socket.io-client": "4.8.3",
 		"uuid": "^14.0.1"
 	},
 	"main": "index.js",

--- a/listener_clients/relay-listener/package.json
+++ b/listener_clients/relay-listener/package.json
@@ -24,7 +24,7 @@
 	"author": "Joseph Adams",
 	"dependencies": {
 		"@josephdadams/usbrelay": "^1.0.3",
-		"bonjour": "^3.5.1",
+		"bonjour-service": "^1.4.4",
 		"cli-color": "^2.0.4",
 		"socket.io-client": "4.8.3",
 		"uuid": "^14.0.1"


### PR DESCRIPTION
## What does this change do?

Fixes four defects in `listener_clients/relay-listener`: it no longer fails to install standalone, it re-registers with the server after a reconnect instead of going silently inert, and mDNS discovery works again. No server, UI, or other listener code is touched.

## Why?

No existing issues — all four were found while commissioning a relay-driven camera tally rig against a v3.3.0 server, and are described in full below. Each commit stands alone; happy to split this up if you'd rather take them separately.

### 1. `socket.io-client` is required but not declared

`index.js:5` requires `socket.io-client`. `package.json` declared `socket.io` — the **server**. Under Socket.IO v2 the server package bundled the client, so it resolved transitively; v3 dropped that bundling, so since the bump to 4.8.3 the client has been absent from a clean tree and the listener dies at startup with `MODULE_NOT_FOUND`.

This stays hidden when the listener runs inside a checkout of this repo, because Node walks up and finds `socket.io-client` in the **root** `node_modules`. It only bites people who install the listener standalone, or after the root tree is cleaned. In my case the root tree had a stale `socket.io-client@4.5.0`, so the listener was quietly running a different client version than the server ships.

```bash
cd listener_clients/relay-listener
rm -rf node_modules && npm install && node index.js
# Error: Cannot find module 'socket.io-client'
```

The `socket.io` server package is not used by this listener at all, so it is replaced rather than supplemented. Lockfile regenerated.

### 2. `listenerclient_connect` is never re-sent after a reconnect

The emit sat inline at the end of `connectToServer()`, so it ran exactly once. On the server side registration is bound to the socket — `socket.join('device-' + deviceId)`, `DeactivateListenerClient(socketId)` on disconnect, `UpdateListenerClients()` filtering on `!l.inactive` — so a reconnect brings a new socket id, leaving the client in no rooms with its records inactive. Nothing re-establishes either.

The listener stays up, logs `Connected to Tally Arbiter server.`, and never actuates a relay again. Relays freeze in whatever state they held when the link dropped.

This also brings the relay listener in line with the other three, which already register inside their `connect` handler:

| Client | connect handler | emit site |
|---|---|---|
| `gpo-listener.py` | `def connect():` line 177 | line 184 |
| `blink1-listener.py` | `def connect():` line 290 | line 293 |
| `pimoroni-blinkt-listener.py` | `def connect():` line 148 | line 151 |
| `relay-listener/index.js` | logged only | end of `connectToServer()` |

Worth flagging: this failure is silent. The process is alive, the log looks healthy, and the tally lights are simply wrong — stuck on for a camera that is off air, or stuck off for one that is live. In a live production that is worse than a crash, because nothing signals anything is wrong.

### 3. An unreadable mDNS TXT record kills the process

`service.txt.version` was dereferenced unguarded at `index.js:265`, so an advertisement that doesn't decode to the expected shape throws before any connection is attempted:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at index.js:265:28
    at Browser.<anonymous> (node_modules/bonjour/index.js:31:13)
```

Commit 4 fixes the decode that makes this reachable, but the guard is worth having on its own: as it stood, one unexpected packet from anything advertising `_tally-arbiter._tcp` on the network was enough to kill a tally listener outright — before any connection, so nothing in the server log would suggest a client had tried. A missing or unreadable version now logs and continues; a genuine 2.x server is still refused.

### 4. `bonjour` is unmaintained and mis-decodes the server's TXT record

This is what made #3 reachable. mDNS discovery has been broken in this listener since `bonjour` moved `^3.5.0` → `3.5.1`: `service.txt` arrives as `{"ersion":"3.3.0uuid=67faf61b"}` instead of `{version, uuid}`.

**The advertisement is not at fault.** I captured the response off port 5353 and walked the TXT rdata by hand, with no library in between:

```
TXT tallyarbiter-67faf61b._tally-arbiter._tcp.local  rdlen=28
0000  0d 76 65 72 73 69 6f 6e 3d 33 2e 33 2e 30 0d 75  |.version=3.3.0.u|
0010  75 69 64 3d 36 37 66 61 66 36 31 62              |uid=67faf61b|

string 0: prefix=0x0d (13)  "version=3.3.0"
string 1: prefix=0x0d (13)  "uuid=67faf61b"
walk consumed exactly 28/28 bytes — self-consistent
```

Two RFC 6763 strings with correct length prefixes, consuming exactly the 28 bytes the record declares. `bonjour-service` on the publishing side is doing the right thing.

The fault is in `bonjour`'s decode path, and it reproduces deterministically from those exact bytes:

- `dns-packet@5` returns TXT as an **array of chunks with the length prefixes already stripped**
- `bonjour/lib/browser.js:181-188` concatenates those chunks back together **without restoring the prefixes**, then hands the result to `dns-txt`, which expects wire format
- `dns-txt` reads the leading `'v'` (`0x76` = **118**) as a length prefix, overruns the 25 bytes that remain, and swallows the rest of the record

Feeding that same `dns-txt` the raw prefixed rdata returns `{"version":"3.3.0","uuid":"67faf61b"}` correctly, which isolates it to that concatenation.

`bonjour` has not been maintained for years. `bonjour-service` is its maintained successor and is **already a dependency of this repo** — it is what the server publishes with — so this puts both sides of the advertisement on the same library. Browsing the same live advertisement with it returns `{"version":"3.3.0","uuid":"67faf61b"}`.

Two behavioural differences had to be handled, so it isn't a drop-in swap:

- `findOne` takes `(opts, timeout, callback)`, not `(opts, callback)`. Passing the callback second silently sets the timeout to `NaN` and it never fires.
- `findOne` gives up after that timeout and calls back with `null`, where `bonjour` waited indefinitely. Giving up would be a regression — the listener and the server are commonly started together at boot, so the server may not be advertising yet. It now logs and browses again, preserving the old wait-until-found behaviour.

## How did you test it?

Platform: **Source** checkout on Windows 11, Node 24.13.1. Server: **v3.3.0 desktop build**. Listener client: **relay-listener**, driving a dcttech **USBRelay4**. Source type: ATEM.

**Reconnect (commit 2)** — listener started, confirmed driving relays, server killed and relaunched:

```
11:56:05  Disconnected from Tally Arbiter server.
11:56:38  Connected to Tally Arbiter server.
11:56:38  Relay 1 off / 2 off / 3 off / 4 off   [full state resync]
```

Before the fix, the same test produced the reconnect line and then nothing at all — no `bus_options`, no `device_states`, no relay commands, ever.

**No double registration (commit 2)** — I checked the server's own registry either side of the restart by emitting `listener_clients` and counting what came back:

```
entries for this relay listener : 4  (active: 4, inactive: 0)
active registrations per socket id: {"S_BuzEekFSzkwQUoAAAH": 4}
```

Exactly one registration per relay group on a single socket, so the fix does not double-register on first connect — Socket.IO buffers the emit made while disconnected and flushes it once. After the server restart the same four came back on a new socket id (`xcn_qo899jcHEGWuAAAD`), which is precisely what was missing before.

**Standalone install (commit 1)** — clean `npm install` in `listener_clients/relay-listener` with no root `node_modules` present, then `require('socket.io-client')` resolves. That is the exact repro above, now passing.

**mDNS end to end (commits 3 and 4)** — config switched to `useMDNS: true`, listener started: `Found TallyArbiter server using MDNS: engAtem:4455`, connected, all four relays synced. Verified against `bonjour-service@1.4.4`, which is what a fresh install of the declared range resolves to. Production config restored afterwards and byte-compared against the saved copy.

**After all of the above**, tally was punched on all four cameras on the live rig and followed correctly.

- [ ] `npm run build` succeeds — **N/A.** `build` is `tsc` over `src/`; this PR touches only `listener_clients/relay-listener/`, which that build does not compile, and the diff contains no TypeScript. Happy to run it if you'd like it on the record anyway.
- [x] I ran the change against a live Tally Arbiter instance
- [x] I verified the UI still loads and existing devices/sources still work <<<SEE NOTE — check or annotate>>>

## Checklist

- [x] The description above matches what the diff actually does
- [x] The diff contains only changes relevant to this PR — no unrelated reformatting, style rewrites, or drive-by edits. `index.js` has pre-existing Prettier drift on `main`; I deliberately left it alone rather than reformatting the file, so the diff stays on the lines that changed.
- [x] Any claim I make in this description (tests pass, scan is clean, build is green) is something I actually ran and can point to
