### PR TITLE
feat(sources): add Pixelhue Q8 source

### DIFF
--- a/docs/docs/usage/sections/sources.md
+++ b/docs/docs/usage/sections/sources.md
@@ -17,6 +17,7 @@ The following source types are supported:
 - OBS Studio
 - Open Sound Control (OSC)
 - Panasonic AV-HS410
+- Pixelhue Q8
 - Riedel SimplyLive
 - Roland Smart Tally
 - Roland VR-50HD-MKII
@@ -83,6 +84,16 @@ Community project: [GPI-to-OSC](https://github.com/simply-Gamic/GPI-to-OSC) conv
 ## Panasonic AV-HS410
 
 You will need the IP address of the switcher. Multicast must also be enabled on the switcher and your network in order to receive the tally data, therefore Tally Arbiter and the Panasonic device must reside on the same subnet.
+
+## Pixelhue Q8
+
+You will need the IP address of the processor and its API port, which is 8088. No password is required. Source addresses are the input number as the device reports it, and the address list is populated with the input names configured on the device, so inputs named `Cam 1`, `Cam 2` and so on appear under those names.
+
+The Q8 has no tally or UMD protocol, so tally is derived from its layer model. An input is on program when an enabled layer carries it on the program scene of a screen being followed, and on preview when the same is true of the preview scene. Because a screen can show several layers at once, more than one input can be on program simultaneously, which is normal for a multi-box or picture-in-picture layout.
+
+Leave **Screens** blank to follow every screen, or list the screens that should drive tally by name or number, separated by commas, for example `Portrait HL, Portrait HR`. The multiviewer is never followed, whether or not it is listed, because every input is present on it permanently and following it would put the entire rack on program.
+
+Tally reflects whether a layer is enabled rather than whether it is ultimately visible, so an input on an enabled layer that happens to sit behind another layer still reports as on program.
 
 ## Riedel SimplyLive
 

--- a/docs/docs/usage/sections/sources.md
+++ b/docs/docs/usage/sections/sources.md
@@ -93,6 +93,8 @@ The Q8 has no tally or UMD protocol, so tally is derived from its layer model. A
 
 Leave **Screens** blank to follow every screen, or list the screens that should drive tally by name or number, separated by commas, for example `Portrait HL, Portrait HR`. The multiviewer is never followed, whether or not it is listed, because every input is present on it permanently and following it would put the entire rack on program.
 
+During a fade, both the outgoing and the incoming inputs are reported on program for as long as the transition lasts. An input fading in is on screen from the moment the fade begins, so its tally lights then rather than when the fade finishes, and an input fading out keeps its tally until the fade is complete. A cut has no such window and takes effect immediately.
+
 Tally reflects whether a layer is enabled rather than whether it is ultimately visible, so an input on an enabled layer that happens to sit behind another layer still reports as on program.
 
 ## Riedel SimplyLive

--- a/docs/docs/usage/sections/sources.md
+++ b/docs/docs/usage/sections/sources.md
@@ -87,7 +87,11 @@ You will need the IP address of the switcher. Multicast must also be enabled on 
 
 ## Pixelhue Q8
 
-You will need the IP address of the processor and its API port, which is 8088. No password is required. Source addresses are the input number as the device reports it, and the address list is populated with the input names configured on the device, so inputs named `Cam 1`, `Cam 2` and so on appear under those names.
+You will need the IP address of the processor and its API port, which is 8088. No password is required.
+
+Source addresses are the connector's position, written as the device writes it: `In 1-11` is card 1, port 11. Inputs are offered by name and position together, so a connector named `Cam 1` on that port is listed as `Cam 1 (In 1-11)`, while one left with its default name appears simply as `In 1-11`. Cards and ports are numbered from 1 as they are on the device, where each input card carries twelve ports — 1 to 4 HDMI, 5 to 8 DisplayPort, 9 to 12 12G-SDI — of which eight may be in use at once.
+
+Addressing by position rather than by name means renaming a connector on the device does not break an existing device source; the tally follows whatever is plugged into that port.
 
 The Q8 has no tally or UMD protocol, so tally is derived from its layer model. An input is on program when an enabled layer carries it on the program scene of a screen being followed, and on preview when the same is true of the preview scene. Because a screen can show several layers at once, more than one input can be on program simultaneously, which is normal for a multi-box or picture-in-picture layout.
 

--- a/src/sources/PixelhueQ8.ts
+++ b/src/sources/PixelhueQ8.ts
@@ -44,7 +44,35 @@ const ERROR_BAD_TOKEN = 8273
 // anything switched.
 const TALLY_RELEVANT_TAG_FAMILIES = [463, 528, 529, 663]
 
-const REFRESH_DEBOUNCE = 250
+// A take arrives as a burst of frames -- measured at three over ~250ms -- and the device
+// applies the swap on the last of them, having first reported the scene it is rebuilding
+// as briefly empty. Reading must therefore wait for the burst to stop rather than for a
+// fixed delay after it starts: anchoring to the first frame means either racing the swap
+// or over-waiting by the length of the burst, which is felt directly as tally lag.
+//
+// So the wait restarts on every frame, and a read happens once the device has been quiet
+// for this long.
+const REFRESH_TRAILING = 150
+
+// ...but a continuous stream of frames must not starve the read entirely. Dragging a layer
+// in the device's own UI emits frames every few milliseconds and would otherwise postpone
+// tally for as long as the operator kept dragging, so a read is forced this long after the
+// first frame still waiting to be served.
+const REFRESH_MAX_WAIT = 1000
+
+// The take. Its payload names the screens involved and the length of the effect, and it
+// arrives twice: status 0 as the transition starts and status 1 once it has finished.
+const TAG_TAKE = 463618
+const TAKE_STARTING = 0
+
+// Fallback only, in case the status 1 frame never arrives: how long past the effect's own
+// duration to hold the transition before settling anyway.
+const TRANSITION_MARGIN = 150
+
+// The input list is large and effectively static during a show, so it is not re-read on
+// every transition. The cost is that renaming an input on the device takes up to this long
+// to reach the address list.
+const INTERFACE_REREAD = 30000
 
 @RegisterTallyInput(
 	'8f2ad4e1',
@@ -71,7 +99,15 @@ export class PixelhueQ8Source extends TallyInput {
 	private refreshTimer: NodeJS.Timeout | undefined
 	private refreshing = false
 	private refreshQueued = false
+	private pendingSince = 0
+	private lastInterfaceRead = 0
 	private monitoredScreens = new Set<number>()
+	// Kept per screen rather than flattened, so that a take affecting one screen cannot put
+	// the other screen's incoming layers on program.
+	private screenProgram = new Map<number, Set<string>>()
+	private screenPreview = new Map<number, Set<string>>()
+	private transitionTimer: NodeJS.Timeout | undefined
+	private inTransitionUntil = 0
 
 	constructor(source: Source) {
 		super(source)
@@ -121,13 +157,17 @@ export class PixelhueQ8Source extends TallyInput {
 	}
 
 	private async refreshNow(): Promise<void> {
+		const readInterfaces = Date.now() - this.lastInterfaceRead > INTERFACE_REREAD
 		const [screens, layers, interfaces] = await Promise.all([
 			this.apiGet('/screen/list-detail'),
 			this.apiGet('/layers/list-detail'),
-			this.apiGet('/interface/list-detail'),
+			readInterfaces ? this.apiGet('/interface/list-detail') : Promise.resolve(null),
 		])
 		this.resolveMonitoredScreens(screens?.list || [])
-		this.registerInputs(interfaces?.list || [])
+		if (interfaces) {
+			this.registerInputs(interfaces.list || [])
+			this.lastInterfaceRead = Date.now()
+		}
 		this.computeTally(layers?.list || [])
 	}
 
@@ -168,7 +208,8 @@ export class PixelhueQ8Source extends TallyInput {
 	}
 
 	private computeTally(layers: any[]): void {
-		const bussesByAddress: Record<string, string[]> = {}
+		const program = new Map<number, Set<string>>()
+		const preview = new Map<number, Set<string>>()
 
 		for (const layer of layers) {
 			const idObj = layer?.layerIdObj
@@ -180,9 +221,8 @@ export class PixelhueQ8Source extends TallyInput {
 			const general = layer.source?.general
 			if (!general?.sourceId) continue
 
-			const bus =
-				idObj.sceneType === SCENE_PROGRAM ? 'program' : idObj.sceneType === SCENE_PREVIEW ? 'preview' : undefined
-			if (!bus) continue
+			const into = idObj.sceneType === SCENE_PROGRAM ? program : idObj.sceneType === SCENE_PREVIEW ? preview : undefined
+			if (!into) continue
 
 			// sourceId is not unique on its own -- 2:7 is an input and 5:7 is a different
 			// source entirely -- so the type has to be part of the address.
@@ -191,17 +231,78 @@ export class PixelhueQ8Source extends TallyInput {
 			// another screen, still have to be listable before they can be mapped to a device.
 			this.addAddress(general.sourceName || address, address)
 
-			if (!bussesByAddress[address]) bussesByAddress[address] = []
-			if (!bussesByAddress[address].includes(bus)) bussesByAddress[address].push(bus)
+			const screen = idObj.attachScreenId
+			if (!into.has(screen)) into.set(screen, new Set())
+			into.get(screen).add(address)
 		}
+
+		this.screenProgram = program
+		this.screenPreview = preview
+		this.publish()
+	}
+
+	/**
+	 * Publish the whole tally map.
+	 *
+	 * `alsoOnProgram` carries the screens mid-fade, whose incoming layers have to read as
+	 * on air even though the device still lists them under preview.
+	 */
+	private publish(alsoOnProgram?: Map<number, Set<string>>): void {
+		const busses: Record<string, string[]> = {}
+		const put = (address: string, bus: string) => {
+			if (!busses[address]) busses[address] = []
+			if (!busses[address].includes(bus)) busses[address].push(bus)
+		}
+		for (const addresses of this.screenProgram.values()) for (const a of addresses) put(a, 'program')
+		for (const addresses of this.screenPreview.values()) for (const a of addresses) put(a, 'preview')
+		if (alsoOnProgram) for (const addresses of alsoOnProgram.values()) for (const a of addresses) put(a, 'program')
 
 		// Every known address is rewritten, not just the ones that appear above. This source
 		// always works from a whole snapshot, so anything absent from it has genuinely gone
 		// dark -- emitting only the changes would leave those addresses latched on.
 		for (const entry of this.addresses.value) {
-			this.setBussesForAddress(entry.address, bussesByAddress[entry.address] || [])
+			this.setBussesForAddress(entry.address, busses[entry.address] || [])
 		}
 		this.sendTallyData()
+	}
+
+	/**
+	 * A fade puts the incoming layers on screen the moment it starts and keeps the outgoing
+	 * ones there until it ends, so for its whole duration both are genuinely on air. Camera
+	 * operators need the incoming tally at the start of the fade, not at the end of it.
+	 *
+	 * The device does not report it that way -- it moves program to the new scene partway
+	 * through -- so for the duration of the transition both sides are published, and normal
+	 * refreshes are suppressed so nothing overwrites that until the take completes.
+	 */
+	private beginTransition(screenIds: number[], effectMs: number): void {
+		const incoming = new Map<number, Set<string>>()
+		for (const id of screenIds) {
+			const layers = this.screenPreview.get(id)
+			if (layers?.size) incoming.set(id, layers)
+		}
+
+		const hold = effectMs + TRANSITION_MARGIN
+		this.inTransitionUntil = Date.now() + hold
+		// Drop any read already pending, which would land mid-fade and undo the union.
+		if (this.refreshTimer) {
+			clearTimeout(this.refreshTimer)
+			this.refreshTimer = undefined
+			this.pendingSince = 0
+		}
+		if (incoming.size) this.publish(incoming)
+
+		if (this.transitionTimer) clearTimeout(this.transitionTimer)
+		this.transitionTimer = setTimeout(() => this.endTransition(), hold)
+	}
+
+	private endTransition(): void {
+		if (this.transitionTimer) {
+			clearTimeout(this.transitionTimer)
+			this.transitionTimer = undefined
+		}
+		this.inTransitionUntil = 0
+		this.scheduleRefresh()
 	}
 
 	private openSocket(): void {
@@ -230,28 +331,79 @@ export class PixelhueQ8Source extends TallyInput {
 	private handleFrame(frame: Buffer): void {
 		if (!Buffer.isBuffer(frame)) return
 
-		let tag: number
+		let tag: number, headerEnd: number
 		try {
 			// Binary TLV: a 40 byte prefix, then a JSON header whose length is a uint16 at
-			// offset 38, then the tag as a uint32. Only the tag is read. The payload is an
-			// incremental change that would have to be merged into a full device model to be
-			// useful, and re-reading the lists instead gives a snapshot that is internally
-			// consistent -- which matters, because a take moves several layers at once.
-			tag = frame.readUInt32LE(40 + frame.readUInt16LE(38))
+			// offset 38, then the tag as a uint32. For everything except the take only the tag
+			// is read: those payloads are incremental changes that would have to be merged into
+			// a full device model to be useful, and re-reading the lists instead gives a
+			// snapshot that is internally consistent -- which matters, because a take moves
+			// several layers at once.
+			headerEnd = 40 + frame.readUInt16LE(38)
+			tag = frame.readUInt32LE(headerEnd)
 		} catch (error) {
 			return // a frame shorter than its own header claims; nothing to act on
 		}
 
+		if (tag === TAG_TAKE) {
+			try {
+				const start = headerEnd + 8
+				const length = (frame.readUInt16LE(headerEnd + 4) << 16) + frame.readUInt16LE(headerEnd + 6)
+				this.handleTake(JSON.parse(frame.subarray(start, start + length).toString() || '{}'))
+			} catch (error) {
+				// Unreadable take payload: fall back to just re-reading once it has settled.
+				this.endTransition()
+			}
+			return
+		}
+
 		if (!TALLY_RELEVANT_TAG_FAMILIES.includes(Math.floor(tag / 1000))) return
+		// Mid-fade the union is deliberately being held; a read now would undo it.
+		if (Date.now() < this.inTransitionUntil) return
 		this.scheduleRefresh()
 	}
 
+	private handleTake(data: any): void {
+		const screenIds: number[] = (data?.screenList || [])
+			.map((s: any) => s?.screenId)
+			.filter((id: number) => this.monitoredScreens.has(id))
+		// A take on screens we do not follow changes nothing we report.
+		if (!screenIds.length) return
+
+		const effectMs = Number(data?.switchEffect?.time) || 0
+		// status 0 opens the transition, status 1 closes it. A cut has no effect time, so
+		// there is no window during which both sides are on screen -- settle immediately.
+		if (data?.status === TAKE_STARTING && effectMs > 0) {
+			this.beginTransition(screenIds, effectMs)
+		} else {
+			this.endTransition()
+		}
+	}
+
 	private scheduleRefresh(): void {
-		if (this.refreshTimer) return
+		const now = Date.now()
+
+		// Leading edge. The first frame after a quiet spell is served straight away, so a cut
+		// reaches tally as fast as the device can be read rather than waiting to find out
+		// whether more frames are coming. If that read catches the device mid-change -- it
+		// sometimes announces a change slightly before applying it -- the worst case is
+		// publishing the state that is already displayed, which changes nothing, and the
+		// trailing read below corrects it.
+		if (!this.pendingSince) {
+			this.pendingSince = now
+			void this.runRefresh()
+		}
+
+		// Trailing edge. Restart the wait on every frame so the confirming read lands after
+		// the burst rather than a fixed delay into it, but never push it past
+		// REFRESH_MAX_WAIT from the first frame still waiting to be served.
+		if (this.refreshTimer) clearTimeout(this.refreshTimer)
+		const wait = Math.max(0, Math.min(REFRESH_TRAILING, this.pendingSince + REFRESH_MAX_WAIT - now))
 		this.refreshTimer = setTimeout(() => {
 			this.refreshTimer = undefined
+			this.pendingSince = 0
 			void this.runRefresh()
-		}, REFRESH_DEBOUNCE)
+		}, wait)
 	}
 
 	private async runRefresh(): Promise<void> {
@@ -285,6 +437,10 @@ export class PixelhueQ8Source extends TallyInput {
 		if (this.refreshTimer) {
 			clearTimeout(this.refreshTimer)
 			this.refreshTimer = undefined
+		}
+		if (this.transitionTimer) {
+			clearTimeout(this.transitionTimer)
+			this.transitionTimer = undefined
 		}
 		if (this.ws) {
 			this.ws.close()

--- a/src/sources/PixelhueQ8.ts
+++ b/src/sources/PixelhueQ8.ts
@@ -72,11 +72,12 @@ const TAKE_STARTING = 0
 // duration to hold the transition before settling anyway.
 const TRANSITION_MARGIN = 150
 
-// Ceiling on the effect duration the device reports. Switcher effects run well under a
-// second in practice, so this is generous; it exists so that a value off the wire cannot
-// set an unbounded timer. Erring short is the safe direction -- the union is released a
-// little early rather than tally being held on indefinitely.
-const MAX_EFFECT_DURATION = 10000
+// Ceiling on how long a transition may be held. The effect duration comes off the wire,
+// and switcher effects run well under a second in practice, so this is generous; it exists
+// so that a value from the device cannot set an unbounded timer. Erring short is the safe
+// direction -- the union is released a little early rather than tally being held on
+// indefinitely.
+const MAX_TRANSITION_HOLD = 10000
 
 // The input list is large and effectively static during a show, so it is not re-read on
 // every transition. The cost is that renaming an input on the device takes up to this long
@@ -363,7 +364,10 @@ export class PixelhueQ8Source extends TallyInput {
 			if (layers?.size) incoming.set(id, layers)
 		}
 
-		const hold = effectMs + TRANSITION_MARGIN
+		// Bounded here, where the timer is actually created, because effectMs came off the
+		// wire. This timer is only a fallback for a closing frame that may never arrive, so an
+		// unbounded value would hold tally showing both sides of the fade indefinitely.
+		const hold = Math.min(effectMs + TRANSITION_MARGIN, MAX_TRANSITION_HOLD)
 		this.inTransitionUntil = Date.now() + hold
 		// Drop any read already pending, which would land mid-fade and undo the union.
 		if (this.refreshTimer) {
@@ -460,12 +464,10 @@ export class PixelhueQ8Source extends TallyInput {
 		// A take on screens we do not follow changes nothing we report.
 		if (!screenIds.length) return
 
-		// The effect duration arrives off the wire, so it is clamped rather than trusted. It
-		// only ever sets a fallback timer -- the device's own closing frame normally ends the
-		// transition -- but if that frame never came, an absurd duration would hold tally
-		// showing both sides of the fade for as long as the device claimed.
+		// A missing or nonsensical duration is treated as a cut. The upper bound is applied in
+		// beginTransition, where the timer is created.
 		const reported = Number(data?.switchEffect?.time)
-		const effectMs = Number.isFinite(reported) ? Math.min(Math.max(reported, 0), MAX_EFFECT_DURATION) : 0
+		const effectMs = Number.isFinite(reported) && reported > 0 ? reported : 0
 
 		// status 0 opens the transition, status 1 closes it. A cut has no effect time, so
 		// there is no window during which both sides are on screen -- settle immediately.

--- a/src/sources/PixelhueQ8.ts
+++ b/src/sources/PixelhueQ8.ts
@@ -108,6 +108,8 @@ export class PixelhueQ8Source extends TallyInput {
 	private screenPreview = new Map<number, Set<string>>()
 	private transitionTimer: NodeJS.Timeout | undefined
 	private inTransitionUntil = 0
+	// Only log the available screens when the set changes, not on every refresh.
+	private lastScreenList = ''
 
 	constructor(source: Source) {
 		super(source)
@@ -171,12 +173,29 @@ export class PixelhueQ8Source extends TallyInput {
 		this.computeTally(layers?.list || [])
 	}
 
+	// The Screens field has to be typed by hand, so the screens the device actually offers are
+	// logged the first time they are seen and named again whenever an entry does not match.
+	// Without that there is no way to discover what to type except opening the device's own UI.
+	private describeScreens(screens: any[]): string {
+		return screens.map((screen) => `${screen.screenId} "${screen.general?.name || '(unnamed)'}"`).join(', ')
+	}
+
 	private resolveMonitoredScreens(screens: any[]): void {
 		const realScreens = screens.filter((screen) => screen?.screenIdObj?.type === SCREEN_TYPE_NORMAL)
 		const configured = String(this.source.data.screens || '').trim()
 
+		const seen = realScreens.map((screen) => screen.screenId).join(',')
+		if (seen !== this.lastScreenList) {
+			this.lastScreenList = seen
+			logger(
+				`Source: ${this.source.name}  Screens available: ${this.describeScreens(realScreens) || '(none)'}.`,
+				'info',
+			)
+		}
+
 		if (!configured) {
 			this.monitoredScreens = new Set(realScreens.map((screen) => screen.screenId))
+			logger(`Source: ${this.source.name}  Following every screen, because Screens is blank.`, 'info-quiet')
 			return
 		}
 
@@ -192,8 +211,18 @@ export class PixelhueQ8Source extends TallyInput {
 			if (match) {
 				selected.add(match.screenId)
 			} else {
-				logger(`Source: ${this.source.name}  No screen named or numbered '${wanted}'.`, 'error')
+				logger(
+					`Source: ${this.source.name}  No screen named or numbered '${wanted}'. Available: ${this.describeScreens(realScreens) || '(none)'}.`,
+					'error',
+				)
 			}
+		}
+
+		if (!selected.size) {
+			logger(
+				`Source: ${this.source.name}  Screens matched nothing, so no tally will be reported. Available: ${this.describeScreens(realScreens) || '(none)'}.`,
+				'error',
+			)
 		}
 		this.monitoredScreens = selected
 	}

--- a/src/sources/PixelhueQ8.ts
+++ b/src/sources/PixelhueQ8.ts
@@ -35,6 +35,9 @@ const SCREEN_TYPE_NORMAL = 2
 // auxiliaryInfo.connectorInfo.interfaceType: 2 is an input, 4 an output, 16 the MVR.
 const INTERFACE_TYPE_INPUT = 2
 
+// What the device calls a connector nobody has renamed, in its own card-port numbering.
+const DEFAULT_CONNECTOR_NAME = /^Input \d+-\d+$/
+
 // The device returns this in a 200 body when the token no longer matches its boot time.
 const ERROR_BAD_TOKEN = 8273
 
@@ -74,24 +77,19 @@ const TRANSITION_MARGIN = 150
 // to reach the address list.
 const INTERFACE_REREAD = 30000
 
-@RegisterTallyInput(
-	'8f2ad4e1',
-	'Pixelhue Q8',
-	'Source addresses are the input number as the device reports it. Leave Screens blank to follow every screen, or list the ones that should drive tally by name or number, separated by commas.',
-	[
-		{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
-		// 'number', not 'port': this is a remote port we connect to, not a local one we
-		// bind, so it must skip the in-use check. 8088 on a Q8.
-		{ fieldName: 'port', fieldLabel: 'API Port', fieldType: 'number' },
-		{
-			fieldName: 'screens',
-			fieldLabel: 'Screens',
-			fieldType: 'text',
-			optional: true,
-			help: 'Comma separated screen names or numbers, e.g. "Portrait HL, Portrait HR". Blank follows every screen. The multiviewer is never followed, because every input sits on it permanently.',
-		},
-	],
-)
+@RegisterTallyInput('8f2ad4e1', 'Pixelhue Q8', '', [
+	{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+	// 'number', not 'port': this is a remote port we connect to, not a local one we
+	// bind, so it must skip the in-use check. 8088 on a Q8.
+	{ fieldName: 'port', fieldLabel: 'API Port', fieldType: 'number' },
+	{
+		fieldName: 'screens',
+		fieldLabel: 'Screens',
+		fieldType: 'text',
+		optional: true,
+		help: 'Screen names or numbers, separated by commas, e.g. "Portrait HL, Portrait HR". Leave blank to follow every screen. To find out what this device offers, save with this blank and the log will list its screens by number and name. The multiviewer is never followed, because every input sits on it permanently.',
+	},
+])
 export class PixelhueQ8Source extends TallyInput {
 	private ws: WebSocket | undefined
 	private token = ''
@@ -110,6 +108,8 @@ export class PixelhueQ8Source extends TallyInput {
 	private inTransitionUntil = 0
 	// Only log the available screens when the set changes, not on every refresh.
 	private lastScreenList = ''
+	// interfaceId -> the address published for it, so a layer's source can be translated.
+	private inputAddressById = new Map<number, string>()
 
 	constructor(source: Source) {
 		super(source)
@@ -227,13 +227,61 @@ export class PixelhueQ8Source extends TallyInput {
 		this.monitoredScreens = selected
 	}
 
+	/**
+	 * Where a connector physically is, written the way the device's own UI and documentation
+	 * write it. Cards and connectors are 0-indexed in the API and 1-indexed everywhere an
+	 * operator looks, so slot 0 connector 10 is "In 1-11". A card carries twelve connector
+	 * positions -- 1-4 HDMI, 5-8 DisplayPort, 9-12 12G-SDI -- of which eight can be in use.
+	 *
+	 * This doubles as the address, so it has to stay unique. splitId and nodeId have only
+	 * ever been seen as 0 and 1 on a single Q8, but both exist in the API and a collision
+	 * would silently give two cameras each other's tally, so they are folded in when set.
+	 */
+	private connectorPosition(iface: any): string {
+		const ids = iface?.interfaceIdObj
+		if (!Number.isInteger(ids?.slotId) || !Number.isInteger(ids?.connectorId)) return ''
+		let position = `In ${ids.slotId + 1}-${ids.connectorId + 1}`
+		if (ids.splitId) position += `.${ids.splitId}`
+		if (ids.nodeId > 1) position = `N${ids.nodeId} ${position}`
+		return position
+	}
+
 	private registerInputs(interfaces: any[]): void {
+		this.inputAddressById.clear()
+
 		for (const iface of interfaces) {
 			if (iface?.auxiliaryInfo?.connectorInfo?.interfaceType !== INTERFACE_TYPE_INPUT) continue
-			const name = iface.general?.name
-			if (!name) continue
-			this.addAddress(name, `${INTERFACE_TYPE_INPUT}:${iface.interfaceId}`)
+
+			const name = String(iface.general?.name || '').trim()
+			const position = this.connectorPosition(iface)
+			// Falling back to the internal id keeps an input addressable at all if the device
+			// ever omits its position, at the cost of an address nobody would recognise.
+			const address = position || `${INTERFACE_TYPE_INPUT}:${iface.interfaceId}`
+			this.inputAddressById.set(iface.interfaceId, address)
+
+			// A connector nobody has renamed still carries the device's own default name, which
+			// already states its position -- repeating it would read as "Input 2-1 (In 2-1)".
+			let label: string
+			if (!position) label = name || address
+			else if (!name || DEFAULT_CONNECTOR_NAME.test(name)) label = position
+			else label = `${name} (${position})`
+
+			this.addAddress(label, address)
 		}
+	}
+
+	/**
+	 * Layers name their source as a type and an id. For inputs that id is the interfaceId,
+	 * which is translated here to the connector position an operator would recognise. Other
+	 * source types -- a screen used as another screen's input, a media item -- have no
+	 * position, so they keep the internal form and rely on their label to be readable.
+	 */
+	private addressForSource(sourceType: number, sourceId: number): string {
+		if (sourceType === INTERFACE_TYPE_INPUT) {
+			const known = this.inputAddressById.get(sourceId)
+			if (known) return known
+		}
+		return `${sourceType}:${sourceId}`
 	}
 
 	private computeTally(layers: any[]): void {
@@ -253,9 +301,7 @@ export class PixelhueQ8Source extends TallyInput {
 			const into = idObj.sceneType === SCENE_PROGRAM ? program : idObj.sceneType === SCENE_PREVIEW ? preview : undefined
 			if (!into) continue
 
-			// sourceId is not unique on its own -- 2:7 is an input and 5:7 is a different
-			// source entirely -- so the type has to be part of the address.
-			const address = `${general.sourceType}:${general.sourceId}`
+			const address = this.addressForSource(general.sourceType, general.sourceId)
 			// Sources the interface list does not cover, such as a screen used as the input to
 			// another screen, still have to be listable before they can be mapped to a device.
 			this.addAddress(general.sourceName || address, address)

--- a/src/sources/PixelhueQ8.ts
+++ b/src/sources/PixelhueQ8.ts
@@ -72,6 +72,12 @@ const TAKE_STARTING = 0
 // duration to hold the transition before settling anyway.
 const TRANSITION_MARGIN = 150
 
+// Ceiling on the effect duration the device reports. Switcher effects run well under a
+// second in practice, so this is generous; it exists so that a value off the wire cannot
+// set an unbounded timer. Erring short is the safe direction -- the union is released a
+// little early rather than tally being held on indefinitely.
+const MAX_EFFECT_DURATION = 10000
+
 // The input list is large and effectively static during a show, so it is not re-read on
 // every transition. The cost is that renaming an input on the device takes up to this long
 // to reach the address list.
@@ -384,7 +390,16 @@ export class PixelhueQ8Source extends TallyInput {
 		const url = `wss://${this.source.data.ip}:${UCENTER_PORT}/unico/v1/ucenter/ws?client-type=8`
 		logger(`Source: ${this.source.name}  Connecting to Pixelhue at ${url}.`, 'info-quiet')
 
-		// The device serves this with a self-signed certificate, so it can never validate.
+		// Certificate validation is disabled for this one socket, deliberately. The device
+		// serves it with a self-signed certificate of its own making: there is no CA to
+		// validate against and no way for an operator to supply one. It is also the only
+		// notification channel the device offers -- plain ws on this port is refused, and the
+		// websocket the device advertises on its API port does not serve this path.
+		//
+		// It costs nothing that is not already given up: every byte of tally data is read
+		// over plain HTTP from the same device, and the token in this header is derived from
+		// a serial and a boot time the device hands out unauthenticated, so there is no
+		// secret here to protect.
 		const ws = new WebSocket(url, { headers: { Authorization: this.token }, rejectUnauthorized: false })
 		this.ws = ws
 
@@ -445,7 +460,13 @@ export class PixelhueQ8Source extends TallyInput {
 		// A take on screens we do not follow changes nothing we report.
 		if (!screenIds.length) return
 
-		const effectMs = Number(data?.switchEffect?.time) || 0
+		// The effect duration arrives off the wire, so it is clamped rather than trusted. It
+		// only ever sets a fallback timer -- the device's own closing frame normally ends the
+		// transition -- but if that frame never came, an absurd duration would hold tally
+		// showing both sides of the fade for as long as the device claimed.
+		const reported = Number(data?.switchEffect?.time)
+		const effectMs = Number.isFinite(reported) ? Math.min(Math.max(reported, 0), MAX_EFFECT_DURATION) : 0
+
 		// status 0 opens the transition, status 1 closes it. A cut has no effect time, so
 		// there is no window during which both sides are on screen -- settle immediately.
 		if (data?.status === TAKE_STARTING && effectMs > 0) {

--- a/src/sources/PixelhueQ8.ts
+++ b/src/sources/PixelhueQ8.ts
@@ -1,0 +1,294 @@
+import axios from 'axios'
+import jwt from 'jsonwebtoken'
+import WebSocket from 'ws'
+import { logger } from '..'
+import { RegisterTallyInput } from '../_decorators/RegisterTallyInput.decorator'
+import { Source } from '../_models/Source'
+import { TallyInput } from './_Source'
+
+// Pixelhue Q8 (the "unico" platform, shared with the P10/P20/P80 but only verified
+// against a Q8 here). The device has no tally or UMD protocol of its own, so tally is
+// derived from its layer model: a screen holds a program scene and a preview scene,
+// each a set of layers, and every layer names the input it displays. An input is live
+// when some enabled layer on a program scene of a monitored screen carries it.
+//
+// Two ports are involved. The REST API is plain HTTP on the port the device advertises
+// (8088 on a Q8), while the change-notification WebSocket is TLS on a fixed 19998 with
+// a self-signed certificate.
+//
+// Authentication is a JWT the client mints for itself: GET /unico/v1/node/open-detail
+// returns the serial and the device's boot time, and the token is {SN} signed with that
+// boot time. Nothing secret is involved, but the boot time changes on reboot, so the
+// token has to be re-minted on every connect rather than cached across one.
+
+const UCENTER_PORT = 19998
+const DEFAULT_API_PORT = 8088
+
+// layerIdObj.sceneType. The device's own web UI labels 2 as PGM and 4 as PVW.
+const SCENE_PROGRAM = 2
+const SCENE_PREVIEW = 4
+
+// screenIdObj.type. 8 is the multiviewer, which carries every input permanently and
+// would therefore tally the whole rack at once; 16 is an aux. Only 2 is a real screen.
+const SCREEN_TYPE_NORMAL = 2
+
+// auxiliaryInfo.connectorInfo.interfaceType: 2 is an input, 4 an output, 16 the MVR.
+const INTERFACE_TYPE_INPUT = 2
+
+// The device returns this in a 200 body when the token no longer matches its boot time.
+const ERROR_BAD_TOKEN = 8273
+
+// Tag families on the notification socket: 463xxx screens, 528xxx/529xxx layers,
+// 663xxx presets and layer sets. Everything else is telemetry -- temperatures, CPU
+// load, thumbnail progress -- which arrives several times a second whether or not
+// anything switched.
+const TALLY_RELEVANT_TAG_FAMILIES = [463, 528, 529, 663]
+
+const REFRESH_DEBOUNCE = 250
+
+@RegisterTallyInput(
+	'8f2ad4e1',
+	'Pixelhue Q8',
+	'Source addresses are the input number as the device reports it. Leave Screens blank to follow every screen, or list the ones that should drive tally by name or number, separated by commas.',
+	[
+		{ fieldName: 'ip', fieldLabel: 'IP Address', fieldType: 'text' },
+		// 'number', not 'port': this is a remote port we connect to, not a local one we
+		// bind, so it must skip the in-use check. 8088 on a Q8.
+		{ fieldName: 'port', fieldLabel: 'API Port', fieldType: 'number' },
+		{
+			fieldName: 'screens',
+			fieldLabel: 'Screens',
+			fieldType: 'text',
+			optional: true,
+			help: 'Comma separated screen names or numbers, e.g. "Portrait HL, Portrait HR". Blank follows every screen. The multiviewer is never followed, because every input sits on it permanently.',
+		},
+	],
+)
+export class PixelhueQ8Source extends TallyInput {
+	private ws: WebSocket | undefined
+	private token = ''
+	private closing = false
+	private refreshTimer: NodeJS.Timeout | undefined
+	private refreshing = false
+	private refreshQueued = false
+	private monitoredScreens = new Set<number>()
+
+	constructor(source: Source) {
+		super(source)
+		void this.connect()
+	}
+
+	private get apiBase(): string {
+		return `http://${this.source.data.ip}:${this.source.data.port || DEFAULT_API_PORT}/unico/v1`
+	}
+
+	private async connect(): Promise<void> {
+		this.closing = false
+		try {
+			await this.mintToken()
+			await this.refreshNow()
+			this.openSocket()
+		} catch (error) {
+			logger(`Source: ${this.source.name}  Pixelhue connection failed: ${error}`, 'error')
+			this.connected.next(false)
+		}
+	}
+
+	private async mintToken(): Promise<void> {
+		const response = await axios.get(`${this.apiBase}/node/open-detail`, { timeout: 5000 })
+		const detail = response.data?.data
+		if (!detail?.sn || !detail?.startTime) {
+			throw new Error('open-detail did not return a serial and start time')
+		}
+		this.token = jwt.sign({ SN: detail.sn }, String(detail.startTime), { algorithm: 'HS256', noTimestamp: true })
+	}
+
+	private async apiGet(path: string, allowRetry = true): Promise<any> {
+		const response = await axios.get(`${this.apiBase}${path}`, {
+			headers: { Authorization: this.token },
+			timeout: 8000,
+		})
+		// A rejected token comes back as a 200 with an error code in the body, and it means
+		// the device rebooted underneath us. Re-mint once instead of dropping the source.
+		if (response.data?.code === ERROR_BAD_TOKEN && allowRetry) {
+			await this.mintToken()
+			return this.apiGet(path, false)
+		}
+		if (response.data?.code !== 0) {
+			throw new Error(`${path} returned code ${response.data?.code}`)
+		}
+		return response.data.data
+	}
+
+	private async refreshNow(): Promise<void> {
+		const [screens, layers, interfaces] = await Promise.all([
+			this.apiGet('/screen/list-detail'),
+			this.apiGet('/layers/list-detail'),
+			this.apiGet('/interface/list-detail'),
+		])
+		this.resolveMonitoredScreens(screens?.list || [])
+		this.registerInputs(interfaces?.list || [])
+		this.computeTally(layers?.list || [])
+	}
+
+	private resolveMonitoredScreens(screens: any[]): void {
+		const realScreens = screens.filter((screen) => screen?.screenIdObj?.type === SCREEN_TYPE_NORMAL)
+		const configured = String(this.source.data.screens || '').trim()
+
+		if (!configured) {
+			this.monitoredScreens = new Set(realScreens.map((screen) => screen.screenId))
+			return
+		}
+
+		const selected = new Set<number>()
+		for (const entry of configured.split(',')) {
+			const wanted = entry.trim()
+			if (!wanted) continue
+			const match = realScreens.find(
+				(screen) =>
+					String(screen.screenId) === wanted ||
+					String(screen.general?.name || '').toLowerCase() === wanted.toLowerCase(),
+			)
+			if (match) {
+				selected.add(match.screenId)
+			} else {
+				logger(`Source: ${this.source.name}  No screen named or numbered '${wanted}'.`, 'error')
+			}
+		}
+		this.monitoredScreens = selected
+	}
+
+	private registerInputs(interfaces: any[]): void {
+		for (const iface of interfaces) {
+			if (iface?.auxiliaryInfo?.connectorInfo?.interfaceType !== INTERFACE_TYPE_INPUT) continue
+			const name = iface.general?.name
+			if (!name) continue
+			this.addAddress(name, `${INTERFACE_TYPE_INPUT}:${iface.interfaceId}`)
+		}
+	}
+
+	private computeTally(layers: any[]): void {
+		const bussesByAddress: Record<string, string[]> = {}
+
+		for (const layer of layers) {
+			const idObj = layer?.layerIdObj
+			if (!idObj || !this.monitoredScreens.has(idObj.attachScreenId)) continue
+			// A disabled layer still holds its source, so it has to be skipped explicitly or
+			// every input ever placed on the screen would read as live.
+			if (layer.enable !== 1) continue
+
+			const general = layer.source?.general
+			if (!general?.sourceId) continue
+
+			const bus =
+				idObj.sceneType === SCENE_PROGRAM ? 'program' : idObj.sceneType === SCENE_PREVIEW ? 'preview' : undefined
+			if (!bus) continue
+
+			// sourceId is not unique on its own -- 2:7 is an input and 5:7 is a different
+			// source entirely -- so the type has to be part of the address.
+			const address = `${general.sourceType}:${general.sourceId}`
+			// Sources the interface list does not cover, such as a screen used as the input to
+			// another screen, still have to be listable before they can be mapped to a device.
+			this.addAddress(general.sourceName || address, address)
+
+			if (!bussesByAddress[address]) bussesByAddress[address] = []
+			if (!bussesByAddress[address].includes(bus)) bussesByAddress[address].push(bus)
+		}
+
+		// Every known address is rewritten, not just the ones that appear above. This source
+		// always works from a whole snapshot, so anything absent from it has genuinely gone
+		// dark -- emitting only the changes would leave those addresses latched on.
+		for (const entry of this.addresses.value) {
+			this.setBussesForAddress(entry.address, bussesByAddress[entry.address] || [])
+		}
+		this.sendTallyData()
+	}
+
+	private openSocket(): void {
+		const url = `wss://${this.source.data.ip}:${UCENTER_PORT}/unico/v1/ucenter/ws?client-type=8`
+		logger(`Source: ${this.source.name}  Connecting to Pixelhue at ${url}.`, 'info-quiet')
+
+		// The device serves this with a self-signed certificate, so it can never validate.
+		const ws = new WebSocket(url, { headers: { Authorization: this.token }, rejectUnauthorized: false })
+		this.ws = ws
+
+		ws.on('open', () => this.connected.next(true))
+		ws.on('message', (data) => this.handleFrame(data as Buffer))
+		ws.on('error', (error) => {
+			// Aborting a socket that is still connecting emits an error; ignore it during
+			// teardown so it can never surface as an unhandled 'error'.
+			if (this.closing) return
+			logger(`Source: ${this.source.name}  Pixelhue connection error: ${error}`, 'error')
+		})
+		ws.on('close', () => {
+			if (this.ws !== ws) return // a socket we already replaced
+			this.ws = undefined
+			if (!this.closing) this.connected.next(false) // let the base class reconnect
+		})
+	}
+
+	private handleFrame(frame: Buffer): void {
+		if (!Buffer.isBuffer(frame)) return
+
+		let tag: number
+		try {
+			// Binary TLV: a 40 byte prefix, then a JSON header whose length is a uint16 at
+			// offset 38, then the tag as a uint32. Only the tag is read. The payload is an
+			// incremental change that would have to be merged into a full device model to be
+			// useful, and re-reading the lists instead gives a snapshot that is internally
+			// consistent -- which matters, because a take moves several layers at once.
+			tag = frame.readUInt32LE(40 + frame.readUInt16LE(38))
+		} catch (error) {
+			return // a frame shorter than its own header claims; nothing to act on
+		}
+
+		if (!TALLY_RELEVANT_TAG_FAMILIES.includes(Math.floor(tag / 1000))) return
+		this.scheduleRefresh()
+	}
+
+	private scheduleRefresh(): void {
+		if (this.refreshTimer) return
+		this.refreshTimer = setTimeout(() => {
+			this.refreshTimer = undefined
+			void this.runRefresh()
+		}, REFRESH_DEBOUNCE)
+	}
+
+	private async runRefresh(): Promise<void> {
+		// Dragging a layer in the device's UI emits a frame every few milliseconds. Holding
+		// bursts behind one in-flight fetch keeps that from queueing hundreds of snapshots.
+		if (this.refreshing) {
+			this.refreshQueued = true
+			return
+		}
+		this.refreshing = true
+		try {
+			await this.refreshNow()
+		} catch (error) {
+			logger(`Source: ${this.source.name}  Pixelhue refresh failed: ${error}`, 'error')
+		} finally {
+			this.refreshing = false
+			if (this.refreshQueued) {
+				this.refreshQueued = false
+				this.scheduleRefresh()
+			}
+		}
+	}
+
+	public reconnect(): void {
+		void this.connect()
+	}
+
+	public exit(): void {
+		super.exit()
+		this.closing = true
+		if (this.refreshTimer) {
+			clearTimeout(this.refreshTimer)
+			this.refreshTimer = undefined
+		}
+		if (this.ws) {
+			this.ws.close()
+			this.ws = undefined
+		}
+	}
+}


### PR DESCRIPTION
## What does this change do?

Adds a **Pixelhue Q8** source type. The processor has no tally or UMD protocol, so tally is derived from its layer model: an input is on program when an enabled layer carries it on the program scene of a screen being followed, and on preview when the same is true of the preview scene.

New file `src/sources/PixelhueQ8.ts` plus a section in the sources documentation. Nothing existing is modified.

## Why?

No existing issue — I needed it for a rig where a Q8 is the final switcher in front of an ATEM, and camera tally has to follow what actually reaches the audience screens.

A few things about the device are worth knowing, because they shaped the implementation and none of them are guessable from the outside:

**It has no tally protocol.** Screens hold a program scene and a preview scene, each a set of layers, and every layer names the input it displays. That is the only source of truth, so the source reads `screen/list-detail` and `layers/list-detail` and derives tally from them.

**Only some screens should drive tally.** A Q8 exposes real screens, auxes and a multiviewer. The multiviewer carries *every* input permanently, so following it would put the whole rack on program. It is excluded structurally via `screenIdObj.type` rather than by name. Which of the remaining screens matter is site-specific — on my rig two of five drive camera tally — so it is a config field, and blank follows all of them.

**Authentication needs no password.** `GET /unico/v1/node/open-detail` returns the serial and the device's boot time unauthenticated, and the token is the serial signed with the boot time. Because it is keyed to boot time, a device reboot silently invalidates it — the device reports that as an error code inside an HTTP 200 body — so the source re-mints on every connect and retries once on that code.

**Both sides of a fade are on air.** An input fading in is on screen from the moment the fade starts, and one fading out stays there until it ends. The device does not report it that way: it moves program to the new scene partway through the effect. Reading once after everything settles gets the outgoing case right by accident and lights the incoming camera a whole fade late — which a camera operator experiences as being live before their tally says so. The take frame carries the screens involved, the effect duration, and a status that opens the transition and another that closes it, so the source publishes the union of outgoing and incoming program for the duration and settles when the device says the take is done.

**Addresses are the connector position.** An operator picking a tally source recognises the name they gave a connector or the port it is plugged into, not the composite id the layer records use internally. So inputs are addressed as `In 1-11` — card 1, port 11, exactly as the device's UI, its documentation and its own default connector names write it — and labelled `Cam 1 (In 1-11)`. Position beats the connector name as an address because it survives a rename, and beats the internal id because it is what the operator reads off the device. Cards and ports are 0-indexed in the API and 1-indexed everywhere a person looks, which is the trap.

**Reads are served on both edges of a burst.** A take arrives as several frames over about 250ms and the device applies the swap on the last of them, having first reported the scene it is rebuilding as briefly empty. A fixed delay anchored to the first frame either races the swap or over-waits by the length of the burst, and the latter is felt directly as tally lag — 600ms measured as "about a second" by the operator using it. So the first frame of a burst is served immediately and a confirming read follows once the device goes quiet, with a cap so that dragging a layer in the device's own UI cannot postpone tally indefinitely.

The `Screens` field declares help text. That renders once the companion UI fix lands (`fix(ui): show config field help and address labels in source settings`, submitted separately) — the source dialog does not currently display `field.help` for any source type. The same information is in the documentation either way.

Verified against a **Q8**. The vendor's own Companion module maps the P10, P20 and P80 to identical endpoints, but I have no access to those, so the source is scoped and named for the Q8 rather than claiming a family it has not been run against.

## How did you test it?

Platform: **Source** checkout on Windows 11, Node 24.13.1 (Angular 22's CLI needs >= 24.15.0, so UI builds used a portable Node 24.19.0). Hardware: a **Pixelhue Q8** (`modelId 29974`, firmware serving the API on 8088) with 48 input connectors across four cards, six cameras on 12G-SDI, and five real screens plus a multiviewer. Tally output driven through the **relay listener** to physical camera tally lamps, with a **Blackmagic ATEM** configured as a second source on the same devices throughout.

**A full production show.** The source ran for 5h15m unbroken — 1893 samples at 10s intervals — with **zero fetch errors, zero fatals and no reconnects**. Over the 2h31m main act an ATEM feed was on the tallied screens 91.3% of the time and direct camera looks 1.4%; all six cameras tallied correctly, and the two mapped to relays lit real lamps.

**Directed testing afterwards**, sampling both the device and Tally Arbiter's own `device_states` at 250ms and snapshotting the device on every notification frame:

- **Program, preview, preview-only and clear-down** all resolve correctly, and cameras resolve independently rather than in lockstep.
- **Screen filtering** — with two of five screens configured, layers on the other three produce no tally. Blank follows all real screens. The multiviewer never tallies.
- **Transitions** — a take decomposes into three frames over ~250ms; the empty-scene window during a rebuild is ~130ms and only ever affected the preview bus, never program. After the transition handling went in, the operator's verdict on fades was "they come on immediately at the start of the fade in and stay lit until the fade is complete… perfectly snappy".
- **Latency** — first frame to tally change measured at 386ms with a 250ms trailing debounce and 676ms with 600ms, which is what drove the move to a leading edge. Endpoint response times: `layers/list-detail` 16ms (192KB), `screen/list-detail` 6ms, `interface/list-detail` 35ms (498KB, so it is not re-read on every transition).
- **Addresses** — all 48 input connectors produce distinct positions, no collisions. Confirmed end to end: the device reported program on screen 6 as its internal `2:11`, which resolved to address `In 2-11`, matched the configured device source and lit the mapped device.
- **Reboot handling** — the rejected-token path was exercised by the source re-minting after the device's boot time moved.

- [x] `npm run build` succeeds — ran on this branch, exit 0. `prettier --check` passes on both files.
- [x] I ran the change against a live Tally Arbiter instance
- [x] I verified the UI still loads and existing devices/sources still work

On the last box: the ATEM source and its six device sources ran alongside this one for two days on the same instance and continued to report normally, and the Sources & Devices tab lists and edits both. Sources, devices and device sources were added and edited through the settings dialog during that period.

One unrelated observation while testing, in case it is useful: on the first load after signing in, the Settings page can sit on the loading spinner until you move to another tab and back. It reproduces on unmodified `main`, and I have put what I found on #1205 — it looks like room membership and the access token both being keyed to the socket id, with nothing re-joining after a reconnect. It has nothing to do with this PR.

## Checklist

- [x] The description above matches what the diff actually does
- [x] The diff contains only changes relevant to this PR — it adds one new source file and one documentation section, and modifies nothing else. No reformatting, no drive-by edits.
- [x] Any claim I make in this description (tests pass, scan is clean, build is green) is something I actually ran and can point to
