### PR TITLE
docs: serve the documentation from docs.tallyarbiter.com

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,8 +2,8 @@
 module.exports = {
 	title: 'TallyArbiter Documentation',
 	tagline: '',
-	url: 'https://josephdadams.github.io',
-	baseUrl: '/TallyArbiter/',
+	url: 'https://docs.tallyarbiter.com',
+	baseUrl: '/',
 	onBrokenLinks: 'throw',
 	onBrokenMarkdownLinks: 'warn',
 	favicon: 'img/favicon.png',

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+docs.tallyarbiter.com


### PR DESCRIPTION
Points the documentation site at `docs.tallyarbiter.com`.

## ⚠️ Do not merge until DNS resolves

Add this record first:

| Type | Name | Value |
|---|---|---|
| CNAME | `docs` | `josephdadams.github.io.` |

Merging before that record exists sets the custom domain while DNS points nowhere, which takes the documentation offline until it is added.

## What changes

**`baseUrl: "/TallyArbiter/"` → `"/"`** — the docs move from a project path to a domain root. Without this, Docusaurus stamps `/TallyArbiter/` onto every asset and internal link and the site loads as unstyled HTML with every nav link one level wrong.

**`url`** → `https://docs.tallyarbiter.com`.

**`docs/static/CNAME`** — new. `JamesIves/github-pages-deploy-action` wipes `gh-pages` on every run, so a domain set only in the repository settings would be erased by the next docs push. Docusaurus copies `static/` into `build/`, so putting it here makes it survive.

## Existing links keep working

GitHub redirects `josephdadams.github.io/TallyArbiter/*` to the custom domain once set, so the README and the links on the marketing site continue to resolve.

## Verified locally

Built the site and served the output at a domain root:

- `CNAME` reaches `build/` with the right contents
- no local path still references `/TallyArbiter/` — the 38 remaining matches are absolute `github.com` URLs and literal config-file paths in the prose
- every docs page the marketing site links to resolves
- `/`, `/docs/intro/` and the hashed CSS bundle all return 200

## After merging

The docs deploy runs on push to `main`. Once it completes, GitHub provisions a Let's Encrypt certificate — the domain's existing CAA record already permits that — and Enforce HTTPS can be switched on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)