### PR TITLE
feat(relay-listener): verify relay switching by reading state back

### DIFF
--- a/listener_clients/relay-listener/README.md
+++ b/listener_clients/relay-listener/README.md
@@ -127,6 +127,37 @@ On `systemctl stop` or `systemctl restart`, the listener turns off the relays it
 
 Upon startup, the program will enumerate through the `config_relays.json` file and attempt to connect to the specified Tally Arbiter server.
 
+# Checking the relays
+
+If you are not standing next to the hardware, you cannot hear the relays click -- so the diagnostics read each relay's state back off the board's own state register instead of assuming a write worked:
+
+```bash
+npm run test-relays
+```
+
+This cycles every relay on every board and reports each one as `confirmed` or `NOT CONFIRMED`. A relay that will not confirm accepted the write but did not change state, which is almost always a permissions problem (try `sudo node test-relays.js`; if that works, install the `udev` rule). If every relay confirms, the hardware is fine and any remaining problem is above the relay layer -- the Device assignment, the bus type, or the relay mapping in `config_relays.json`.
+
+To test one relay instead of all of them:
+
+```bash
+node test-relays.js --board BITFT --relay 3
+```
+
+To watch tally changes arrive, run this **while the service is running** and trigger a tally:
+
+```bash
+node test-relays.js --watch
+```
+
+It polls the boards directly and prints a timestamped line whenever a relay changes, so you can see whether tally data is reaching the hardware:
+
+```
+[2:52:00 PM] BITFT relay 1: off -> ON
+[2:52:02 PM] BITFT relay 1: ON  -> off
+```
+
+Nothing printing while a tally is active means the states are not reaching the relays; the listener's own log (`journalctl -u tallyarbiter-relay -f`) is the next place to look.
+
 # Relay Hardware
 
 Tally Arbiter Relay Listener supports USB relays with up to 8 separate relays. If you need more relays, run the program on more devices. It is designed to run on a Raspberry Pi Zero 2 W for a low cost of entry.

--- a/listener_clients/relay-listener/package.json
+++ b/listener_clients/relay-listener/package.json
@@ -37,6 +37,7 @@
 	"main": "index.js",
 	"scripts": {
 		"setup": "node setup.js",
-		"start": "node index.js"
+		"start": "node index.js",
+		"test-relays": "node test-relays.js"
 	}
 }

