### PR TITLE
Add Analog Way LivePremier / Aquilon source

### DIFF
--- a/docs/docs/usage/sections/sources.md
+++ b/docs/docs/usage/sections/sources.md
@@ -9,6 +9,7 @@ Sources represent all of the tally data that is generated. This is usually your 
 The following source types are supported:
 
 - Analog Way Livecore Image Processors
+- Analog Way LivePremier / Aquilon
 - Blackmagic ATEM
 - Blackmagic VideoHub
 - Grass Valley Contribution Tally
@@ -29,6 +30,14 @@ When you add a source and the connection to the tally source (video switcher, so
 ## Analog Way Livecore Image Processors
 
 You will need the IP address of the device, and the port (standard port is 10600).
+
+## Analog Way LivePremier / Aquilon
+
+For LivePremier and Aquilon processors (the AWJ platform), running firmware 6.1.60 or later. You will need the IP address of the device and the port used by its Web RCS, which is usually 80. Source addresses are the input number.
+
+Program and preview tally are read directly from each input's on-air state, which the device already unions across every screen and aux, so any input routed to program or preview on any output will tally. Note that this reflects routing rather than on-screen visibility: an input assigned to a layer that is currently hidden (for example at zero opacity) still reports as on program or preview, matching what the device's own Web RCS shows.
+
+The device only pushes tally changes, not a snapshot on connect, so an input that is already on program or preview when Tally Arbiter connects will tally on its next program or preview change.
 
 ## Blackmagic ATEM
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
 				"tsl-umd-v5": "^1.0.5",
 				"uuid": "^14.0.0",
 				"winston": "^3.17.0",
+				"ws": "^8.21.1",
 				"xml2js": "^0.6.2"
 			},
 			"bin": {
@@ -51,6 +52,7 @@
 				"@types/find-remove": "^2.0.1",
 				"@types/mqtt": "^2.5.0",
 				"@types/node": "^26.1.2",
+				"@types/ws": "^8.5.10",
 				"@types/xml2js": "^0.4.11",
 				"electron": "^39.8.5",
 				"electron-builder": "^26.8.1",
@@ -3444,27 +3446,6 @@
 				"xmlhttprequest-ssl": "~2.1.1"
 			}
 		},
-		"node_modules/engine.io-client/node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/engine.io-parser": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -3481,27 +3462,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/engine.io/node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/env-paths": {
@@ -5354,27 +5314,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/mqtt/node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5702,17 +5641,16 @@
 				"ws": "*"
 			}
 		},
-		"node_modules/obs-websocket-js-5/node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-			"license": "MIT",
+		"node_modules/obs-websocket-js/node_modules/ws": {
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=8.3.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
+				"utf-8-validate": "^5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -6958,27 +6896,6 @@
 				"ws": "~8.21.0"
 			}
 		},
