### PR TITLE
fix(users): keep passwords on edit, and make the change-password page reachable

### DIFF
--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -1467,23 +1467,26 @@
 			</select>
 			<small class="form-text">Use Ctrl to select multiple items.</small>
 		</div>
-		<div class="mb-3" *ngIf="!editingUser">
-			<label for="userPassword" class="form-label">Password</label>
+		<div class="mb-3">
+			<label for="userPassword" class="form-label">{{ editingUser ? 'New Password' : 'Password' }}</label>
 			<input
-				required
+				[required]="!editingUser"
 				type="password"
 				class="form-control"
 				id="userPassword"
 				autocomplete="new-password"
 				[(ngModel)]="currentUser.password"
 			/>
-			<small class="form-text">At least {{ minPasswordLength }} characters.</small>
-			<div class="text-danger mt-1" *ngIf="currentUser.password && newUserPasswordError">
-				{{ newUserPasswordError }}
+			<small class="form-text" *ngIf="!editingUser">At least {{ minPasswordLength }} characters.</small>
+			<small class="form-text" *ngIf="editingUser"
+				>Leave blank to keep the current password. At least {{ minPasswordLength }} characters otherwise.</small
+			>
+			<div class="text-danger mt-1" *ngIf="currentUser.password && userPasswordError">
+				{{ userPasswordError }}
 			</div>
 		</div>
 		<div class="d-flex justify-content-end">
-			<button class="btn btn-primary" (click)="saveCurrentUser()" [disabled]="newUserPasswordError !== ''">
+			<button class="btn btn-primary" (click)="saveCurrentUser()" [disabled]="userPasswordError !== ''">
 				<i class="fas fa-save"></i> {{ editingUser ? 'Save Changes' : 'Add User' }}
 			</button>
 		</div>

--- a/UI/src/app/_components/settings/settings.component.html
+++ b/UI/src/app/_components/settings/settings.component.html
@@ -568,8 +568,8 @@
 							<i class="fas fa-exclamation-triangle me-2"></i>
 							<strong>{{ socketService.defaultPasswordUsers.join(', ') }}</strong>
 							{{ socketService.defaultPasswordUsers.length === 1 ? 'is' : 'are' }} still using the default password that
-							Tally Arbiter ships with. Anyone who can reach this server can sign in. Please set a real password below —
-							this will be enforced in a future release.
+							Tally Arbiter ships with. Anyone who can reach this server can sign in. Use <strong>Edit</strong> below to
+							set a real password — this will be enforced in a future release.
 						</div>
 						<span class="text-muted mt-3 d-block" *ngIf="socketService.users.length == 0"
 							>No user found. This should not happen... Please, open a bug report on Github.</span

--- a/UI/src/app/_components/settings/settings.component.ts
+++ b/UI/src/app/_components/settings/settings.component.ts
@@ -782,11 +782,13 @@ export class SettingsComponent implements OnInit, OnDestroy {
 	}
 
 	//a new user needs a real password. this used to fall back to '12345', which quietly
