### PR TITLE
ci: run the UI unit tests on every pull request

### DIFF
--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -1,0 +1,50 @@
+name: UI Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ng-test:
+    name: UI Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            UI/package-lock.json
+
+      # UI/src/app/_models, _types and _schemas are copied from the server's own
+      # sources and are gitignored, so a fresh checkout does not have them and
+      # nothing under src/ will compile until it does. This is a plain filesystem
+      # copy with no dependencies of its own, so it runs before any install.
+      - name: Sync shared models and types
+        run: node scripts/sync-ui-shared.js
+
+      # src/environments/versions.ts is generated and gitignored as well, and the
+      # About screen imports it, so the spec compilation needs it in place.
+      - name: Generate version file
+        run: node git.version.js
+        working-directory: UI
+
+      # Only the UI's dependencies: nothing here runs the server, and skipping the
+      # root install avoids the Electron download that a test run has no use for.
+      - name: Install dependencies
+        run: npm ci
+        working-directory: UI
+
+      # ChromeHeadlessCI is defined in karma.conf.js and adds --no-sandbox.
+      - name: Run unit tests
+        run: npx ng test --watch=false --browsers=ChromeHeadlessCI
+        working-directory: UI

--- a/UI/karma.conf.js
+++ b/UI/karma.conf.js
@@ -30,6 +30,15 @@ module.exports = function (config) {
 			reporters: [{ type: 'html' }, { type: 'text-summary' }],
 		},
 		reporters: ['progress', 'kjhtml'],
+		customLaunchers: {
+			// Headless Chrome cannot set up its own sandbox on a CI runner, where
+			// the process does not have the privileges to do so, and exits rather
+			// than starting. Used by the UI Tests workflow.
+			ChromeHeadlessCI: {
+				base: 'ChromeHeadless',
+				flags: ['--no-sandbox', '--disable-gpu'],
+			},
+		},
 		port: 9876,
 		colors: true,
 		logLevel: config.LOG_INFO,


### PR DESCRIPTION
No workflow ran `ng test`, so a change that breaks the UI suite still reported a clean set of checks.

[#1198](https://github.com/josephdadams/TallyArbiter/pull/1198) is the live example: it bumps `jasmine-core` to 7, which stops **every** spec from executing, and every check on it passes.

## What this adds

- **`.github/workflows/ui-tests.yaml`** — runs `ng test` headless on every pull request and on pushes to `main`.
- **`ChromeHeadlessCI`** in `karma.conf.js` — adds `--no-sandbox`, which headless Chrome needs on a runner where it cannot set up its own sandbox.

The workflow generates `UI/src/app/_models`, `_types`, `_schemas` and `environments/versions.ts` before installing, since all of them are gitignored and a fresh checkout compiles nothing without them. It installs only the UI's dependencies — nothing here runs the server, and skipping the root install avoids the Electron download.

## Scope note

This branch originally also repaired the suite, which could not run at all: a legacy `src/test.ts` entry point using `require.context()`, CLI scaffold assertions in `app.component.spec.ts`, and standalone components in `declarations`. All of that arrived with [#1217](https://github.com/josephdadams/TallyArbiter/pull/1217), so the branch has been rebased down to just the workflow and the launcher.

Verified against the post-#1217 `main` on Node 24, running the workflow's exact steps: **`TOTAL: 101 SUCCESS`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