-		"node_modules/socket.io-adapter/node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/socket.io-client": {
 			"version": "4.8.3",
 			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -8086,16 +8003,15 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "7.5.13",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
-			"license": "MIT",
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
 			"engines": {
-				"node": ">=8.3.0"
+				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
 		"tsl-umd-v5": "^1.0.5",
 		"uuid": "^14.0.0",
 		"winston": "^3.17.0",
+		"ws": "^8.21.1",
 		"xml2js": "^0.6.2"
 	},
 	"main": "main.js",
@@ -205,6 +206,7 @@
 		"@types/find-remove": "^2.0.1",
 		"@types/mqtt": "^2.5.0",
 		"@types/node": "^26.1.2",
+		"@types/ws": "^8.5.10",
 		"@types/xml2js": "^0.4.11",
 		"electron": "^39.8.5",
 		"electron-builder": "^26.8.1",

--- a/src/sources/AnalogWayLivePremier.ts
+++ b/src/sources/AnalogWayLivePremier.ts
@@ -1,0 +1,155 @@
+import { logger } from '..'
+import { RegisterTallyInput } from '../_decorators/RegisterTallyInput.decorator'
+import { Source } from '../_models/Source'
+import { TallyInput } from './_Source'
+import WebSocket from 'ws'
+
+// Analog Way LivePremier / Aquilon (the AWJ platform). This is a different
+// platform from the older Livecore processors in AnalogWayLivecore.ts and
+// speaks a different protocol, hence a separate source type.
+//
+// LivePremier has no tally/UMD protocol. Each input instead carries isOnProgram
+// and isOnPreview booleans, which the device already unions across every screen
+// and aux, so one flag pair per input answers "live/next on any output". These
+// track routing rather than on-screen visibility: an input on a hidden layer
+// (e.g. zero opacity) still reads on-air, matching the device's own Web RCS.
+//
+// The Web RCS port also serves a plain WebSocket (ws://<host>:<port>) that
+// streams device-model changes as JSON frames on a "DEVICE" channel, e.g.
+//   {"channel":"DEVICE","data":{"path":["device","inputList","items","IN_5",
+//     "status","pp","isOnProgram"],"value":true}}
+// The socket only sends changes, never a snapshot on connect, so an input that
+// is already on-air when Tally Arbiter connects tallies on its next change.
+
+const INPUT_KEY = /^IN_(\d+)$/
+
+interface InputState {
+	program: boolean
+	preview: boolean
+}
+
+@RegisterTallyInput(
+	'c7e1a94f',
+	'Analog Way LivePremier',
+	'For LivePremier / Aquilon (AWJ), firmware 6.1.60 or later. Use the same IP and port as the Web RCS. Source addresses are the input number.',
+	[
+		{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+		// 'number', not 'port': this is the remote Web RCS port we connect to, not a
+		// local port we bind, so it must skip the in-use check (the Web RCS is often 80).
+		{ fieldName: 'port', fieldLabel: 'Port', fieldType: 'number' },
+	],
+)
+export class AWLivePremierSource extends TallyInput {
+	private ws: WebSocket | undefined
+	private inputs: Record<string, InputState> = {}
+	private closing = false
+
+	constructor(source: Source) {
+		super(source)
+		this.connect()
+	}
+
+	private connect(): void {
+		this.closing = false
+		const url = `ws://${this.source.data.ip}:${this.source.data.port}`
+		logger(`Source: ${this.source.name}  Connecting to Analog Way LivePremier at ${url}.`, 'info-quiet')
+
+		const ws = new WebSocket(url)
+		this.ws = ws
+
+		ws.on('open', () => this.connected.next(true))
+		ws.on('message', (data) => this.handleMessage(data.toString()))
+		ws.on('error', (error) => {
+			// Aborting a socket that is still connecting emits an error; ignore it
+			// during teardown so it can never surface as an unhandled 'error'.
+			if (this.closing) return
+			logger(`Source: ${this.source.name}  Analog Way LivePremier connection error: ${error}`, 'error')
+		})
+		ws.on('close', () => {
+			if (this.ws !== ws) return // a socket we already replaced
+			this.ws = undefined
+			if (!this.closing) this.connected.next(false) // let the base class reconnect
+		})
+	}
+
+	private handleMessage(raw: string): void {
+		let message: any
+		try {
+			message = JSON.parse(raw)
+		} catch (e) {
+			return
+		}
+		// Only the DEVICE channel carries the per-input flags, one leaf per frame.
+		if (message?.channel !== 'DEVICE' || !message.data || !Array.isArray(message.data.path)) return
+
+		// Path shape: [..., "items", "IN_<n>", ..., "<leaf>"].
+		const path: any[] = message.data.path
+		const itemsIndex = path.indexOf('items')
+		if (itemsIndex === -1) return
+		const keyMatch = INPUT_KEY.exec(String(path[itemsIndex + 1] ?? ''))
+		if (!keyMatch) return
+
+		const address = keyMatch[1]
+		const leaf = String(path[path.length - 1])
+		const value = message.data.value
+
+		switch (leaf) {
+			case 'isOnProgram':
+				this.registerInput(address).program = Boolean(value)
+				this.sendInputTally(address)
+				break
+			case 'isOnPreview':
+				this.registerInput(address).preview = Boolean(value)
+				this.sendInputTally(address)
+				break
+			case 'label':
+				// Surface the device's own input name instead of a bare number.
+				this.ensureInput(address)
+				this.addAddress(String(value) || `Input ${address}`, address)
+				break
+		}
+	}
+
+	private ensureInput(address: string): InputState {
+		if (!this.inputs[address]) this.inputs[address] = { program: false, preview: false }
+		return this.inputs[address]
+	}
+
+	// As ensureInput, but also list the input (under a placeholder label until
+	// its real label frame arrives) so it shows up as an address.
+	private registerInput(address: string): InputState {
+		const isNew = !this.inputs[address]
+		const state = this.ensureInput(address)
+		if (isNew) this.addAddress(`Input ${address}`, address)
+		return state
+	}
+
+	private sendInputTally(address: string): void {
+		const state = this.inputs[address]
+		const busses: string[] = []
+		if (state.program) busses.push('program')
+		if (state.preview) busses.push('preview')
+		this.sendIndividualTallyData(address, busses)
+	}
+
+	public reconnect(): void {
+		this.connect()
+	}
+
+	public exit(): void {
+		super.exit()
+		this.closing = true
+		if (this.ws) {
+			const ws = this.ws
+			this.ws = undefined
+			// Keep the 'error' listener attached (it ignores errors while closing)
+			// so terminating a still-connecting socket can't raise an unhandled
+			// 'error'. terminate() aborts a pending connection immediately.
+			ws.removeAllListeners('open')
+			ws.removeAllListeners('message')
+			ws.removeAllListeners('close')
+			ws.terminate()
+		}
+		this.connected.next(false)
+	}
+}


### PR DESCRIPTION
# Add Analog Way LivePremier / Aquilon source

Disclaimer: Yes, this was mostly vibed up using Claude Opus, I don't have the coding expertise to do this on my own.  That said I DID read through it, and I did test it against both AW Simulator and a live Aquilon C+, it seems to work as designed.  

Adds a source type for Analog Way **LivePremier / Aquilon** processors (the AWJ
platform). These are a different platform from the Ascender / NeXtage processors
handled by `AnalogWayLivecore.ts` and speak a different protocol, so this is a
sibling source type rather than a change to the existing one.

## How it works

LivePremier has no tally/UMD protocol. Each input instead carries `isOnProgram`
and `isOnPreview` booleans, which the device already unions across every screen
and aux — so one flag pair per input answers "live/next on any output", with no
screen tree to walk.

The Web RCS port also serves a plain WebSocket that streams device-model changes
as JSON frames on a `DEVICE` channel:

```json
{"channel":"DEVICE","data":{"path":["device","inputList","items","IN_5","status","pp","isOnProgram"],"value":true}}
```

The source reacts to these and emits a per-input delta. Input labels from the
device are used as the address label when present. Source addresses are the
input number.

Two things worth calling out for review:

- **Semantics: routing, not visibility.** `isOnProgram` / `isOnPreview` report an
  input as on-air even if it is on a hidden layer (e.g. zero opacity). This
  matches the device's own Web RCS and is the safer signal for tally. Documented.
- **No snapshot on connect.** The socket only sends changes. An input already
  on-air when Tally Arbiter connects tallies on its next change. Documented; a
  snapshot read would mean a second, much heavier transport, which did not seem
  worth it for a tally source.

## Dependency

Uses `ws`, already deep in the dependency tree (pinned via `overrides` for `osc`
at `^8.21.1`); this declares it as a direct dependency and adds `@types/ws`.
`package-lock.json` is updated accordingly.

## Testing

Verified against an Analog Way Aquilon simulator (firmware 6.1.60, carrying a
real show config) with perturb-and-recall:

- Program / preview / both / clear map correctly across takes on a single screen,
  across multiple screens, and via auxes (confirming the screen+aux union).
- Input label frames are picked up and used as the address label.
- Also confirmed against a live LivePremier unit (Web RCS on port 80): program and
  preview tally track a real input correctly on both the on and off transitions.
- Builds clean (`tsc`) and passes `prettier --check`.

## Files

- `src/sources/AnalogWayLivePremier.ts` — the source
- `package.json` / `package-lock.json` — declare `ws` + `@types/ws`
- `docs/docs/usage/sections/sources.md` — list entry + section