-	//created accounts on the password Tally Arbiter ships with.
-	public get newUserPasswordError(): string {
-		if (this.editingUser) return ''
+	//created accounts on the password Tally Arbiter ships with. when editing, a blank
+	//field means 'keep the current password', so only a non-empty one is checked.
+	public get userPasswordError(): string {
 		const password = this.currentUser.password || ''
-		if (password.length === 0) return 'Please set a password for this user.'
+		if (password.length === 0) {
+			return this.editingUser ? '' : 'Please set a password for this user.'
+		}
 		if (password.length < MIN_PASSWORD_LENGTH) {
 			return `The password must be at least ${MIN_PASSWORD_LENGTH} characters long.`
 		}
@@ -794,12 +796,17 @@ export class SettingsComponent implements OnInit, OnDestroy {
 	}
 
 	public saveCurrentUser() {
-		if (this.newUserPasswordError !== '') return
+		if (this.userPasswordError !== '') return
 		const userObj = {
 			...this.currentUser,
 		} as any
 		if (!userObj.roles) {
 			userObj.roles = 'tally_view'
+		}
+		//a blank field on an edit means 'leave the password alone', so send nothing at all
+		//rather than an empty one
+		if (this.editingUser && !userObj.password) {
+			delete userObj.password
 		}
 		const arbiterObj = {
 			action: this.editingUser ? 'edit' : 'add',
@@ -1006,7 +1013,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
 	public editUser(user: User, modal: any) {
 		this.editingUser = true
-		this.currentUser = user
+		//a copy: the dialog binds straight to this object, so editing the list entry itself
+		//would show unsaved edits in the table behind it, and would leave a typed password
+		//sitting in the users list after the dialog is dismissed
+		this.currentUser = { ...user } as User
 		this.selectedUserRoles = user.roles.split(';')
 		this.modalService.open(modal)
 	}

--- a/UI/src/app/app.component.html
+++ b/UI/src/app/app.component.html
@@ -25,6 +25,11 @@
 					<a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/about">About</a>
 				</li>
 				<li class="nav-item" *ngIf="authService.profile !== undefined">
+					<a class="nav-link" routerLinkActive="active" (click)="showMenu = false" routerLink="/change-password/home"
+						>Change Password</a
+					>
+				</li>
+				<li class="nav-item" *ngIf="authService.profile !== undefined">
 					<a class="nav-link" (click)="showMenu = false; authService.logout()" style="cursor: pointer">Logout</a>
 				</li>
 				<li class="nav-item" *ngIf="authService.profile === undefined">

--- a/src/_helpers/auth.ts
+++ b/src/_helpers/auth.ts
@@ -161,6 +161,12 @@ export function editUser(user: User) {
 			const passwordChanged = !!user.password && !BCRYPT_HASH_PATTERN.test(user.password)
 			if (passwordChanged) {
 				user.password = hashPassword(user.password)
+			} else if (!user.password) {
+				//the users list is served without passwords, so an edit that only changes roles
+				//arrives with the field missing entirely. the whole record is replaced below, so
+				//without this the account is left with no password at all and can never sign in
+				//again -- and there is no way back, because it is not the caller's own account.
+				user.password = user_original.password
 			}
 			//the whole record is replaced here, so an edit that does not touch the password
 			//(changing roles, say) must not quietly clear a pending forced change

--- a/src/index.ts
+++ b/src/index.ts
@@ -1670,7 +1670,7 @@ export function WarnAboutDefaultPasswords(): Promise<string[]> {
 				logger(
 					`WARNING: ${usernames.map((u) => `'${u}'`).join(', ')} ${
 						usernames.length === 1 ? 'is' : 'are'
-					} still using the default password. Change it in Settings > Users.`,
+					} still using the default password. Change it from Settings > Users, or from the Change Password link in the menu.`,
 					'error',
 				)
 			}


### PR DESCRIPTION
## What does this change do?

Editing a user in Settings > Users no longer erases that user's password, and the dialog now offers an optional **New Password** field so an existing account can actually be given one. The change-password page also gets a link in the menu, and the two places that told operators to "change it in Settings > Users" now name something that can do the job.

## Why?

Fixes #1199.

That issue reports that the default-password banner tells you to set a real password "below", but the Users edit dialog has no password field and the working `/change-password` page isn't linked from anywhere.

While wiring the field up I found the same path is worse than a dead end — **it destroys the account**.

### The data loss

`editUser()` in `src/_helpers/auth.ts` replaces the whole record with whatever the client sends:

```ts
currentConfig.users[index] = user
```

The users list is served with passwords stripped (`getUsersList()` deletes them), so the object the settings UI holds has no `password` field and `saveCurrentUser()` spreads it straight back. `passwordChanged` is false, nothing repopulates the field, and the stored hash is gone. Changing a user's **role** is enough to trigger it, and the account cannot be recovered from the UI — precisely because there was no way to set a password on an existing user.

Reproduced against a server on `main` by emitting the exact payload `settings.component.ts` sends:

```
payload: {"username":"producer","roles":"producer;tally_view","mustChangePassword":true}

--- config BEFORE the edit ---
  producer   password=$2b$10$vkthC...  roles=producer            mustChange=true
--- config AFTER the edit ---
  producer   password=*** ABSENT ***   roles=producer;tally_view mustChange=true

producer login with its original password: false | Wrong username or password!
```

Present in v3.3.0 as well — `editUser`, `getUsersList` and both UI methods are identical at that tag.

The fix keeps the stored hash when the incoming record has no password. A supplied bcrypt hash is still left alone, so behaviour only changes when the field is absent or empty.

### The rest

**No new server endpoint was needed**, which answers the question the issue left open. `editUser()` already hashes an incoming plaintext password and leaves an existing bcrypt hash alone — `BCRYPT_HASH_PATTERN` is there for exactly this — and `manage` is already behind `requireRole('settings')`, so it is already admin-scoped.

On an edit the password field is optional: blank means "keep the current password", only a non-empty value is length-checked, and a blank one is stripped from the payload rather than sent as an empty string. `editUser()` in the component now takes a copy of the user rather than aliasing the list entry — without that, the dialog binds to the object in the users table, so a typed password would sit in that list even after dismissing the dialog.

Three commits, each standing alone:

1. `fix(users): keep the stored password when an edit does not set a new one` — `src/_helpers/auth.ts`
2. `feat(ui): let an admin set a user's password from the edit dialog` — settings component
3. `fix(ui): make the change-password page reachable and its signposts accurate` — navbar, banner, server hint

## How did you test it?

Platform: **Source** checkout on Windows 11, Node 24.13.1 (Angular 22's CLI needs >= 24.15.0, so the UI was built with a portable Node 24.19.0). Source type: **Internal Test Mode**. Server run from this branch with an isolated `APPDATA` and `PORT=4456` so it could not touch a production config.

**The data-loss fix**, driven over the socket API:

```
CASE A: edit roles only, no password supplied
  [PASS] stored password still present
  [PASS] stored password unchanged
  [PASS] producer can still log in with its original password

CASE B: edit and supply a new password
  [PASS] stored value is a bcrypt hash, not plaintext
  [PASS] stored password actually changed
  [PASS] producer logs in with the NEW password
  [PASS] producer no longer logs in with the old one
```

**Then the same two cases through the actual dialog in Chrome**, against that server with the UI built from this branch:

- Settings > Users > **Edit** shows the **New Password** field with "Leave blank to keep the current password. At least 8 characters otherwise."
- Saving with the field blank logs `Edited user producer` and leaves the stored hash byte-identical (`$2b$10$sjVStrNg84rMt…` before and after). On v3.3.0 the same click empties it.
- Saving with a password typed in replaces the hash (`$2b$10$WMuXVuWZBMZFQ…`); the account then logs in with the new password and not the old one.

**The reachability changes:**

- **Change Password** appears in the menu once signed in and not before, and reaches the page. The first-run forced change still works.
- The banner renders as "…Anyone who can reach this server can sign in. Use **Edit** below to set a real password", directly above the control that now does the job.
- The boot warning reads `WARNING: 'producer' is still using the default password. Change it from Settings > Users, or from the Change Password link in the menu.`

Note for anyone reproducing the banner: it only renders for an account that is on the shipped password **and** not flagged `mustChangePassword`, so a fresh install never shows it — I cleared the flag on one account to get it on screen.

- [x] `npm run build` succeeds — ran it, exit 0. `ng build` in `UI/` is also clean, and `prettier --check` passes on all five files touched.
- [x] I ran the change against a live Tally Arbiter instance
- [x] I verified the UI still loads and existing devices/sources still work

On the last box: this branch rebased onto current `main` was run against a config holding an Internal Test Mode source, a device and a mapping, and the Sources & Devices tab renders both rows. The server side was checked independently too — an authenticated socket client receives `initialdata` carrying `sources: ["Test Mode Source"]`, `devices: ["Camera 1"]`, one device source on `TEST_0`, ten addresses and ten device states.

One thing worth flagging, because it is easy to mistake for this diff and is **not** caused by it. On the very first load after signing in, the Settings page can sit on the loading spinner; moving to another tab and back renders it correctly. That is a pre-existing race, unrelated to these changes, and it reproduces on a branch that touches only the users modal and one navbar entry.

The cause looks like this, if it is useful — it may be the same thing as #1205:

- `socket.on('settings')` requires the access token, which is registered separately by `socket.on('access_token')` into `tmpSocketAccessTokens[socket.id]`. If `settings` arrives before the token does, `requireRole('settings')` rejects, the handler's `.catch` does `console.error(e)`, and the client is never told anything it acts on. `initialDataLoaded` is only set on receipt of `initialdata`, so the spinner never clears. Navigating away and back rebuilds the component, whose constructor calls `joinAdmins()` again, which is why that fixes it.
- The same keying bites on reconnect. `socket.io.on('reconnect')` re-sends `access_token` but nothing re-emits `settings` or `producer` — `joinAdmins()` and `joinProducers()` are called only from their components' constructors. A reconnect gets a new socket id, so the socket ends up in no room and stops receiving broadcasts until the page is reloaded. I confirmed this against a running server: after forcing a reconnect no `initialdata` arrives unprompted, and emitting `settings` again restores it.

That is the same shape as the relay-listener bug fixed in #1200, where registration was keyed to the socket id and had to be re-sent on reconnect. Happy to open that as its own issue or PR if you would like it separated from this one.

## Checklist

- [x] The description above matches what the diff actually does
- [x] The diff contains only changes relevant to this PR — no unrelated reformatting, style rewrites, or drive-by edits. `settings.component.html` was Prettier-clean on `main` and still is; the only reflow is the banner line I edited.
- [x] Any claim I make in this description (tests pass, scan is clean, build is green) is something I actually ran and can point to