--- a/listener_clients/relay-listener/setup.js
+++ b/listener_clients/relay-listener/setup.js
@@ -125,16 +125,60 @@ function detectBoards() {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
-//pulses a relay so the user can hear/see which physical channel they are configuring
-async function testRelay(board, relayNumber) {
+//reads the relay state back off the board itself, so we are not just trusting the write
+function readRelayState(board, relayNumber) {
+	try {
+		return board.relay.getState(relayNumber)
+	} catch (error) {
+		return { error: error.message }
+	}
+}
+
+const showState = (state) => (state ? clc.green.bold('ON') : clc.blackBright('off'))
+
+//pulses a relay and confirms the change by reading the board's own state register, so this is
+//verifiable over SSH with nobody standing next to the hardware
+async function testRelay(board, relayNumber, { pulseMs = 1500 } = {}) {
+	const before = readRelayState(board, relayNumber)
+	if (before && before.error) {
+		fail(`  Could not read relay ${relayNumber} on ${board.serial}: ${before.error}`)
+		return false
+	}
+
 	try {
 		board.relay.setState(relayNumber, true)
-		await sleep(600)
-		board.relay.setState(relayNumber, false)
-		note(`  Pulsed relay ${relayNumber} on ${board.serial}.`)
 	} catch (error) {
-		fail(`  Could not switch relay ${relayNumber}: ${error.message}`)
+		fail(`  Could not switch relay ${relayNumber} on: ${error.message}`)
+		return false
 	}
+
+	const whileOn = readRelayState(board, relayNumber)
+	note(`  Relay ${relayNumber} on ${board.serial}: was ${showState(before)}, now reads ${showState(whileOn)}`)
+
+	if (whileOn !== true) {
+		fail('  The board did not report this relay as on, so it probably did not switch.')
+		warn('  Check the relay number, and that this board is the one you think it is.')
+	} else {
+		note(`  Holding for ${pulseMs / 1000} seconds -- listen for the click, or watch the relay LED.`)
+	}
+
+	await sleep(pulseMs)
+
+	try {
+		board.relay.setState(relayNumber, false)
+	} catch (error) {
+		fail(`  Could not switch relay ${relayNumber} back off: ${error.message}`)
+		return false
+	}
+
+	const after = readRelayState(board, relayNumber)
+	note(`  Relay ${relayNumber} released, now reads ${showState(after)}`)
+
+	if (whileOn === true && after === false) {
+		note(clc.green('  Confirmed: the board reported this relay switching on and back off.'))
+		return true
+	}
+	return false
 }
 
 function turnAllOff(boards) {

--- a/listener_clients/relay-listener/test-relays.js
+++ b/listener_clients/relay-listener/test-relays.js
@@ -1,0 +1,220 @@
+/* Tally Arbiter Relay Listener -- relay diagnostics */
+
+// Answers "did the relay actually switch?" without anyone standing next to the hardware,
+// by reading each relay's state back off the board's own state register.
+//
+//   node test-relays.js                        cycle every relay, confirming each one
+//   node test-relays.js --watch                show relay states live, as they change
+//   node test-relays.js --board BITFT --relay 3  cycle just one relay
+//
+// --watch is safe to run while the service is running, which is the point: start a tally and
+// watch the states change here.
+
+const clc = require('cli-color')
+const USBRelay = require('@josephdadams/usbrelay')
+
+const MAX_RELAYS_PER_BOARD = 8
+const WATCH_INTERVAL_MS = 250
+
+const args = process.argv.slice(2)
+const hasFlag = (name) => args.includes(name)
+const flagValue = (name) => {
+	const index = args.indexOf(name)
+	return index === -1 ? null : args[index + 1]
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const showState = (state) =>
+	state === true ? clc.green.bold('ON ') : state === false ? clc.blackBright('off') : clc.red('? ')
+
+function relayCountFor(board) {
+	const match = /USBRelay(\d+)/i.exec(board.product || '')
+	if (!match) return MAX_RELAYS_PER_BOARD
+	return Math.min(parseInt(match[1], 10), MAX_RELAYS_PER_BOARD)
+}
+
+function openBoards() {
+	let descriptors = []
+	try {
+		descriptors = USBRelay.Relays
+	} catch (error) {
+		console.log(clc.red.bold(`Could not enumerate USB relays: ${error.message}`))
+		return []
+	}
+
+	const boards = []
+	for (const descriptor of descriptors) {
+		try {
+			descriptor.relay = new USBRelay(descriptor.path)
+			boards.push(descriptor)
+		} catch (error) {
+			console.log(clc.red(`Could not open ${descriptor.path}: ${error.message}`))
+		}
+	}
+	return boards
+}
+
+function readState(board, relayNumber) {
+	try {
+		return board.relay.getState(relayNumber)
+	} catch {
+		return null //null means unreadable, which is different from off
+	}
+}
+
+function readAll(board) {
+	const states = []
+	for (let n = 1; n <= relayCountFor(board); n++) states.push(readState(board, n))
+	return states
+}
+
+function describeBoard(board) {
+	return `${board.product || 'USB relay'} serial ${clc.bold(board.serial || '(none)')} at ${board.path}`
+}
+
+function printBoardStates(board) {
+	const states = readAll(board)
+	const cells = states.map((state, index) => `${index + 1}:${showState(state)}`)
+	console.log(`  ${clc.bold((board.serial || board.path).padEnd(6))} ${cells.join('  ')}`)
+}
+
+//cycles one relay and reports whether the board confirmed the change
+async function cycleRelay(board, relayNumber) {
+	const before = readState(board, relayNumber)
+
+	try {
+		board.relay.setState(relayNumber, true)
+	} catch (error) {
+		console.log(clc.red(`  relay ${relayNumber}: could not switch on -- ${error.message}`))
+		return false
+	}
+	const whileOn = readState(board, relayNumber)
+
+	await sleep(700)
+
+	try {
+		board.relay.setState(relayNumber, false)
+	} catch (error) {
+		console.log(clc.red(`  relay ${relayNumber}: could not switch off -- ${error.message}`))
+		return false
+	}
+	const after = readState(board, relayNumber)
+
+	const confirmed = whileOn === true && after === false
+	const verdict = confirmed ? clc.green.bold('confirmed') : clc.red.bold('NOT CONFIRMED')
+	console.log(
+		`  relay ${relayNumber}: ${showState(before)} -> ${showState(whileOn)} -> ${showState(after)}  ${verdict}`,
+	)
+	return confirmed
+}
+
+async function cycleMode(boards) {
+	const onlyBoard = flagValue('--board')
+	const onlyRelay = flagValue('--relay') ? Number(flagValue('--relay')) : null
+
+	let confirmed = 0
+	let attempted = 0
+
+	for (const board of boards) {
+		if (onlyBoard && board.serial !== onlyBoard) continue
+
+		console.log('')
+		console.log(describeBoard(board))
+		console.log(clc.blackBright('  current state:'))
+		printBoardStates(board)
+		console.log(clc.blackBright('  cycling:'))
+
+		const count = relayCountFor(board)
+		for (let n = 1; n <= count; n++) {
+			if (onlyRelay !== null && n !== onlyRelay) continue
+			attempted++
+			if (await cycleRelay(board, n)) confirmed++
+		}
+	}
+
+	console.log('')
+	if (attempted === 0) {
+		console.log(clc.yellow('Nothing was tested. Check --board / --relay against the list above.'))
+		return
+	}
+
+	if (confirmed === attempted) {
+		console.log(clc.green.bold(`All ${attempted} relay(s) confirmed switching by read-back.`))
+		console.log(clc.blackBright('The hardware works. If tally still does nothing, the problem is above the relay:'))
+		console.log(clc.blackBright('the config mapping, the Device assignment, or the bus type.'))
+	} else {
+		console.log(clc.red.bold(`${confirmed} of ${attempted} relay(s) confirmed.`))
+		console.log(clc.blackBright('A relay that will not confirm is usually a permissions or wiring problem.'))
+	}
+}
+
+//polls every relay and prints a line whenever one changes, so a tally change is visible over SSH
+async function watchMode(boards) {
+	console.log('')
+	console.log(clc.blue.bold('Watching relay states. Trigger a tally now. Ctrl-C to stop.'))
+	console.log(clc.blackBright('This reads the boards directly, so it works while the service is running.'))
+	console.log('')
+
+	for (const board of boards) {
+		console.log(describeBoard(board))
+	}
+	console.log('')
+	console.log(clc.blackBright('Initial state:'))
+	for (const board of boards) printBoardStates(board)
+	console.log('')
+
+	const previous = new Map()
+	for (const board of boards) previous.set(board.path, readAll(board))
+
+	for (;;) {
+		await sleep(WATCH_INTERVAL_MS)
+
+		for (const board of boards) {
+			const now = readAll(board)
+			const before = previous.get(board.path)
+
+			for (let i = 0; i < now.length; i++) {
+				if (now[i] !== before[i]) {
+					const stamp = new Date().toLocaleTimeString()
+					console.log(
+						`[${stamp}] ${board.serial || board.path} relay ${i + 1}: ${showState(before[i])} -> ${showState(now[i])}`,
+					)
+				}
+			}
+			previous.set(board.path, now)
+		}
+	}
+}
+
+async function main() {
+	console.log('')
+	console.log(clc.blue.bold('Tally Arbiter Relay Listener -- relay diagnostics'))
+
+	const boards = openBoards()
+
+	if (boards.length === 0) {
+		console.log('')
+		console.log(clc.red.bold('No USB relay boards could be opened.'))
+		console.log(clc.blackBright('If the boards are plugged in, this is almost always permissions.'))
+		console.log(clc.blackBright('Try `sudo node test-relays.js`; if that works, install the udev rule'))
+		console.log(clc.blackBright('(see the README) so it works without root.'))
+		process.exit(1)
+	}
+
+	if (hasFlag('--watch')) {
+		await watchMode(boards)
+	} else {
+		await cycleMode(boards)
+	}
+}
+
+process.on('SIGINT', () => {
+	console.log('')
+	console.log(clc.blackBright('Stopped. Relay states were left as they are.'))
+	process.exit(0)
+})
+
+main().catch((error) => {
+	console.log(clc.red.bold(`Diagnostics failed: ${error.stack || error.message}`))
+	process.exit(1)
+})


### PR DESCRIPTION
Follow-up to #1209. Reported from the field: running the wizard over SSH, the pulse prints success and a tally changes nothing visible — with no way to tell a working relay from one silently doing nothing, because you can't hear the click from another room.

## The gap

Both the wizard's pulse and the tally path were unverifiable remotely. The code wrote to the relay and reported success, but "success" only meant the feature report was sent without throwing. A board that accepts writes and does nothing looked identical to a working one.

These boards can report their own state — `getState()` reads a feature report and takes the relay bitmask out of byte 8 (`@josephdadams/usbrelay`). Nothing was using it.

## The change

**The wizard's pulse now verifies itself.** It reads the relay before, during, and after, prints each state, and says explicitly whether the board confirmed the change. Hold time goes from 600ms to 1.5s, which is long enough to actually hear.

```
Relay 1 on BITFT: was off, now reads ON
Holding for 1.5 seconds -- listen for the click, or watch the relay LED.
Relay 1 released, now reads off
Confirmed: the board reported this relay switching on and back off.
```

**`npm run test-relays`** cycles every relay and reports each as `confirmed` or `NOT CONFIRMED`. This is the diagnostic that splits the problem in two: if every relay confirms, the hardware and permissions are fine and the fault is above the relay layer — Device assignment, bus type, or the mapping in `config_relays.json`. If relays don't confirm, it's the hardware path, and permissions is the usual cause. `--board` / `--relay` narrow it to one.

**`node test-relays.js --watch`** polls the boards and prints a timestamped line whenever a relay changes. It reads the hardware directly rather than going through the listener, so it runs *alongside* the service — start a tally and watch whether it lands:

```
[2:52:00 PM] BITFT relay 1: off -> ON
[2:52:02 PM] BITFT relay 1: ON  -> off
```

Nothing printing during an active tally means the states aren't reaching the relays, and the listener's own log is the next place to look.

## Testing

Tested against a simulated pair of boards — one honest, one deliberately rigged to accept writes and never change state, since that silent-failure case is the whole reason for the feature. It's correctly distinguished:

```
USBRelay2 serial BITFT at /dev/fake0
  relay 1: off -> ON  -> off  confirmed
  relay 2: off -> ON  -> off  confirmed

USBRelay8 serial DEAD1 at /dev/fake1
  relay 1: off -> off -> off  NOT CONFIRMED
  ...
2 of 10 relay(s) confirmed.
```

Also verified: channel count is respected (the `USBRelay2` is offered 2 relays, not 8), `--watch` picks up externally-driven changes with timestamps, `--board`/`--relay` filter correctly, and a filter matching nothing says so instead of silently passing.

**Read-back itself is unproven on real hardware.** This is the load-bearing caveat: if `getState()` is unreliable on these boards, the diagnostic will confidently report `NOT CONFIRMED` for relays that are physically working, which is worse than having no diagnostic. That's the first thing to check on a real board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
